### PR TITLE
Add NewsRAG architecture and backlog plan

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,144 @@
+# NewsRAG Architecture
+
+NewsRAG is a local-first CLI evidence retrieval tool for city hall PDFs. The first product shape is a single-user, scriptable research tool that ingests civic PDF documents, normalizes them through OCR, indexes page-grounded passages with hybrid keyword/vector search, and returns cited evidence in terminal output or Markdown source packets.
+
+## Product goals
+
+The MVP should let a user collect city hall PDFs from local folders, direct PDF URLs, or a hand-written YAML manifest; process them in the background; search them with natural-language or keyword queries; and export reusable Markdown source packets with page-level citations. The system should prioritize evidence retrieval over answer generation: results should show passages, document metadata, page numbers, and source references so a human can inspect and reuse the evidence.
+
+## Primary workflow
+
+A user configures NewsRAG once, starts a local daemon through an external process manager, and works through CLI commands. The CLI can register documents from a folder, a direct PDF URL, or a YAML manifest. Registered documents become durable jobs. The daemon watches configured folders, reacts to filesystem events, processes queued jobs asynchronously, and updates the local search indexes. The user runs `newsrag search` for quick cited evidence and `newsrag packet` to write a Markdown source packet.
+
+Example commands:
+
+```bash
+newsrag doctor
+newsrag daemon run
+newsrag watch add ./pdfs --body "City Council" --document-type agenda_packet
+newsrag ingest ./pdfs --body "City Council" --document-type agenda_packet
+newsrag ingest-url https://example.gov/packet.pdf --meeting-date 2026-04-12
+newsrag ingest-manifest sources.yaml
+newsrag search "stormwater downtown" --body "Planning Commission" --since 2025-01-01
+newsrag packet "affordable housing funding" --out packets/housing.md
+newsrag status
+newsrag jobs list
+newsrag jobs retry <job-id>
+```
+
+## Storage and configuration
+
+NewsRAG uses configurable local storage with a per-corpus data directory defaulting to `./.newsrag/`. A user can override the active data directory with a CLI flag or configured default. The data directory contains the corpus-local SQLite database, LanceDB vector index directory, downloaded source PDFs, OCR-normalized PDFs, processing artifacts, and local logs relevant to that corpus.
+
+Configuration is user-global, for example `~/.config/newsrag/config.yaml`. The global config stores daemon settings, embedding provider/model defaults, watched folder registrations, and user-level defaults. CLI flags can override config values for a specific command.
+
+The daemon is global and may manage many data directories over time. Search behavior for multiple corpora is deferred until there is more than one corpus in active use; MVP search targets the selected/current data directory.
+
+## Core entities
+
+NewsRAG is organized around a small set of durable entities rather than a server-side application model.
+
+- **Corpus/data directory**: a local collection of documents, metadata, artifacts, and indexes stored under a `.newsrag/` directory or configured equivalent.
+- **Document**: a source PDF and its user-supplied civic metadata, such as title, source URL, meeting date, body or committee, document type, and jurisdiction.
+- **Normalized PDF artifact**: the OCR-normalized/searchable PDF produced from the source document and used for text extraction.
+- **Page**: canonical extracted page text with page number and extraction quality information. Pages are the source of citation truth.
+- **Chunk**: a searchable passage derived from page text. MVP chunking is page-first, with long pages split into overlapping chunks. Chunks retain page start/end and allow future structure fields such as section title, heading path, agenda item, and bounding box.
+- **Embedding**: a vector representation of a chunk stored in LanceDB, linked back to the chunk identifier and tagged with embedding provider, model, and version.
+- **Job**: durable processing work tracked through pending, running, done, and failed states, with error details and retry support.
+- **Watch**: a configured folder watcher with default metadata used when new PDFs appear.
+- **Packet**: a generated Markdown evidence file assembled from retrieved chunks and source metadata.
+
+## Ingestion pipeline
+
+Ingestion registers documents and jobs quickly; processing happens in the daemon. Sources supported by the MVP are local PDFs/folders, direct PDF URLs, and YAML manifests. URL support is direct PDF download only. A manifest is the preferred way to provide civic metadata for multiple documents.
+
+Example manifest:
+
+```yaml
+documents:
+  - url: https://example.gov/council/packet-2026-04-12.pdf
+    title: City Council Packet
+    meeting_date: 2026-04-12
+    body: City Council
+    document_type: agenda_packet
+    jurisdiction: Example City
+```
+
+Processing is idempotent. The system hashes source content to avoid duplicate indexing and to detect changed documents. Each document is normalized through OCR first, then text is extracted from the normalized PDF. This makes scanned and born-digital PDFs follow the same downstream path.
+
+The OCR stage uses `ocrmypdf` with Tesseract and its required supporting tools. Text extraction uses PyMuPDF as the primary extractor and pdfplumber as a fallback or table-oriented extraction path. Page text is stored before chunking so citations remain stable and inspectable.
+
+## Chunking and citations
+
+The MVP uses page-first chunking. Each page is stored as canonical extracted text. Short pages may produce one chunk; long pages are split into overlapping passages while preserving page start/end. This keeps citations simple and reliable for city hall PDFs, where page numbers are often the most important reference.
+
+The data model should allow structure-aware chunking later without changing the retrieval contract. Optional chunk metadata can include section title, heading path, agenda item, table marker, and bounding box.
+
+Terminal citations use a concise format:
+
+```text
+City Council Packet — 2026-04-12 — p. 27
+```
+
+Markdown packet/source-list citations can include richer context:
+
+```text
+City Council Packet (City Council, 2026-04-12), p. 27 — source.pdf
+```
+
+## Search and retrieval
+
+Search is evidence-first. The default `newsrag search` command returns ranked passages with citations and metadata. It does not generate an answer by default. When no evidence is found, the system should report that clearly.
+
+The MVP retrieval pipeline uses hybrid search:
+
+1. SQLite stores canonical metadata, pages, chunks, job state, watches, and FTS5 keyword indexes.
+2. LanceDB stores chunk embeddings for vector search.
+3. Search collects keyword candidates from SQLite FTS5 and semantic candidates from LanceDB.
+4. Candidate scores are normalized and merged into a hybrid ranking.
+5. A reranker interface exists in the pipeline, but the MVP implementation is a no-op.
+6. Final results are returned as cited passages.
+
+Search filters should use user-supplied civic metadata, including body, document type, meeting date ranges, jurisdiction/source, and source URL where useful.
+
+## Embeddings
+
+Embeddings are pluggable. The MVP is local-first and defaults to Ollama running `nomic-embed-text`. The architecture also supports `bge-base-en` as a local model option and OpenAI `text-embedding-3-small` as an optional hosted provider.
+
+Every embedding record should retain provider, model, and version information. This allows safe index rebuilds when the embedding model changes. `newsrag doctor` checks embedding provider availability, including whether Ollama is reachable and whether the configured model is installed or pullable.
+
+## Daemon and jobs
+
+The daemon is a long-running process exposed through `newsrag daemon run` and intended to be managed by an external process manager such as launchd in regular use or a development process manager during local development. NewsRAG should not rely on custom PID-file supervision as its core architecture.
+
+The daemon uses filesystem notifications through `watchfiles` and an async worker model. Watched folder events should be debounced so partially copied PDFs are not processed too early. SQLite is the durable queue and job-state store. Failed jobs retain contextual error messages and timestamps, and CLI retry commands make failures visible and recoverable.
+
+## Doctor and observability
+
+`newsrag doctor` validates local prerequisites and configuration before long processing runs. It should check external binaries, data directory writability, embedding provider availability, daemon connectivity where applicable, and basic config validity. Error messages should be actionable.
+
+`newsrag status` and `newsrag jobs list` should show queue health, failed jobs, and processing state. This matters because OCR and embedding jobs can be slow and failures should not be silent.
+
+## Packet generation
+
+`newsrag packet` uses the same retrieval pipeline as search and writes an extractive Markdown source packet. The initial packet template is fixed and research-oriented, with configurable templates left for later.
+
+Default packet structure:
+
+```markdown
+# Source Packet: <query>
+
+## Key Evidence
+
+## Timeline
+
+## Open Questions
+
+## Source List
+```
+
+The MVP packet is templated and evidence-based. It should quote or summarize retrieved passages only enough to organize the evidence, and it should preserve citations to document titles, dates, bodies, pages, and source files.
+
+## Implementation guidance
+
+The CLI should use Typer and the project should use `uv` as its package/runtime tool. Development commands should run through `uv run ...`. Tests should be mostly unit tests with mocked OCR, PDF extraction, embedding providers, storage boundaries, and retrieval components so the suite is fast and stable. Integration tests with real PDFs can be added later after the pipeline shape is implemented.

--- a/docs/plans/01-cli-config-doctor.md
+++ b/docs/plans/01-cli-config-doctor.md
@@ -1,0 +1,24 @@
+# CLI, config, and doctor foundation
+
+## Goal
+
+Create the initial Typer CLI foundation, global config loading, selected data-directory resolution, and a `newsrag doctor` command that reports whether the local environment is ready for NewsRAG work.
+
+## Requirements
+
+- Add a Typer-based `newsrag` CLI entrypoint runnable through `uv run newsrag`.
+- Load user-global configuration from a conventional config path such as `~/.config/newsrag/config.yaml`.
+- Resolve the active corpus data directory from CLI flag, config, or default `./.newsrag/`.
+- Implement `newsrag doctor` with checks for config validity, data-dir writability, OCR tooling presence, embedding provider availability, and daemon connectivity when applicable.
+- Keep output readable for humans and stable enough for agents to inspect.
+
+## Acceptance criteria
+
+- [ ] `uv run newsrag --help` shows the CLI and top-level commands.
+- [ ] `uv run newsrag doctor` runs without crashing in a fresh checkout and reports missing optional prerequisites clearly.
+- [ ] Config loading has unit test coverage for default config, missing config, invalid config, and CLI override behavior.
+- [ ] Data-directory resolution has unit test coverage.
+
+## Dependencies
+
+No blockers.

--- a/docs/plans/02-corpus-storage-lifecycle.md
+++ b/docs/plans/02-corpus-storage-lifecycle.md
@@ -1,0 +1,23 @@
+# Corpus data directory and storage lifecycle
+
+## Goal
+
+Make a selected corpus data directory usable by the CLI and daemon by creating, validating, and reporting the local storage layout for SQLite, LanceDB, source PDFs, OCR artifacts, logs, and processing state.
+
+## Requirements
+
+- Initialize a `.newsrag/` data directory when needed.
+- Create stable subdirectories for source PDFs, downloaded PDFs, OCR-normalized PDFs, LanceDB data, logs, and transient processing artifacts.
+- Create or migrate the SQLite database enough to track high-level entities: documents, pages, chunks, jobs, watches, and metadata.
+- Ensure storage initialization is idempotent.
+- Add a `newsrag status` view that can report the active data directory and basic storage health.
+
+## Acceptance criteria
+
+- [ ] Running a storage-initializing command twice leaves the data directory valid and does not duplicate state.
+- [ ] `newsrag status` reports the selected data directory and whether required local storage exists.
+- [ ] Unit tests cover fresh initialization, existing initialization, invalid/unwritable data directory, and status output shaping.
+
+## Dependencies
+
+- task-11831224 — CLI, config, and doctor foundation

--- a/docs/plans/03-daemon-job-queue.md
+++ b/docs/plans/03-daemon-job-queue.md
@@ -1,0 +1,24 @@
+# Daemon run loop and durable job queue
+
+## Goal
+
+Implement the portable daemon entrypoint and durable job queue so NewsRAG can process work asynchronously while the CLI remains responsive.
+
+## Requirements
+
+- Add `newsrag daemon run` as the foreground long-running daemon entrypoint for external process managers.
+- Store jobs durably in SQLite with pending, running, done, and failed states.
+- Implement an async worker loop that claims pending jobs, executes registered handlers, and records completion or failure.
+- Add `newsrag jobs list` or equivalent visibility into queued and running jobs.
+- Keep job processing deterministic and testable with mocked job handlers.
+
+## Acceptance criteria
+
+- [ ] `newsrag daemon run` can start against an initialized data directory and wait for jobs.
+- [ ] A mocked job can move from pending to running to done under test.
+- [ ] A failing mocked job records failed state and an error message under test.
+- [ ] `newsrag jobs list` shows pending, running, done, and failed jobs in a human-readable form.
+
+## Dependencies
+
+- task-9c242503 — Corpus storage lifecycle

--- a/docs/plans/04-watch-folder-ingestion.md
+++ b/docs/plans/04-watch-folder-ingestion.md
@@ -1,0 +1,24 @@
+# Watched folder ingestion
+
+## Goal
+
+Allow users to register folders for automatic PDF ingestion so the daemon can enqueue new documents when files appear.
+
+## Requirements
+
+- Add `newsrag watch add <path>` with metadata options such as body, document type, meeting date default, and jurisdiction where appropriate.
+- Add `newsrag watch list` to show configured watches.
+- Store watch registrations in durable state associated with the selected data directory.
+- Use `watchfiles` in the daemon to observe registered folders.
+- Enqueue newly discovered PDFs as ingestion jobs without immediately doing all processing in the CLI.
+
+## Acceptance criteria
+
+- [ ] A watch can be added and listed.
+- [ ] The daemon observes a configured folder and enqueues a job when a PDF appears, using mocked filesystem events in tests.
+- [ ] Non-PDF files are ignored.
+- [ ] Duplicate file events do not create duplicate jobs for the same unchanged file.
+
+## Dependencies
+
+- task-6142564f — Daemon run loop and durable job queue

--- a/docs/plans/05-local-pdf-ingest-e2e.md
+++ b/docs/plans/05-local-pdf-ingest-e2e.md
@@ -1,0 +1,29 @@
+# Local PDF ingest end-to-end
+
+## Goal
+
+Implement the first user-visible ingestion path: add local PDF files or folders, process them through OCR, extraction, chunking, embedding, and indexing, then make them available for later search.
+
+## Requirements
+
+- Add `newsrag ingest <path>` for a PDF file or directory of PDFs.
+- Record document metadata from CLI flags and source file properties.
+- Hash source content for idempotency and duplicate detection.
+- Run OCR normalization with `ocrmypdf` before text extraction.
+- Extract page text with PyMuPDF.
+- Store page text as canonical citation source.
+- Create page-first chunks with overlap for long pages.
+- Store chunk metadata in SQLite and vector embeddings in LanceDB.
+- Use interfaces/mocks around OCR, extraction, and embedding so tests remain fast.
+
+## Acceptance criteria
+
+- [ ] Running `newsrag ingest ./pdfs` enqueues local PDF processing jobs.
+- [ ] A mocked end-to-end local PDF job creates a document, pages, chunks, and vector records under test.
+- [ ] Re-ingesting an unchanged PDF does not duplicate document/chunk records.
+- [ ] Ingestion failures are recorded as failed jobs with contextual errors.
+
+## Dependencies
+
+- task-6142564f — Daemon run loop and durable job queue
+- task-241cdb95 — Embedding provider integration

--- a/docs/plans/06-url-ingest-e2e.md
+++ b/docs/plans/06-url-ingest-e2e.md
@@ -1,0 +1,24 @@
+# Direct PDF URL ingest end-to-end
+
+## Goal
+
+Allow users to ingest a direct PDF URL into the selected corpus with supplied civic metadata.
+
+## Requirements
+
+- Add `newsrag ingest-url <url>` with metadata options such as title, meeting date, body, document type, and jurisdiction.
+- Download direct PDF URLs into the data directory while preserving source URL and retrieval timestamp.
+- Hash downloaded content and avoid duplicate indexing of unchanged files.
+- Reuse the same background processing path as local PDF ingestion.
+- Fail clearly when the URL does not return a PDF-like response or cannot be downloaded.
+
+## Acceptance criteria
+
+- [ ] `newsrag ingest-url` enqueues a processing job for a direct PDF URL.
+- [ ] Download behavior is unit-tested with mocked HTTP responses.
+- [ ] Source URL and retrieval timestamp are stored with the document.
+- [ ] Download failures create failed jobs or clear CLI errors with actionable messages.
+
+## Dependencies
+
+- task-7b45b114 — Local PDF ingest end-to-end

--- a/docs/plans/07-yaml-manifest-ingest.md
+++ b/docs/plans/07-yaml-manifest-ingest.md
@@ -1,0 +1,24 @@
+# YAML manifest ingest end-to-end
+
+## Goal
+
+Allow users to ingest a hand-curated YAML manifest of direct PDF URLs and metadata so civic document batches can be managed reproducibly.
+
+## Requirements
+
+- Add `newsrag ingest-manifest <path>` for YAML manifests.
+- Support a `documents` list with URL and optional metadata fields including title, meeting date, body, document type, and jurisdiction.
+- Validate manifest shape and report useful errors for missing URLs, invalid dates, and unsupported fields.
+- Enqueue one processing job per valid manifest document.
+- Reuse direct URL ingestion and local processing behavior.
+
+## Acceptance criteria
+
+- [ ] A valid manifest enqueues one job per document.
+- [ ] Invalid manifests fail with clear validation errors and do not enqueue partial ambiguous work unless behavior is explicit.
+- [ ] Manifest metadata is preserved on created documents.
+- [ ] Unit tests cover valid manifests, missing required fields, invalid date values, and duplicate URLs.
+
+## Dependencies
+
+- task-44db91c8 — Direct PDF URL ingest end-to-end

--- a/docs/plans/08-embedding-providers.md
+++ b/docs/plans/08-embedding-providers.md
@@ -1,0 +1,26 @@
+# Embedding provider integration
+
+## Goal
+
+Provide a pluggable embedding layer with a local-first default so chunks can be embedded for LanceDB vector search without hard-coding one provider forever.
+
+## Requirements
+
+- Define an embedding provider interface for embedding chunks and queries.
+- Implement the default Ollama provider for `nomic-embed-text`.
+- Make provider/model configurable through global config and CLI override where useful.
+- Store provider, model, and version information with embedding records.
+- Add `doctor` checks for Ollama reachability and configured model availability.
+- Leave room for `bge-base-en` and OpenAI providers without forcing them as the first implementation if sequencing requires a smaller slice.
+
+## Acceptance criteria
+
+- [ ] Query and chunk embedding calls work through a provider interface under test.
+- [ ] The Ollama provider can be tested with mocked HTTP/API behavior.
+- [ ] Missing Ollama or missing model produces actionable `doctor` output.
+- [ ] Embedding metadata records include provider/model identity.
+
+## Dependencies
+
+- task-11831224 — CLI, config, and doctor foundation
+- task-9c242503 — Corpus storage lifecycle

--- a/docs/plans/09-hybrid-search-citations.md
+++ b/docs/plans/09-hybrid-search-citations.md
@@ -1,0 +1,26 @@
+# Hybrid search with citations
+
+## Goal
+
+Implement `newsrag search` so users can query indexed PDFs and receive ranked evidence passages with page-level citations.
+
+## Requirements
+
+- Add `newsrag search <query>`.
+- Search SQLite FTS5 for keyword candidates.
+- Search LanceDB for vector candidates using the configured query embedding provider.
+- Merge keyword and vector candidates with simple score normalization and weighting.
+- Include a no-op reranker hook in the retrieval pipeline.
+- Return cited evidence passages with document title, meeting date, page number, and snippet text.
+- Report clearly when no matching evidence is found.
+
+## Acceptance criteria
+
+- [ ] Search over mocked indexed chunks returns ranked cited passages.
+- [ ] Keyword-only, vector-only, and overlapping candidate sets merge deterministically under test.
+- [ ] Citations use the concise format `Title — date — p. N` where metadata is available.
+- [ ] Empty results produce a clear no-evidence message.
+
+## Dependencies
+
+- task-7b45b114 — Local PDF ingest end-to-end

--- a/docs/plans/10-search-metadata-filters.md
+++ b/docs/plans/10-search-metadata-filters.md
@@ -1,0 +1,23 @@
+# Search metadata filters
+
+## Goal
+
+Make search useful for civic research by allowing users to filter results by supplied document metadata.
+
+## Requirements
+
+- Add search filters for body, document type, jurisdiction/source, and meeting date range.
+- Apply filters consistently across keyword candidates, vector candidates, and final merged results.
+- Preserve filter metadata in result output where helpful.
+- Keep filter behavior deterministic and documented in CLI help.
+
+## Acceptance criteria
+
+- [ ] `newsrag search "query" --body "Planning Commission" --since 2025-01-01` filters results as expected under test.
+- [ ] Filters apply to both FTS5 and LanceDB-backed candidate paths or are enforced during final merge without leaking out-of-filter results.
+- [ ] Invalid date filters produce clear CLI errors.
+- [ ] Filtered no-result cases distinguish no evidence from invalid input.
+
+## Dependencies
+
+- task-e5c2f467 — Hybrid search with citations

--- a/docs/plans/11-markdown-source-packets.md
+++ b/docs/plans/11-markdown-source-packets.md
@@ -1,0 +1,24 @@
+# Markdown source packet generation
+
+## Goal
+
+Implement `newsrag packet` so users can generate reusable Markdown source packets from retrieved evidence.
+
+## Requirements
+
+- Add `newsrag packet <query> --out <path>`.
+- Use the same retrieval pipeline and metadata filters as `newsrag search`.
+- Generate a fixed research-oriented Markdown template with sections for Key Evidence, Timeline, Open Questions, and Source List.
+- Include cited passages and source-list entries with document title, body, meeting date, page number, and source file where available.
+- Keep packet generation extractive and templated rather than LLM-authored.
+
+## Acceptance criteria
+
+- [ ] `newsrag packet "query" --out packet.md` writes a Markdown file from mocked retrieval results.
+- [ ] The packet contains `# Source Packet: <query>`, `## Key Evidence`, `## Timeline`, `## Open Questions`, and `## Source List`.
+- [ ] Evidence entries include citations in the agreed human-readable format.
+- [ ] Existing output files are handled safely with explicit overwrite behavior.
+
+## Dependencies
+
+- task-8b24551a — Search metadata filters

--- a/docs/plans/12-job-failure-retry.md
+++ b/docs/plans/12-job-failure-retry.md
@@ -1,0 +1,25 @@
+# Job failure visibility and retry UX
+
+## Goal
+
+Make background processing failures visible, debuggable, and recoverable from the CLI.
+
+## Requirements
+
+- Store failure error messages, timestamps, and enough context to understand which document/job failed.
+- Add or refine `newsrag jobs list` to highlight failed jobs.
+- Add `newsrag jobs retry <job-id>` to move retryable failed jobs back to pending.
+- Ensure retry does not duplicate already-created records for idempotent processing steps.
+- Make `newsrag status` summarize failed job count and queue health.
+
+## Acceptance criteria
+
+- [ ] A failed mocked job appears in status/jobs output with an error message.
+- [ ] Retrying a failed job changes it back to pending and allows the daemon to process it again.
+- [ ] Retrying a non-failed or unknown job reports a clear error.
+- [ ] Unit tests cover failure display, retry state transition, and idempotent retry behavior.
+
+## Dependencies
+
+- task-6142564f — Daemon run loop and durable job queue
+- task-7b45b114 — Local PDF ingest end-to-end

--- a/docs/plans/13-pdfplumber-fallback.md
+++ b/docs/plans/13-pdfplumber-fallback.md
@@ -1,0 +1,24 @@
+# pdfplumber fallback extraction path
+
+## Goal
+
+Improve PDF text extraction robustness by adding a pdfplumber fallback or table-oriented extraction path behind the extraction interface.
+
+## Requirements
+
+- Keep PyMuPDF as the primary page text extractor.
+- Add pdfplumber as a fallback when extraction quality is low or when table-oriented extraction is requested.
+- Preserve page numbers and citation provenance regardless of extractor path.
+- Record which extractor path produced page text or supplemental table text where useful.
+- Keep tests mock-heavy and avoid requiring large real PDF fixtures.
+
+## Acceptance criteria
+
+- [ ] The extraction interface can choose PyMuPDF or pdfplumber under test.
+- [ ] Low-quality primary extraction can trigger fallback behavior in a deterministic test.
+- [ ] Page records retain page numbers and source document identity after fallback extraction.
+- [ ] Extraction errors include context about document path and extraction stage.
+
+## Dependencies
+
+- task-7b45b114 — Local PDF ingest end-to-end

--- a/docs/plans/14-watcher-debounce-health.md
+++ b/docs/plans/14-watcher-debounce-health.md
@@ -1,0 +1,25 @@
+# Watcher debouncing and daemon health checks
+
+## Goal
+
+Make folder watching reliable enough for real PDF drops by debouncing filesystem events, avoiding partially copied files, and exposing daemon health through CLI status/doctor commands.
+
+## Requirements
+
+- Add debounce/stabilization logic around watchfiles events before enqueueing PDFs.
+- Avoid processing files that are still changing or partially copied.
+- Surface daemon connectivity and watcher health in `newsrag status` and `newsrag doctor`.
+- Ensure repeated filesystem events for the same stable file do not create duplicate processing jobs.
+- Keep watcher behavior unit-testable with mocked events and clocks.
+
+## Acceptance criteria
+
+- [ ] A burst of events for one PDF produces one enqueue action after stabilization.
+- [ ] A changing file is not enqueued until it is stable under test.
+- [ ] `doctor` or `status` reports whether daemon connectivity can be established where applicable.
+- [ ] Watcher health failures produce actionable errors.
+
+## Dependencies
+
+- task-40c08a4f — Watched folder ingestion
+- task-393a0a9c — Job failure visibility and retry UX

--- a/docs/plans/15-backlog-conversion.md
+++ b/docs/plans/15-backlog-conversion.md
@@ -1,0 +1,26 @@
+# Architecture validation and backlog conversion
+
+## Goal
+
+Validate the architecture and planning files, then create real backend task records with real dependency IDs so future implementation agents can execute the work without guessing.
+
+## Requirements
+
+- Review `docs/architecture.md` and all `docs/plans/*.md` files for consistency.
+- Convert approved plan files into backend task records.
+- Ensure every created backend task includes title, `## Goal`, `## Requirements`, `## Acceptance criteria`, and `## Dependencies`.
+- Replace plan-file dependency references with real created task IDs.
+- Do not use task status changes such as moving untouched tasks to waiting to communicate ordering.
+- Add a comment or summary to the design task listing the created backend task IDs and dependency order.
+
+## Acceptance criteria
+
+- [ ] Architecture/design output exists and matches the agreed brainstorming decisions.
+- [ ] Backend implementation tasks exist as real task records.
+- [ ] Every backend task has the required sections.
+- [ ] Sequencing and blockers use real task IDs in each task's `## Dependencies` section.
+- [ ] The design task can be closed only after backend task creation is complete.
+
+## Dependencies
+
+- None

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,25 @@
+# NewsRAG Implementation Plans
+
+These files are the reviewed implementation backlog derived from `docs/architecture.md` and converted into backend task records.
+
+Each plan uses the task structure expected for backend tasks: `## Goal`, `## Requirements`, `## Acceptance criteria`, and `## Dependencies`.
+
+Dependencies reference the real backend task IDs created for the `newsrag` project.
+
+## Proposed vertical-slice order
+
+1. task-11831224 — [CLI, config, and doctor foundation](01-cli-config-doctor.md)
+2. task-9c242503 — [Corpus data directory and storage lifecycle](02-corpus-storage-lifecycle.md)
+3. task-6142564f — [Daemon run loop and durable job queue](03-daemon-job-queue.md)
+4. task-40c08a4f — [Watched folder ingestion](04-watch-folder-ingestion.md)
+5. task-7b45b114 — [Local PDF ingest end-to-end](05-local-pdf-ingest-e2e.md)
+6. task-44db91c8 — [Direct PDF URL ingest end-to-end](06-url-ingest-e2e.md)
+7. task-9b0e618d — [YAML manifest ingest end-to-end](07-yaml-manifest-ingest.md)
+8. task-241cdb95 — [Embedding provider integration](08-embedding-providers.md)
+9. task-e5c2f467 — [Hybrid search with citations](09-hybrid-search-citations.md)
+10. task-8b24551a — [Search metadata filters](10-search-metadata-filters.md)
+11. task-f0a187f0 — [Markdown source packet generation](11-markdown-source-packets.md)
+12. task-393a0a9c — [Job failure visibility and retry UX](12-job-failure-retry.md)
+13. task-13e07a5a — [pdfplumber fallback extraction path](13-pdfplumber-fallback.md)
+14. task-c98325bb — [Watcher debouncing and daemon health checks](14-watcher-debounce-health.md)
+15. task-4bb15b57 — [Architecture validation and backlog conversion](15-backlog-conversion.md)


### PR DESCRIPTION
## Summary

- Add the NewsRAG MVP architecture document from the design brainstorming session
- Add reviewed implementation plan files under docs/plans with backend task IDs and dependencies
- Capture the vertical-slice backlog order for future implementation tasks

## Verification

- make check
- ./scripts/pre-pr.sh

Task: task-bd6b2ab2