### PR TITLE
feat: add corpus storage lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ uv sync --dev
 ```bash
 uv run newsrag --help
 uv run newsrag doctor
+uv run newsrag status --initialize
 ```
 
 ## How to work on this project

--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -14,6 +14,12 @@ from newsrag.config import (
     resolve_data_dir,
 )
 from newsrag.doctor import format_report, run_doctor
+from newsrag.storage import (
+    StorageError,
+    format_status_report,
+    get_storage_status,
+    initialize_storage,
+)
 
 CONFIG_PATH_OPTION = typer.Option(
     None,
@@ -59,6 +65,52 @@ def main(
 def doctor(ctx: typer.Context) -> None:
     """Validate the local NewsRAG environment and configuration."""
 
+    settings, config_error = _resolve_runtime_settings(ctx)
+    report = run_doctor(settings, config_error=config_error)
+    typer.echo(format_report(report, settings=settings))
+
+    if report.has_errors:
+        raise typer.Exit(code=1)
+
+
+@app.command()
+def status(
+    ctx: typer.Context,
+    initialize: bool = typer.Option(
+        False,
+        "--initialize",
+        help="Create the storage layout before reporting status.",
+    ),
+) -> None:
+    """Report storage layout health for the active data directory."""
+
+    settings, _ = _resolve_runtime_settings(ctx)
+
+    if initialize:
+        try:
+            initialize_storage(settings.data_dir)
+        except StorageError as exc:
+            typer.echo(
+                format_status_report(
+                    get_storage_status(settings.data_dir), data_dir=settings.data_dir
+                )
+            )
+            raise typer.Exit(code=1) from exc
+
+    report = get_storage_status(settings.data_dir)
+    typer.echo(format_status_report(report, data_dir=settings.data_dir))
+
+    if report.has_errors:
+        raise typer.Exit(code=1)
+
+
+def run() -> None:
+    """Run the Typer application."""
+
+    app()
+
+
+def _resolve_runtime_settings(ctx: typer.Context) -> tuple[RuntimeSettings, str | None]:
     state = _get_state(ctx)
     config_error: str | None = None
 
@@ -73,17 +125,7 @@ def doctor(ctx: typer.Context) -> None:
         data_dir=resolve_data_dir(state.data_dir, config),
         config=config,
     )
-    report = run_doctor(settings, config_error=config_error)
-    typer.echo(format_report(report, settings=settings))
-
-    if report.has_errors:
-        raise typer.Exit(code=1)
-
-
-def run() -> None:
-    """Run the Typer application."""
-
-    app()
+    return settings, config_error
 
 
 def _get_state(ctx: typer.Context) -> CliState:

--- a/newsrag/storage.py
+++ b/newsrag/storage.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class StorageError(Exception):
+    """Raised when the NewsRAG storage layout cannot be initialized or inspected."""
+
+
+@dataclass(frozen=True)
+class StoragePaths:
+    """Resolved storage paths for one NewsRAG data directory."""
+
+    data_dir: Path
+    source_pdfs: Path
+    downloaded_pdfs: Path
+    ocr_pdfs: Path
+    lancedb: Path
+    logs: Path
+    artifacts: Path
+    database: Path
+
+
+@dataclass(frozen=True)
+class StorageCheck:
+    """One storage health check result."""
+
+    name: str
+    status: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class StorageStatusReport:
+    """Structured storage status output."""
+
+    checks: tuple[StorageCheck, ...]
+
+    @property
+    def has_errors(self) -> bool:
+        return any(check.status == "error" for check in self.checks)
+
+    @property
+    def has_warnings(self) -> bool:
+        return any(check.status == "warn" for check in self.checks)
+
+    @property
+    def summary(self) -> str:
+        if self.has_errors:
+            return "error"
+        if self.has_warnings:
+            return "warn"
+        return "ok"
+
+
+DIRECTORY_NAMES: tuple[tuple[str, str], ...] = (
+    ("source_pdfs", "source-pdfs"),
+    ("downloaded_pdfs", "downloaded-pdfs"),
+    ("ocr_pdfs", "ocr-pdfs"),
+    ("lancedb", "lancedb"),
+    ("logs", "logs"),
+    ("artifacts", "artifacts"),
+)
+DATABASE_FILENAME = "newsrag.sqlite3"
+SCHEMA_VERSION = "1"
+REQUIRED_TABLES = {
+    "documents",
+    "pages",
+    "chunks",
+    "jobs",
+    "watches",
+    "metadata",
+}
+SCHEMA_STATEMENTS = (
+    """
+    CREATE TABLE IF NOT EXISTS metadata (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS documents (
+        id TEXT PRIMARY KEY,
+        source_path TEXT,
+        source_url TEXT,
+        title TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS pages (
+        id TEXT PRIMARY KEY,
+        document_id TEXT NOT NULL,
+        page_number INTEGER NOT NULL,
+        text TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(document_id) REFERENCES documents(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS chunks (
+        id TEXT PRIMARY KEY,
+        document_id TEXT NOT NULL,
+        page_start INTEGER NOT NULL,
+        page_end INTEGER NOT NULL,
+        text TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(document_id) REFERENCES documents(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS jobs (
+        id TEXT PRIMARY KEY,
+        kind TEXT NOT NULL,
+        status TEXT NOT NULL,
+        payload_json TEXT NOT NULL DEFAULT '{}',
+        error TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS watches (
+        id TEXT PRIMARY KEY,
+        path TEXT NOT NULL UNIQUE,
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+    """,
+)
+
+
+def build_storage_paths(data_dir: Path) -> StoragePaths:
+    """Build the expected storage paths for one data directory."""
+
+    directory_paths = {name: data_dir / relative_path for name, relative_path in DIRECTORY_NAMES}
+    return StoragePaths(
+        data_dir=data_dir,
+        source_pdfs=directory_paths["source_pdfs"],
+        downloaded_pdfs=directory_paths["downloaded_pdfs"],
+        ocr_pdfs=directory_paths["ocr_pdfs"],
+        lancedb=directory_paths["lancedb"],
+        logs=directory_paths["logs"],
+        artifacts=directory_paths["artifacts"],
+        database=data_dir / DATABASE_FILENAME,
+    )
+
+
+def initialize_storage(data_dir: Path) -> StoragePaths:
+    """Create or update the NewsRAG storage layout for one data directory."""
+
+    paths = build_storage_paths(data_dir)
+    _validate_storage_target(paths.data_dir)
+    paths.data_dir.mkdir(parents=True, exist_ok=True)
+
+    for directory in _iter_directories(paths):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    _initialize_database(paths.database)
+    return paths
+
+
+def get_storage_status(data_dir: Path) -> StorageStatusReport:
+    """Inspect the current storage layout without mutating it."""
+
+    checks: list[StorageCheck] = []
+    paths = build_storage_paths(data_dir)
+
+    if paths.data_dir.exists() and not paths.data_dir.is_dir():
+        return StorageStatusReport(
+            checks=(
+                StorageCheck(
+                    "data_dir",
+                    "error",
+                    f"{paths.data_dir} exists but is not a directory",
+                ),
+            )
+        )
+
+    target = paths.data_dir if paths.data_dir.exists() else _nearest_existing_parent(paths.data_dir)
+    if target is None:
+        checks.append(
+            StorageCheck("data_dir", "error", f"cannot resolve parent for {paths.data_dir}")
+        )
+        return StorageStatusReport(checks=tuple(checks))
+
+    if not os.access(target, os.W_OK | os.X_OK):
+        checks.append(StorageCheck("data_dir", "error", f"{target} is not writable"))
+        return StorageStatusReport(checks=tuple(checks))
+
+    if paths.data_dir.exists():
+        checks.append(StorageCheck("data_dir", "ok", f"{paths.data_dir} exists"))
+    else:
+        checks.append(
+            StorageCheck(
+                "data_dir",
+                "warn",
+                f"{paths.data_dir} does not exist yet; parent {target} is writable",
+            )
+        )
+
+    for name, directory in _directory_checks(paths):
+        if directory.exists() and directory.is_dir():
+            checks.append(StorageCheck(name, "ok", f"present at {directory}"))
+        elif directory.exists():
+            checks.append(StorageCheck(name, "error", f"{directory} exists but is not a directory"))
+        else:
+            checks.append(StorageCheck(name, "warn", f"missing directory {directory}"))
+
+    if not paths.database.exists():
+        checks.append(StorageCheck("database", "warn", f"missing database {paths.database}"))
+        return StorageStatusReport(checks=tuple(checks))
+
+    if not paths.database.is_file():
+        checks.append(
+            StorageCheck("database", "error", f"{paths.database} exists but is not a file")
+        )
+        return StorageStatusReport(checks=tuple(checks))
+
+    missing_tables = REQUIRED_TABLES.difference(_existing_tables(paths.database))
+    if missing_tables:
+        table_list = ", ".join(sorted(missing_tables))
+        checks.append(StorageCheck("database", "warn", f"missing tables: {table_list}"))
+    else:
+        checks.append(StorageCheck("database", "ok", f"schema ready at {paths.database}"))
+
+    return StorageStatusReport(checks=tuple(checks))
+
+
+def format_status_report(report: StorageStatusReport, *, data_dir: Path) -> str:
+    """Format storage status for terminal output."""
+
+    lines = [
+        "NewsRAG Status",
+        f"data_dir: {data_dir}",
+    ]
+
+    for check in report.checks:
+        lines.append(f"{check.name}: {check.status} - {check.detail}")
+
+    lines.append(f"summary: {report.summary}")
+    return "\n".join(lines)
+
+
+def _directory_checks(paths: StoragePaths) -> tuple[tuple[str, Path], ...]:
+    return (
+        ("source_pdfs", paths.source_pdfs),
+        ("downloaded_pdfs", paths.downloaded_pdfs),
+        ("ocr_pdfs", paths.ocr_pdfs),
+        ("lancedb", paths.lancedb),
+        ("logs", paths.logs),
+        ("artifacts", paths.artifacts),
+    )
+
+
+def _iter_directories(paths: StoragePaths) -> tuple[Path, ...]:
+    return tuple(directory for _, directory in _directory_checks(paths))
+
+
+def _initialize_database(database_path: Path) -> None:
+    with sqlite3.connect(database_path) as connection:
+        connection.execute("PRAGMA foreign_keys = ON")
+        for statement in SCHEMA_STATEMENTS:
+            connection.execute(statement)
+        connection.execute(
+            "INSERT OR IGNORE INTO metadata(key, value) VALUES(?, ?)",
+            ("schema_version", SCHEMA_VERSION),
+        )
+        connection.commit()
+
+
+def _existing_tables(database_path: Path) -> set[str]:
+    with sqlite3.connect(database_path) as connection:
+        cursor = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+        )
+        rows = cursor.fetchall()
+    return {row[0] for row in rows}
+
+
+def _validate_storage_target(data_dir: Path) -> None:
+    if data_dir.exists() and not data_dir.is_dir():
+        raise StorageError(f"{data_dir} exists but is not a directory")
+
+    target = data_dir if data_dir.exists() else _nearest_existing_parent(data_dir)
+    if target is None:
+        raise StorageError(f"cannot resolve writable parent for {data_dir}")
+    if not os.access(target, os.W_OK | os.X_OK):
+        raise StorageError(f"{target} is not writable")
+
+
+def _nearest_existing_parent(path: Path) -> Path | None:
+    current = path
+    while not current.exists():
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+    return current

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ def test_help_shows_cli_commands() -> None:
 
     assert result.exit_code == 0
     assert "doctor" in result.stdout
+    assert "status" in result.stdout
 
 
 def test_doctor_runs_without_crashing(tmp_path: Path) -> None:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from newsrag.cli import app
+from newsrag.storage import REQUIRED_TABLES, StorageError, _existing_tables, initialize_storage
+
+runner = CliRunner()
+
+
+def test_initialize_storage_creates_layout_and_schema(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+
+    paths = initialize_storage(data_dir)
+
+    assert paths.data_dir == data_dir
+    assert paths.source_pdfs.is_dir()
+    assert paths.downloaded_pdfs.is_dir()
+    assert paths.ocr_pdfs.is_dir()
+    assert paths.lancedb.is_dir()
+    assert paths.logs.is_dir()
+    assert paths.artifacts.is_dir()
+    assert paths.database.is_file()
+    assert REQUIRED_TABLES.issubset(_existing_tables(paths.database))
+
+
+def test_initialize_storage_is_idempotent(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+
+    first_paths = initialize_storage(data_dir)
+    second_paths = initialize_storage(data_dir)
+
+    assert first_paths == second_paths
+    assert REQUIRED_TABLES == REQUIRED_TABLES.intersection(_existing_tables(second_paths.database))
+
+
+def test_initialize_storage_rejects_file_path(tmp_path: Path) -> None:
+    data_dir = tmp_path / "not-a-directory"
+    data_dir.write_text("x", encoding="utf-8")
+
+    with pytest.raises(StorageError):
+        initialize_storage(data_dir)
+
+
+def test_initialize_storage_rejects_unwritable_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_dir = tmp_path / "nested" / ".newsrag"
+
+    def fake_access(path: object, mode: int) -> bool:
+        del mode
+        candidate = Path(str(path))
+        if candidate == tmp_path:
+            return False
+        return True
+
+    monkeypatch.setattr("newsrag.storage.os.access", fake_access)
+
+    with pytest.raises(StorageError):
+        initialize_storage(data_dir)
+
+
+def test_status_command_reports_storage_health(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+
+    first_result = runner.invoke(app, ["--data-dir", str(data_dir), "status"])
+    second_result = runner.invoke(app, ["--data-dir", str(data_dir), "status", "--initialize"])
+    third_result = runner.invoke(app, ["--data-dir", str(data_dir), "status"])
+
+    assert first_result.exit_code == 0
+    assert "NewsRAG Status" in first_result.stdout
+    assert "summary: warn" in first_result.stdout
+    assert f"data_dir: {data_dir}" in first_result.stdout
+
+    assert second_result.exit_code == 0
+    assert "summary: ok" in second_result.stdout
+
+    assert third_result.exit_code == 0
+    assert "database: ok" in third_result.stdout
+    assert "source_pdfs: ok" in third_result.stdout
+    assert "summary: ok" in third_result.stdout


### PR DESCRIPTION
## Summary

Add the first storage lifecycle slice for NewsRAG by creating the local data-dir layout, initializing the SQLite schema, and reporting storage health through `newsrag status`.

## Task

- #task-9c242503

## Changes

- add a storage module that builds and initializes the `.newsrag/` directory layout idempotently
- create stable directories for source PDFs, downloaded PDFs, OCR PDFs, LanceDB data, logs, and transient artifacts
- initialize a SQLite database with high-level tables for documents, pages, chunks, jobs, watches, and metadata
- add a `newsrag status` command with optional `--initialize` support and health reporting for directories and schema
- add direct tests for fresh init, idempotent re-init, invalid/unwritable targets, and CLI status output shaping
- document `uv run newsrag status --initialize` in the README quick start

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
