### PR TITLE
feat: add CLI config and doctor foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ For the full macOS setup, installation commands, and validation steps, see [docs
 uv sync --dev
 ```
 
+## CLI quick start
+
+```bash
+uv run newsrag --help
+uv run newsrag doctor
+```
+
 ## How to work on this project
 
 ### Start the dev environment

--- a/newsrag/__main__.py
+++ b/newsrag/__main__.py
@@ -1,0 +1,4 @@
+from .cli import run
+
+if __name__ == "__main__":
+    run()

--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+
+from newsrag.config import AppConfig, ConfigError, RuntimeSettings, load_config, resolve_data_dir
+from newsrag.doctor import format_report, run_doctor
+
+CONFIG_PATH_OPTION = typer.Option(
+    None,
+    "--config-path",
+    help="Override the path to the user-global config file.",
+    dir_okay=False,
+    resolve_path=False,
+)
+DATA_DIR_OPTION = typer.Option(
+    None,
+    "--data-dir",
+    help="Override the active corpus data directory.",
+    file_okay=False,
+    resolve_path=False,
+)
+
+app = typer.Typer(help="Local-first evidence retrieval for city hall PDFs.")
+
+
+@dataclass(frozen=True)
+class CliState:
+    """CLI state shared across commands."""
+
+    config_path: Path
+    data_dir: Path | None
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    config_path: Path | None = CONFIG_PATH_OPTION,
+    data_dir: Path | None = DATA_DIR_OPTION,
+) -> None:
+    """Run NewsRAG commands."""
+
+    ctx.obj = CliState(
+        config_path=(config_path or Path("~/.config/newsrag/config.yaml")).expanduser(),
+        data_dir=data_dir,
+    )
+
+
+@app.command()
+def doctor(ctx: typer.Context) -> None:
+    """Validate the local NewsRAG environment and configuration."""
+
+    state = _get_state(ctx)
+    config_error: str | None = None
+
+    try:
+        config = load_config(state.config_path)
+    except ConfigError as exc:
+        config = AppConfig(source_path=state.config_path)
+        config_error = str(exc)
+
+    settings = RuntimeSettings(
+        config_path=state.config_path,
+        data_dir=resolve_data_dir(state.data_dir, config),
+        config=config,
+    )
+    report = run_doctor(settings, config_error=config_error)
+    typer.echo(format_report(report, settings=settings))
+
+    if report.has_errors:
+        raise typer.Exit(code=1)
+
+
+def run() -> None:
+    """Run the Typer application."""
+
+    app()
+
+
+def _get_state(ctx: typer.Context) -> CliState:
+    state = ctx.obj
+    if isinstance(state, CliState):
+        return state
+    return CliState(
+        config_path=Path("~/.config/newsrag/config.yaml").expanduser(),
+        data_dir=None,
+    )

--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -5,7 +5,14 @@ from pathlib import Path
 
 import typer
 
-from newsrag.config import AppConfig, ConfigError, RuntimeSettings, load_config, resolve_data_dir
+from newsrag.config import (
+    DEFAULT_CONFIG_PATH,
+    AppConfig,
+    ConfigError,
+    RuntimeSettings,
+    load_config,
+    resolve_data_dir,
+)
 from newsrag.doctor import format_report, run_doctor
 
 CONFIG_PATH_OPTION = typer.Option(
@@ -43,7 +50,7 @@ def main(
     """Run NewsRAG commands."""
 
     ctx.obj = CliState(
-        config_path=(config_path or Path("~/.config/newsrag/config.yaml")).expanduser(),
+        config_path=(config_path or DEFAULT_CONFIG_PATH).expanduser(),
         data_dir=data_dir,
     )
 
@@ -84,6 +91,6 @@ def _get_state(ctx: typer.Context) -> CliState:
     if isinstance(state, CliState):
         return state
     return CliState(
-        config_path=Path("~/.config/newsrag/config.yaml").expanduser(),
+        config_path=DEFAULT_CONFIG_PATH,
         data_dir=None,
     )

--- a/newsrag/config.py
+++ b/newsrag/config.py
@@ -37,7 +37,10 @@ class AppConfig:
 
     source_path: Path
     data_dir: Path | None = None
-    embedding_provider: str = "ollama"
+    embedding_provider: str | None = None
+    embedding_base_url: str | None = None
+    embedding_model: str | None = None
+    embedding_api_key_env: str | None = None
     ollama: OllamaConfig = OllamaConfig()
     daemon: DaemonConfig = DaemonConfig()
 
@@ -85,15 +88,28 @@ def load_config(config_path: Path | None = None) -> AppConfig:
     else:
         raise ConfigError(f"Config file {resolved_path} must contain a top-level mapping.")
 
+    embedding_data = _mapping_value(data, "embedding", default={})
+
     return AppConfig(
         source_path=resolved_path,
         data_dir=_optional_path(data.get("data_dir"), field_name="data_dir"),
         embedding_provider=_optional_string(
-            _mapping_value(data, "embedding", default={}).get("provider"),
+            embedding_data.get("provider"),
             field_name="embedding.provider",
-        )
-        or "ollama",
-        ollama=_load_ollama_config(_mapping_value(data, "embedding", default={})),
+        ),
+        embedding_base_url=_optional_string(
+            embedding_data.get("base_url"),
+            field_name="embedding.base_url",
+        ),
+        embedding_model=_optional_string(
+            embedding_data.get("model"),
+            field_name="embedding.model",
+        ),
+        embedding_api_key_env=_optional_string(
+            embedding_data.get("api_key_env"),
+            field_name="embedding.api_key_env",
+        ),
+        ollama=_load_ollama_config(embedding_data),
         daemon=_load_daemon_config(_mapping_value(data, "daemon", default={})),
     )
 

--- a/newsrag/config.py
+++ b/newsrag/config.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+DEFAULT_CONFIG_PATH = Path("~/.config/newsrag/config.yaml").expanduser()
+DEFAULT_DATA_DIR_NAME = ".newsrag"
+DEFAULT_OLLAMA_HOST = "http://127.0.0.1:11434"
+DEFAULT_OLLAMA_MODEL = "nomic-embed-text"
+
+
+class ConfigError(Exception):
+    """Raised when the NewsRAG config file is invalid."""
+
+
+@dataclass(frozen=True)
+class OllamaConfig:
+    """Settings for the local Ollama embedding provider."""
+
+    host: str = DEFAULT_OLLAMA_HOST
+    model: str = DEFAULT_OLLAMA_MODEL
+
+
+@dataclass(frozen=True)
+class DaemonConfig:
+    """Settings for optional daemon connectivity checks."""
+
+    socket_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class AppConfig:
+    """User-global NewsRAG configuration."""
+
+    source_path: Path
+    data_dir: Path | None = None
+    embedding_provider: str = "ollama"
+    ollama: OllamaConfig = OllamaConfig()
+    daemon: DaemonConfig = DaemonConfig()
+
+
+@dataclass(frozen=True)
+class RuntimeSettings:
+    """Resolved runtime settings after CLI overrides are applied."""
+
+    config_path: Path
+    data_dir: Path
+    config: AppConfig
+
+
+EMPTY_CONFIG = AppConfig(source_path=DEFAULT_CONFIG_PATH)
+
+
+def load_config(config_path: Path | None = None) -> AppConfig:
+    """Load the NewsRAG config file from disk.
+
+    Args:
+        config_path: Optional override path for the config file.
+
+    Returns:
+        The loaded config, or defaults when the file does not exist.
+
+    Raises:
+        ConfigError: If the config file exists but is invalid.
+    """
+
+    resolved_path = (config_path or DEFAULT_CONFIG_PATH).expanduser()
+    if not resolved_path.exists():
+        return AppConfig(source_path=resolved_path)
+
+    raw_content = resolved_path.read_text(encoding="utf-8")
+
+    try:
+        loaded = yaml.safe_load(raw_content)
+    except yaml.YAMLError as exc:  # pragma: no cover - exercised by tests via ConfigError
+        raise ConfigError(f"Invalid YAML in {resolved_path}: {exc}") from exc
+
+    if loaded is None:
+        data: Mapping[str, object] = {}
+    elif isinstance(loaded, dict):
+        data = loaded
+    else:
+        raise ConfigError(f"Config file {resolved_path} must contain a top-level mapping.")
+
+    return AppConfig(
+        source_path=resolved_path,
+        data_dir=_optional_path(data.get("data_dir"), field_name="data_dir"),
+        embedding_provider=_optional_string(
+            _mapping_value(data, "embedding", default={}).get("provider"),
+            field_name="embedding.provider",
+        )
+        or "ollama",
+        ollama=_load_ollama_config(_mapping_value(data, "embedding", default={})),
+        daemon=_load_daemon_config(_mapping_value(data, "daemon", default={})),
+    )
+
+
+def resolve_data_dir(
+    cli_data_dir: Path | None,
+    config: AppConfig,
+    *,
+    cwd: Path | None = None,
+) -> Path:
+    """Resolve the active corpus data directory.
+
+    Args:
+        cli_data_dir: CLI override for the data directory.
+        config: Loaded application config.
+        cwd: Optional working directory for resolving relative paths.
+
+    Returns:
+        The absolute active data directory path.
+    """
+
+    base_dir = cwd or Path.cwd()
+    selected = cli_data_dir or config.data_dir or Path(DEFAULT_DATA_DIR_NAME)
+    return _normalize_path(selected, cwd=base_dir)
+
+
+def resolve_runtime_settings(
+    *,
+    config_path: Path | None = None,
+    data_dir: Path | None = None,
+    cwd: Path | None = None,
+) -> RuntimeSettings:
+    """Load config and apply CLI overrides to build runtime settings."""
+
+    config = load_config(config_path)
+    resolved_config_path = (config_path or DEFAULT_CONFIG_PATH).expanduser()
+    resolved_data_dir = resolve_data_dir(data_dir, config, cwd=cwd)
+    return RuntimeSettings(
+        config_path=resolved_config_path,
+        data_dir=resolved_data_dir,
+        config=config,
+    )
+
+
+def _load_ollama_config(embedding_data: Mapping[str, object]) -> OllamaConfig:
+    ollama_data = _mapping_value(embedding_data, "ollama", default={})
+    return OllamaConfig(
+        host=_optional_string(ollama_data.get("host"), field_name="embedding.ollama.host")
+        or DEFAULT_OLLAMA_HOST,
+        model=_optional_string(ollama_data.get("model"), field_name="embedding.ollama.model")
+        or DEFAULT_OLLAMA_MODEL,
+    )
+
+
+def _load_daemon_config(daemon_data: Mapping[str, object]) -> DaemonConfig:
+    return DaemonConfig(
+        socket_path=_optional_path(daemon_data.get("socket_path"), field_name="daemon.socket_path")
+    )
+
+
+def _mapping_value(
+    data: Mapping[str, object],
+    key: str,
+    *,
+    default: Mapping[str, object],
+) -> Mapping[str, object]:
+    value = data.get(key)
+    if value is None:
+        return default
+    if isinstance(value, dict):
+        return value
+    raise ConfigError(f"Config field {key} must be a mapping.")
+
+
+def _optional_string(value: object, *, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    raise ConfigError(f"Config field {field_name} must be a string.")
+
+
+def _optional_path(value: object, *, field_name: str) -> Path | None:
+    string_value = _optional_string(value, field_name=field_name)
+    if string_value is None:
+        return None
+    return Path(string_value).expanduser()
+
+
+def _normalize_path(path: Path, *, cwd: Path) -> Path:
+    expanded = path.expanduser()
+    if expanded.is_absolute():
+        return expanded
+    return (cwd / expanded).resolve()

--- a/newsrag/config.py
+++ b/newsrag/config.py
@@ -8,8 +8,6 @@ import yaml
 
 DEFAULT_CONFIG_PATH = Path("~/.config/newsrag/config.yaml").expanduser()
 DEFAULT_DATA_DIR_NAME = ".newsrag"
-DEFAULT_OLLAMA_HOST = "http://127.0.0.1:11434"
-DEFAULT_OLLAMA_MODEL = "nomic-embed-text"
 
 
 class ConfigError(Exception):
@@ -17,11 +15,13 @@ class ConfigError(Exception):
 
 
 @dataclass(frozen=True)
-class OllamaConfig:
-    """Settings for the local Ollama embedding provider."""
+class EmbeddingConfig:
+    """Embedding provider configuration."""
 
-    host: str = DEFAULT_OLLAMA_HOST
-    model: str = DEFAULT_OLLAMA_MODEL
+    provider: str | None = None
+    base_url: str | None = None
+    model: str | None = None
+    api_key_env: str | None = None
 
 
 @dataclass(frozen=True)
@@ -37,11 +37,7 @@ class AppConfig:
 
     source_path: Path
     data_dir: Path | None = None
-    embedding_provider: str | None = None
-    embedding_base_url: str | None = None
-    embedding_model: str | None = None
-    embedding_api_key_env: str | None = None
-    ollama: OllamaConfig = OllamaConfig()
+    embedding: EmbeddingConfig = EmbeddingConfig()
     daemon: DaemonConfig = DaemonConfig()
 
 
@@ -88,28 +84,10 @@ def load_config(config_path: Path | None = None) -> AppConfig:
     else:
         raise ConfigError(f"Config file {resolved_path} must contain a top-level mapping.")
 
-    embedding_data = _mapping_value(data, "embedding", default={})
-
     return AppConfig(
         source_path=resolved_path,
         data_dir=_optional_path(data.get("data_dir"), field_name="data_dir"),
-        embedding_provider=_optional_string(
-            embedding_data.get("provider"),
-            field_name="embedding.provider",
-        ),
-        embedding_base_url=_optional_string(
-            embedding_data.get("base_url"),
-            field_name="embedding.base_url",
-        ),
-        embedding_model=_optional_string(
-            embedding_data.get("model"),
-            field_name="embedding.model",
-        ),
-        embedding_api_key_env=_optional_string(
-            embedding_data.get("api_key_env"),
-            field_name="embedding.api_key_env",
-        ),
-        ollama=_load_ollama_config(embedding_data),
+        embedding=_load_embedding_config(_mapping_value(data, "embedding", default={})),
         daemon=_load_daemon_config(_mapping_value(data, "daemon", default={})),
     )
 
@@ -154,13 +132,15 @@ def resolve_runtime_settings(
     )
 
 
-def _load_ollama_config(embedding_data: Mapping[str, object]) -> OllamaConfig:
-    ollama_data = _mapping_value(embedding_data, "ollama", default={})
-    return OllamaConfig(
-        host=_optional_string(ollama_data.get("host"), field_name="embedding.ollama.host")
-        or DEFAULT_OLLAMA_HOST,
-        model=_optional_string(ollama_data.get("model"), field_name="embedding.ollama.model")
-        or DEFAULT_OLLAMA_MODEL,
+def _load_embedding_config(embedding_data: Mapping[str, object]) -> EmbeddingConfig:
+    return EmbeddingConfig(
+        provider=_optional_string(embedding_data.get("provider"), field_name="embedding.provider"),
+        base_url=_optional_string(embedding_data.get("base_url"), field_name="embedding.base_url"),
+        model=_optional_string(embedding_data.get("model"), field_name="embedding.model"),
+        api_key_env=_optional_string(
+            embedding_data.get("api_key_env"),
+            field_name="embedding.api_key_env",
+        ),
     )
 
 

--- a/newsrag/doctor.py
+++ b/newsrag/doctor.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from newsrag.config import AppConfig, RuntimeSettings
+
+
+@dataclass(frozen=True)
+class DoctorCheck:
+    """One doctor check result."""
+
+    name: str
+    status: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class DoctorReport:
+    """Structured doctor output."""
+
+    checks: tuple[DoctorCheck, ...]
+
+    @property
+    def has_errors(self) -> bool:
+        return any(check.status == "error" for check in self.checks)
+
+
+def run_doctor(
+    settings: RuntimeSettings,
+    *,
+    config_error: str | None = None,
+    timeout_seconds: float = 2.0,
+) -> DoctorReport:
+    """Run environment checks for NewsRAG."""
+
+    checks: list[DoctorCheck] = []
+    checks.append(_config_check(settings.config_path, config_error))
+    checks.append(_data_dir_check(settings.data_dir))
+    checks.extend(_ocr_checks())
+    checks.append(_embedding_check(settings.config, timeout_seconds=timeout_seconds))
+    checks.append(_daemon_check(settings.config))
+    return DoctorReport(checks=tuple(checks))
+
+
+def format_report(report: DoctorReport, *, settings: RuntimeSettings) -> str:
+    """Format a doctor report for terminal output."""
+
+    lines = [
+        "NewsRAG Doctor",
+        f"config_path: {settings.config_path}",
+        f"data_dir: {settings.data_dir}",
+    ]
+
+    for check in report.checks:
+        lines.append(f"{check.name}: {check.status} - {check.detail}")
+
+    summary = "error" if report.has_errors else "ok"
+    lines.append(f"summary: {summary}")
+    return "\n".join(lines)
+
+
+def _config_check(config_path: Path, config_error: str | None) -> DoctorCheck:
+    if config_error is not None:
+        return DoctorCheck("config", "error", config_error)
+    if config_path.exists():
+        return DoctorCheck("config", "ok", f"loaded {config_path}")
+    return DoctorCheck("config", "ok", f"missing {config_path}; using defaults")
+
+
+def _data_dir_check(data_dir: Path) -> DoctorCheck:
+    if data_dir.exists() and not data_dir.is_dir():
+        return DoctorCheck("data_dir", "error", f"{data_dir} exists but is not a directory")
+
+    target = data_dir if data_dir.exists() else _nearest_existing_parent(data_dir)
+    if target is None:
+        return DoctorCheck("data_dir", "error", f"cannot resolve writable parent for {data_dir}")
+
+    if not os.access(target, os.W_OK | os.X_OK):
+        return DoctorCheck("data_dir", "error", f"{target} is not writable")
+
+    if data_dir.exists():
+        return DoctorCheck("data_dir", "ok", f"{data_dir} exists and is writable")
+    return DoctorCheck(
+        "data_dir", "ok", f"{data_dir} does not exist yet; parent {target} is writable"
+    )
+
+
+def _ocr_checks() -> tuple[DoctorCheck, ...]:
+    return (
+        _command_check("ocrmypdf", "ocrmypdf"),
+        _command_check("tesseract", "tesseract"),
+        _command_check("ghostscript", "gs"),
+        _command_check("qpdf", "qpdf"),
+    )
+
+
+def _command_check(name: str, command: str) -> DoctorCheck:
+    location = shutil.which(command)
+    if location is None:
+        return DoctorCheck(name, "warn", f"missing command '{command}'")
+    return DoctorCheck(name, "ok", f"found {location}")
+
+
+def _embedding_check(config: AppConfig, *, timeout_seconds: float) -> DoctorCheck:
+    provider = config.embedding_provider.lower()
+    if provider == "ollama":
+        return _ollama_check(config, timeout_seconds=timeout_seconds)
+    if provider == "openai":
+        return _openai_check()
+    return DoctorCheck(
+        "embedding",
+        "error",
+        f"unsupported provider '{config.embedding_provider}'",
+    )
+
+
+def _ollama_check(config: AppConfig, *, timeout_seconds: float) -> DoctorCheck:
+    ollama_binary = shutil.which("ollama")
+    if ollama_binary is None:
+        return DoctorCheck(
+            "embedding",
+            "warn",
+            "provider=ollama but the 'ollama' command is missing",
+        )
+
+    endpoint = config.ollama.host.rstrip("/") + "/api/tags"
+    try:
+        response = httpx.get(endpoint, timeout=timeout_seconds)
+        response.raise_for_status()
+        payload = response.json()
+    except httpx.HTTPError:
+        return DoctorCheck(
+            "embedding",
+            "warn",
+            (
+                "provider=ollama but the local server is unreachable at "
+                f"{config.ollama.host}; start Ollama and run 'ollama pull {config.ollama.model}'"
+            ),
+        )
+
+    model_names = _extract_ollama_model_names(payload)
+    if _ollama_model_available(config.ollama.model, model_names):
+        return DoctorCheck(
+            "embedding",
+            "ok",
+            (f"provider=ollama host={config.ollama.host} model={config.ollama.model} is available"),
+        )
+
+    return DoctorCheck(
+        "embedding",
+        "warn",
+        (
+            f"provider=ollama host={config.ollama.host} is reachable but "
+            f"model={config.ollama.model} is not installed; run 'ollama pull {config.ollama.model}'"
+        ),
+    )
+
+
+def _openai_check() -> DoctorCheck:
+    if os.getenv("OPENAI_API_KEY"):
+        return DoctorCheck("embedding", "ok", "provider=openai and OPENAI_API_KEY is set")
+    return DoctorCheck(
+        "embedding",
+        "warn",
+        "provider=openai but OPENAI_API_KEY is not set",
+    )
+
+
+def _daemon_check(config: AppConfig) -> DoctorCheck:
+    socket_path = config.daemon.socket_path
+    if socket_path is None:
+        return DoctorCheck("daemon", "info", "not configured")
+
+    try:
+        mode = socket_path.stat().st_mode
+    except FileNotFoundError:
+        return DoctorCheck("daemon", "warn", f"configured socket {socket_path} not found")
+
+    if stat.S_ISSOCK(mode):
+        return DoctorCheck("daemon", "ok", f"socket available at {socket_path}")
+    return DoctorCheck(
+        "daemon", "warn", f"configured path {socket_path} exists but is not a socket"
+    )
+
+
+def _nearest_existing_parent(path: Path) -> Path | None:
+    current = path
+    while not current.exists():
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+    return current
+
+
+def _extract_ollama_model_names(payload: Any) -> set[str]:
+    if not isinstance(payload, dict):
+        return set()
+
+    models = payload.get("models")
+    if not isinstance(models, list):
+        return set()
+
+    names: set[str] = set()
+    for model in models:
+        if isinstance(model, dict):
+            name = model.get("name")
+            if isinstance(name, str):
+                names.add(name)
+    return names
+
+
+def _ollama_model_available(expected_model: str, installed_models: set[str]) -> bool:
+    return any(
+        model_name == expected_model or model_name.startswith(f"{expected_model}:")
+        for model_name in installed_models
+    )

--- a/newsrag/doctor.py
+++ b/newsrag/doctor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import shutil
 import stat
 from dataclasses import dataclass
 from pathlib import Path
@@ -9,7 +8,11 @@ from typing import Any
 
 import httpx
 
-from newsrag.config import AppConfig, RuntimeSettings
+from newsrag.config import EmbeddingConfig, RuntimeSettings
+
+DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434"
+DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_OPENAI_API_KEY_ENV = "OPENAI_API_KEY"
 
 
 @dataclass(frozen=True)
@@ -55,9 +58,12 @@ def run_doctor(
     checks: list[DoctorCheck] = []
     checks.append(_config_check(settings.config_path, config_error))
     checks.append(_data_dir_check(settings.data_dir))
-    checks.extend(_ocr_checks())
-    checks.append(_embedding_check(settings.config, timeout_seconds=timeout_seconds))
-    checks.append(_daemon_check(settings.config))
+    checks.append(_binary_check("ocrmypdf", "ocrmypdf"))
+    checks.append(_binary_check("tesseract", "tesseract"))
+    checks.append(_binary_check("ghostscript", "gs"))
+    checks.append(_binary_check("qpdf", "qpdf"))
+    checks.append(_embedding_check(settings.config.embedding, timeout_seconds=timeout_seconds))
+    checks.append(_daemon_check(settings.config.daemon.socket_path))
     return DoctorReport(checks=tuple(checks))
 
 
@@ -103,124 +109,130 @@ def _data_dir_check(data_dir: Path) -> DoctorCheck:
     )
 
 
-def _ocr_checks() -> tuple[DoctorCheck, ...]:
-    return (
-        _command_check("ocrmypdf", "ocrmypdf"),
-        _command_check("tesseract", "tesseract"),
-        _command_check("ghostscript", "gs"),
-        _command_check("qpdf", "qpdf"),
-    )
-
-
-def _command_check(name: str, command: str) -> DoctorCheck:
-    location = shutil.which(command)
+def _binary_check(name: str, command: str) -> DoctorCheck:
+    location = _which(command)
     if location is None:
         return DoctorCheck(name, "warn", f"missing command '{command}'")
     return DoctorCheck(name, "ok", f"found {location}")
 
 
-def _embedding_check(config: AppConfig, *, timeout_seconds: float) -> DoctorCheck:
-    provider = config.embedding_provider
+def _embedding_check(embedding: EmbeddingConfig, *, timeout_seconds: float) -> DoctorCheck:
+    provider = embedding.provider
     if provider is None:
-        return DoctorCheck(
-            "embedding",
-            "warn",
-            "no embedding provider configured",
-        )
+        return DoctorCheck("embedding", "warn", "no embedding provider configured")
 
     normalized_provider = provider.lower()
     if normalized_provider == "ollama":
-        return _ollama_check(config, timeout_seconds=timeout_seconds)
+        return _ollama_check(embedding, timeout_seconds=timeout_seconds)
     if normalized_provider in {"openai", "openai_compatible"}:
-        return _openai_compatible_check(config)
-    return DoctorCheck(
-        "embedding",
-        "error",
-        f"unsupported provider '{provider}'",
+        return _openai_compatible_check(embedding, timeout_seconds=timeout_seconds)
+    return DoctorCheck("embedding", "error", f"unsupported provider '{provider}'")
+
+
+def _ollama_check(embedding: EmbeddingConfig, *, timeout_seconds: float) -> DoctorCheck:
+    if embedding.model is None:
+        return DoctorCheck(
+            "embedding",
+            "warn",
+            "provider=ollama is configured but embedding.model is missing",
+        )
+
+    base_url = embedding.base_url or DEFAULT_OLLAMA_BASE_URL
+    endpoint = f"{base_url.rstrip('/')}/api/tags"
+    payload = _json_get(
+        endpoint,
+        provider_label="ollama",
+        timeout_seconds=timeout_seconds,
     )
-
-
-def _ollama_check(config: AppConfig, *, timeout_seconds: float) -> DoctorCheck:
-    ollama_binary = shutil.which("ollama")
-    if ollama_binary is None:
-        return DoctorCheck(
-            "embedding",
-            "warn",
-            "provider=ollama but the 'ollama' command is missing",
-        )
-
-    endpoint = config.ollama.host.rstrip("/") + "/api/tags"
-    try:
-        response = httpx.get(endpoint, timeout=timeout_seconds)
-        response.raise_for_status()
-        payload = response.json()
-    except httpx.HTTPError:
-        return DoctorCheck(
-            "embedding",
-            "warn",
-            (
-                "provider=ollama but the local server is unreachable at "
-                f"{config.ollama.host}; start Ollama and run 'ollama pull {config.ollama.model}'"
-            ),
-        )
-    except ValueError:
-        return DoctorCheck(
-            "embedding",
-            "warn",
-            f"provider=ollama returned malformed JSON from {config.ollama.host}",
-        )
+    if isinstance(payload, DoctorCheck):
+        return payload
 
     model_names = _extract_ollama_model_names(payload)
-    if _ollama_model_available(config.ollama.model, model_names):
+    if _model_available(embedding.model, model_names):
         return DoctorCheck(
             "embedding",
             "ok",
-            (f"provider=ollama host={config.ollama.host} model={config.ollama.model} is available"),
+            f"provider=ollama base_url={base_url} model={embedding.model} is available",
         )
 
     return DoctorCheck(
         "embedding",
         "warn",
         (
-            f"provider=ollama host={config.ollama.host} is reachable but "
-            f"model={config.ollama.model} is not installed; run 'ollama pull {config.ollama.model}'"
+            f"provider=ollama base_url={base_url} is reachable but model={embedding.model} "
+            f"is not installed; run 'ollama pull {embedding.model}'"
         ),
     )
 
 
-def _openai_compatible_check(config: AppConfig) -> DoctorCheck:
-    provider = config.embedding_provider or "openai_compatible"
-    if config.embedding_model is None:
+def _openai_compatible_check(
+    embedding: EmbeddingConfig,
+    *,
+    timeout_seconds: float,
+) -> DoctorCheck:
+    provider = embedding.provider or "openai_compatible"
+    if embedding.model is None:
         return DoctorCheck(
             "embedding",
             "warn",
             f"provider={provider} is configured but embedding.model is missing",
         )
 
-    api_key_env = config.embedding_api_key_env
-    if api_key_env is not None and not os.getenv(api_key_env):
+    api_key_env = embedding.api_key_env
+    if provider.lower() == "openai" and api_key_env is None:
+        api_key_env = DEFAULT_OPENAI_API_KEY_ENV
+
+    headers: dict[str, str] = {}
+    if api_key_env is not None:
+        api_key = os.getenv(api_key_env)
+        if not api_key:
+            return DoctorCheck(
+                "embedding",
+                "warn",
+                f"provider={provider} expects environment variable {api_key_env}",
+            )
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    base_url = embedding.base_url
+    if provider.lower() == "openai" and base_url is None:
+        base_url = DEFAULT_OPENAI_BASE_URL
+
+    if base_url is None:
         return DoctorCheck(
             "embedding",
             "warn",
-            f"provider={provider} expects environment variable {api_key_env}",
+            f"provider={provider} is configured but embedding.base_url is missing",
         )
 
-    if config.embedding_base_url is None:
+    endpoint = f"{base_url.rstrip('/')}/models"
+    payload = _json_get(
+        endpoint,
+        provider_label=provider,
+        timeout_seconds=timeout_seconds,
+        headers=headers,
+    )
+    if isinstance(payload, DoctorCheck):
+        return payload
+
+    model_names = _extract_openai_compatible_model_names(payload)
+    if model_names and not _model_available(embedding.model, model_names):
         return DoctorCheck(
             "embedding",
-            "ok",
-            f"provider={provider} model={config.embedding_model}",
+            "warn",
+            (
+                f"provider={provider} base_url={base_url} is reachable but model={embedding.model} "
+                "is not listed"
+            ),
         )
 
     return DoctorCheck(
         "embedding",
         "ok",
-        f"provider={provider} base_url={config.embedding_base_url} model={config.embedding_model}",
+        f"provider={provider} base_url={base_url} model={embedding.model} is available",
     )
 
 
-def _daemon_check(config: AppConfig) -> DoctorCheck:
-    socket_path = config.daemon.socket_path
+def _daemon_check(socket_path: Path | None) -> DoctorCheck:
     if socket_path is None:
         return DoctorCheck("daemon", "info", "not configured")
 
@@ -236,6 +248,39 @@ def _daemon_check(config: AppConfig) -> DoctorCheck:
     )
 
 
+def _json_get(
+    endpoint: str,
+    *,
+    provider_label: str,
+    timeout_seconds: float,
+    headers: dict[str, str] | None = None,
+) -> dict[str, Any] | DoctorCheck:
+    try:
+        response = httpx.get(endpoint, timeout=timeout_seconds, headers=headers)
+        response.raise_for_status()
+        payload = response.json()
+    except httpx.HTTPError:
+        return DoctorCheck(
+            "embedding",
+            "warn",
+            f"provider={provider_label} endpoint {endpoint} is unreachable",
+        )
+    except ValueError:
+        return DoctorCheck(
+            "embedding",
+            "warn",
+            f"provider={provider_label} endpoint {endpoint} returned malformed JSON",
+        )
+
+    if not isinstance(payload, dict):
+        return DoctorCheck(
+            "embedding",
+            "warn",
+            f"provider={provider_label} endpoint {endpoint} returned an unexpected payload shape",
+        )
+    return payload
+
+
 def _nearest_existing_parent(path: Path) -> Path | None:
     current = path
     while not current.exists():
@@ -246,10 +291,7 @@ def _nearest_existing_parent(path: Path) -> Path | None:
     return current
 
 
-def _extract_ollama_model_names(payload: Any) -> set[str]:
-    if not isinstance(payload, dict):
-        return set()
-
+def _extract_ollama_model_names(payload: dict[str, Any]) -> set[str]:
     models = payload.get("models")
     if not isinstance(models, list):
         return set()
@@ -263,8 +305,30 @@ def _extract_ollama_model_names(payload: Any) -> set[str]:
     return names
 
 
-def _ollama_model_available(expected_model: str, installed_models: set[str]) -> bool:
+def _extract_openai_compatible_model_names(payload: dict[str, Any]) -> set[str]:
+    data = payload.get("data")
+    if not isinstance(data, list):
+        return set()
+
+    names: set[str] = set()
+    for model in data:
+        if isinstance(model, dict):
+            identifier = model.get("id")
+            if isinstance(identifier, str):
+                names.add(identifier)
+    return names
+
+
+def _model_available(expected_model: str, installed_models: set[str]) -> bool:
     return any(
         model_name == expected_model or model_name.startswith(f"{expected_model}:")
         for model_name in installed_models
     )
+
+
+def _which(command: str) -> str | None:
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = Path(directory) / command
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None

--- a/newsrag/doctor.py
+++ b/newsrag/doctor.py
@@ -31,6 +31,18 @@ class DoctorReport:
     def has_errors(self) -> bool:
         return any(check.status == "error" for check in self.checks)
 
+    @property
+    def has_warnings(self) -> bool:
+        return any(check.status == "warn" for check in self.checks)
+
+    @property
+    def summary(self) -> str:
+        if self.has_errors:
+            return "error"
+        if self.has_warnings:
+            return "warn"
+        return "ok"
+
 
 def run_doctor(
     settings: RuntimeSettings,
@@ -61,8 +73,7 @@ def format_report(report: DoctorReport, *, settings: RuntimeSettings) -> str:
     for check in report.checks:
         lines.append(f"{check.name}: {check.status} - {check.detail}")
 
-    summary = "error" if report.has_errors else "ok"
-    lines.append(f"summary: {summary}")
+    lines.append(f"summary: {report.summary}")
     return "\n".join(lines)
 
 
@@ -109,15 +120,23 @@ def _command_check(name: str, command: str) -> DoctorCheck:
 
 
 def _embedding_check(config: AppConfig, *, timeout_seconds: float) -> DoctorCheck:
-    provider = config.embedding_provider.lower()
-    if provider == "ollama":
+    provider = config.embedding_provider
+    if provider is None:
+        return DoctorCheck(
+            "embedding",
+            "warn",
+            "no embedding provider configured",
+        )
+
+    normalized_provider = provider.lower()
+    if normalized_provider == "ollama":
         return _ollama_check(config, timeout_seconds=timeout_seconds)
-    if provider == "openai":
-        return _openai_check()
+    if normalized_provider in {"openai", "openai_compatible"}:
+        return _openai_compatible_check(config)
     return DoctorCheck(
         "embedding",
         "error",
-        f"unsupported provider '{config.embedding_provider}'",
+        f"unsupported provider '{provider}'",
     )
 
 
@@ -144,6 +163,12 @@ def _ollama_check(config: AppConfig, *, timeout_seconds: float) -> DoctorCheck:
                 f"{config.ollama.host}; start Ollama and run 'ollama pull {config.ollama.model}'"
             ),
         )
+    except ValueError:
+        return DoctorCheck(
+            "embedding",
+            "warn",
+            f"provider=ollama returned malformed JSON from {config.ollama.host}",
+        )
 
     model_names = _extract_ollama_model_names(payload)
     if _ollama_model_available(config.ollama.model, model_names):
@@ -163,13 +188,34 @@ def _ollama_check(config: AppConfig, *, timeout_seconds: float) -> DoctorCheck:
     )
 
 
-def _openai_check() -> DoctorCheck:
-    if os.getenv("OPENAI_API_KEY"):
-        return DoctorCheck("embedding", "ok", "provider=openai and OPENAI_API_KEY is set")
+def _openai_compatible_check(config: AppConfig) -> DoctorCheck:
+    provider = config.embedding_provider or "openai_compatible"
+    if config.embedding_model is None:
+        return DoctorCheck(
+            "embedding",
+            "warn",
+            f"provider={provider} is configured but embedding.model is missing",
+        )
+
+    api_key_env = config.embedding_api_key_env
+    if api_key_env is not None and not os.getenv(api_key_env):
+        return DoctorCheck(
+            "embedding",
+            "warn",
+            f"provider={provider} expects environment variable {api_key_env}",
+        )
+
+    if config.embedding_base_url is None:
+        return DoctorCheck(
+            "embedding",
+            "ok",
+            f"provider={provider} model={config.embedding_model}",
+        )
+
     return DoctorCheck(
         "embedding",
-        "warn",
-        "provider=openai but OPENAI_API_KEY is not set",
+        "ok",
+        f"provider={provider} base_url={config.embedding_base_url} model={config.embedding_model}",
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,15 @@ dependencies = [
     "watchfiles",
 ]
 
+[project.scripts]
+newsrag = "newsrag.cli:run"
+
 [dependency-groups]
 dev = [
     "mypy>=1.18.0",
     "pytest>=9.0.0",
     "ruff>=0.14.0",
+    "types-pyyaml>=6.0.12.20250915",
 ]
 
 [build-system]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from newsrag.cli import app
+
+runner = CliRunner()
+
+
+def test_help_shows_cli_commands() -> None:
+    result = runner.invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "doctor" in result.stdout
+
+
+def test_doctor_runs_without_crashing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+embedding:
+  provider: ollama
+  ollama:
+    host: http://127.0.0.1:11434
+    model: nomic-embed-text
+""".strip(),
+        encoding="utf-8",
+    )
+
+    def fake_get(url: str, timeout: float) -> httpx.Response:
+        request = httpx.Request("GET", url)
+        return httpx.Response(
+            200,
+            request=request,
+            json={"models": [{"name": "nomic-embed-text:latest"}]},
+        )
+
+    monkeypatch.setattr("newsrag.doctor.httpx.get", fake_get)
+
+    result = runner.invoke(app, ["--config-path", str(config_path), "doctor"])
+
+    assert result.exit_code == 0
+    assert "NewsRAG Doctor" in result.stdout
+    assert "summary: ok" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import httpx
-import pytest
 from typer.testing import CliRunner
 
 from newsrag.cli import app
@@ -18,31 +16,12 @@ def test_help_shows_cli_commands() -> None:
     assert "doctor" in result.stdout
 
 
-def test_doctor_runs_without_crashing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_doctor_runs_without_crashing(tmp_path: Path) -> None:
     config_path = tmp_path / "config.yaml"
-    config_path.write_text(
-        """
-embedding:
-  provider: ollama
-  ollama:
-    host: http://127.0.0.1:11434
-    model: nomic-embed-text
-""".strip(),
-        encoding="utf-8",
-    )
-
-    def fake_get(url: str, timeout: float) -> httpx.Response:
-        request = httpx.Request("GET", url)
-        return httpx.Response(
-            200,
-            request=request,
-            json={"models": [{"name": "nomic-embed-text:latest"}]},
-        )
-
-    monkeypatch.setattr("newsrag.doctor.httpx.get", fake_get)
+    config_path.write_text("", encoding="utf-8")
 
     result = runner.invoke(app, ["--config-path", str(config_path), "doctor"])
 
     assert result.exit_code == 0
     assert "NewsRAG Doctor" in result.stdout
-    assert "summary: ok" in result.stdout
+    assert "summary:" in result.stdout

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from newsrag.config import (
+    DEFAULT_CONFIG_PATH,
+    AppConfig,
+    ConfigError,
+    load_config,
+    resolve_data_dir,
+    resolve_runtime_settings,
+)
+
+
+def test_load_config_uses_defaults_for_empty_file(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("", encoding="utf-8")
+
+    config = load_config(config_path)
+
+    assert config == AppConfig(source_path=config_path)
+
+
+def test_load_config_missing_file_returns_defaults(tmp_path: Path) -> None:
+    config_path = tmp_path / "missing.yaml"
+
+    config = load_config(config_path)
+
+    assert config.source_path == config_path
+    assert config.data_dir is None
+    assert config.embedding_provider == "ollama"
+    assert config.ollama.host == "http://127.0.0.1:11434"
+    assert config.ollama.model == "nomic-embed-text"
+
+
+def test_load_config_invalid_yaml_raises(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("data_dir: [", encoding="utf-8")
+
+    with pytest.raises(ConfigError):
+        load_config(config_path)
+
+
+def test_resolve_runtime_settings_prefers_cli_data_dir(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("data_dir: from-config\n", encoding="utf-8")
+    cli_data_dir = tmp_path / "from-cli"
+
+    settings = resolve_runtime_settings(
+        config_path=config_path,
+        data_dir=cli_data_dir,
+        cwd=tmp_path,
+    )
+
+    assert settings.config_path == config_path
+    assert settings.data_dir == cli_data_dir
+    assert settings.config.data_dir == Path("from-config")
+
+
+def test_resolve_data_dir_uses_config_value(tmp_path: Path) -> None:
+    config = AppConfig(source_path=DEFAULT_CONFIG_PATH, data_dir=Path("configured-dir"))
+
+    data_dir = resolve_data_dir(None, config, cwd=tmp_path)
+
+    assert data_dir == (tmp_path / "configured-dir").resolve()
+
+
+def test_resolve_data_dir_defaults_to_local_newsrag(tmp_path: Path) -> None:
+    config = AppConfig(source_path=DEFAULT_CONFIG_PATH)
+
+    data_dir = resolve_data_dir(None, config, cwd=tmp_path)
+
+    assert data_dir == (tmp_path / ".newsrag").resolve()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,7 @@ from newsrag.config import (
     DEFAULT_CONFIG_PATH,
     AppConfig,
     ConfigError,
+    EmbeddingConfig,
     load_config,
     resolve_data_dir,
     resolve_runtime_settings,
@@ -30,11 +31,7 @@ def test_load_config_missing_file_returns_defaults(tmp_path: Path) -> None:
 
     assert config.source_path == config_path
     assert config.data_dir is None
-    assert config.embedding_provider is None
-    assert config.embedding_base_url is None
-    assert config.embedding_model is None
-    assert config.ollama.host == "http://127.0.0.1:11434"
-    assert config.ollama.model == "nomic-embed-text"
+    assert config.embedding == EmbeddingConfig()
 
 
 def test_load_config_reads_generic_embedding_provider(tmp_path: Path) -> None:
@@ -52,10 +49,10 @@ embedding:
 
     config = load_config(config_path)
 
-    assert config.embedding_provider == "openai_compatible"
-    assert config.embedding_base_url == "http://localhost:1234/v1"
-    assert config.embedding_model == "text-embedding-3-small"
-    assert config.embedding_api_key_env == "OPENAI_API_KEY"
+    assert config.embedding.provider == "openai_compatible"
+    assert config.embedding.base_url == "http://localhost:1234/v1"
+    assert config.embedding.model == "text-embedding-3-small"
+    assert config.embedding.api_key_env == "OPENAI_API_KEY"
 
 
 def test_load_config_invalid_yaml_raises(tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,9 +30,32 @@ def test_load_config_missing_file_returns_defaults(tmp_path: Path) -> None:
 
     assert config.source_path == config_path
     assert config.data_dir is None
-    assert config.embedding_provider == "ollama"
+    assert config.embedding_provider is None
+    assert config.embedding_base_url is None
+    assert config.embedding_model is None
     assert config.ollama.host == "http://127.0.0.1:11434"
     assert config.ollama.model == "nomic-embed-text"
+
+
+def test_load_config_reads_generic_embedding_provider(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+embedding:
+  provider: openai_compatible
+  base_url: http://localhost:1234/v1
+  model: text-embedding-3-small
+  api_key_env: OPENAI_API_KEY
+""".strip(),
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+
+    assert config.embedding_provider == "openai_compatible"
+    assert config.embedding_base_url == "http://localhost:1234/v1"
+    assert config.embedding_model == "text-embedding-3-small"
+    assert config.embedding_api_key_env == "OPENAI_API_KEY"
 
 
 def test_load_config_invalid_yaml_raises(tmp_path: Path) -> None:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from newsrag.config import AppConfig, RuntimeSettings
+from newsrag.doctor import DoctorCheck, DoctorReport, format_report, run_doctor
+
+
+def test_format_report_uses_warn_summary_for_warnings(tmp_path: Path) -> None:
+    settings = RuntimeSettings(
+        config_path=tmp_path / "config.yaml",
+        data_dir=tmp_path / ".newsrag",
+        config=AppConfig(source_path=tmp_path / "config.yaml"),
+    )
+    report = DoctorReport(checks=(DoctorCheck("embedding", "warn", "not configured"),))
+
+    formatted = format_report(report, settings=settings)
+
+    assert "summary: warn" in formatted
+
+
+def test_format_report_uses_error_summary_for_errors(tmp_path: Path) -> None:
+    settings = RuntimeSettings(
+        config_path=tmp_path / "config.yaml",
+        data_dir=tmp_path / ".newsrag",
+        config=AppConfig(source_path=tmp_path / "config.yaml"),
+    )
+    report = DoctorReport(checks=(DoctorCheck("config", "error", "invalid"),))
+
+    formatted = format_report(report, settings=settings)
+
+    assert "summary: error" in formatted
+
+
+def test_run_doctor_warns_when_embedding_provider_is_unconfigured(tmp_path: Path) -> None:
+    settings = RuntimeSettings(
+        config_path=tmp_path / "config.yaml",
+        data_dir=tmp_path / ".newsrag",
+        config=AppConfig(source_path=tmp_path / "config.yaml"),
+    )
+
+    report = run_doctor(settings)
+
+    embedding_check = next(check for check in report.checks if check.name == "embedding")
+    assert embedding_check.status == "warn"
+    assert "no embedding provider configured" in embedding_check.detail
+    assert report.summary == "warn"
+
+
+def test_run_doctor_handles_malformed_ollama_response(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = RuntimeSettings(
+        config_path=tmp_path / "config.yaml",
+        data_dir=tmp_path / ".newsrag",
+        config=AppConfig(
+            source_path=tmp_path / "config.yaml",
+            embedding_provider="ollama",
+        ),
+    )
+
+    def fake_get(url: str, timeout: float) -> httpx.Response:
+        request = httpx.Request("GET", url)
+        response = httpx.Response(200, request=request, content=b"not-json")
+        return response
+
+    monkeypatch.setattr("newsrag.doctor.httpx.get", fake_get)
+    monkeypatch.setattr("newsrag.doctor.shutil.which", lambda command: f"/usr/bin/{command}")
+
+    report = run_doctor(settings)
+
+    embedding_check = next(check for check in report.checks if check.name == "embedding")
+    assert embedding_check.status == "warn"
+    assert "malformed JSON" in embedding_check.detail
+
+
+def test_run_doctor_checks_generic_openai_compatible_provider(tmp_path: Path) -> None:
+    settings = RuntimeSettings(
+        config_path=tmp_path / "config.yaml",
+        data_dir=tmp_path / ".newsrag",
+        config=AppConfig(
+            source_path=tmp_path / "config.yaml",
+            embedding_provider="openai_compatible",
+            embedding_base_url="http://localhost:1234/v1",
+            embedding_model="text-embedding-3-small",
+        ),
+    )
+
+    report = run_doctor(settings)
+
+    embedding_check = next(check for check in report.checks if check.name == "embedding")
+    assert embedding_check.status == "ok"
+    assert "provider=openai_compatible" in embedding_check.detail

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import httpx
 import pytest
 
-from newsrag.config import AppConfig, RuntimeSettings
+from newsrag.config import AppConfig, EmbeddingConfig, RuntimeSettings
 from newsrag.doctor import DoctorCheck, DoctorReport, format_report, run_doctor
 
 
@@ -59,17 +59,15 @@ def test_run_doctor_handles_malformed_ollama_response(
         data_dir=tmp_path / ".newsrag",
         config=AppConfig(
             source_path=tmp_path / "config.yaml",
-            embedding_provider="ollama",
+            embedding=EmbeddingConfig(provider="ollama", model="nomic-embed-text"),
         ),
     )
 
-    def fake_get(url: str, timeout: float) -> httpx.Response:
+    def fake_get(url: str, timeout: float, headers: dict[str, str] | None = None) -> httpx.Response:
         request = httpx.Request("GET", url)
-        response = httpx.Response(200, request=request, content=b"not-json")
-        return response
+        return httpx.Response(200, request=request, content=b"not-json")
 
     monkeypatch.setattr("newsrag.doctor.httpx.get", fake_get)
-    monkeypatch.setattr("newsrag.doctor.shutil.which", lambda command: f"/usr/bin/{command}")
 
     report = run_doctor(settings)
 
@@ -78,20 +76,69 @@ def test_run_doctor_handles_malformed_ollama_response(
     assert "malformed JSON" in embedding_check.detail
 
 
-def test_run_doctor_checks_generic_openai_compatible_provider(tmp_path: Path) -> None:
+def test_run_doctor_checks_generic_openai_compatible_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     settings = RuntimeSettings(
         config_path=tmp_path / "config.yaml",
         data_dir=tmp_path / ".newsrag",
         config=AppConfig(
             source_path=tmp_path / "config.yaml",
-            embedding_provider="openai_compatible",
-            embedding_base_url="http://localhost:1234/v1",
-            embedding_model="text-embedding-3-small",
+            embedding=EmbeddingConfig(
+                provider="openai_compatible",
+                base_url="http://localhost:1234/v1",
+                model="text-embedding-3-small",
+            ),
         ),
     )
+
+    def fake_get(url: str, timeout: float, headers: dict[str, str] | None = None) -> httpx.Response:
+        request = httpx.Request("GET", url, headers=headers)
+        return httpx.Response(
+            200,
+            request=request,
+            json={"data": [{"id": "text-embedding-3-small"}]},
+        )
+
+    monkeypatch.setattr("newsrag.doctor.httpx.get", fake_get)
 
     report = run_doctor(settings)
 
     embedding_check = next(check for check in report.checks if check.name == "embedding")
     assert embedding_check.status == "ok"
     assert "provider=openai_compatible" in embedding_check.detail
+
+
+def test_run_doctor_checks_ollama_provider_when_selected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = RuntimeSettings(
+        config_path=tmp_path / "config.yaml",
+        data_dir=tmp_path / ".newsrag",
+        config=AppConfig(
+            source_path=tmp_path / "config.yaml",
+            embedding=EmbeddingConfig(
+                provider="ollama",
+                base_url="http://127.0.0.1:11434",
+                model="nomic-embed-text",
+            ),
+        ),
+    )
+
+    def fake_get(url: str, timeout: float, headers: dict[str, str] | None = None) -> httpx.Response:
+        request = httpx.Request("GET", url)
+        return httpx.Response(
+            200,
+            request=request,
+            json={"models": [{"name": "nomic-embed-text:latest"}]},
+        )
+
+    monkeypatch.setattr("newsrag.doctor.httpx.get", fake_get)
+
+    report = run_doctor(settings)
+
+    embedding_check = next(check for check in report.checks if check.name == "embedding")
+    assert embedding_check.status == "ok"
+    assert "provider=ollama" in embedding_check.detail

--- a/uv.lock
+++ b/uv.lock
@@ -584,6 +584,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -603,6 +604,7 @@ dev = [
     { name = "mypy", specifier = ">=1.18.0" },
     { name = "pytest", specifier = ">=9.0.0" },
     { name = "ruff", specifier = ">=0.14.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 
 [[package]]
@@ -1228,6 +1230,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150, upload-time = "2026-04-26T08:46:14.767Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993, upload-time = "2026-04-26T08:46:15.889Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add the first runnable NewsRAG CLI slice with config loading, data-dir resolution, and a `doctor` command for local environment checks.

## Task

- #task-11831224

## Changes

- add a Typer-based `newsrag` CLI entrypoint and console script
- add global config loading from `~/.config/newsrag/config.yaml` with typed parsing and validation
- add runtime data-dir resolution from CLI override, config, or default `./.newsrag/`
- add `newsrag doctor` checks for config validity, data-dir writability, OCR tooling, embedding availability, and optional daemon socket status
- add unit tests for config loading, override behavior, data-dir resolution, CLI help, and doctor command stability
- document the new CLI quick-start commands in `README.md`

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
