### PR TITLE
feat: add daemon run loop and job queue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-.PHONY: dev dev-stop dev-status dev-logs dev-tail check pre-pr help
+.PHONY: dev dev-stop dev-status dev-logs dev-tail dev-connect check pre-pr help
 
 SOCKET := ./.overmind.sock
 SETUP_DOC := docs/development.md
+SERVICE ?= newsrag
 
 define require_command
 	@command -v $(1) >/dev/null 2>&1 || { \
@@ -63,6 +64,15 @@ dev-tail: ## Show last 100 lines of logs (non-blocking)
 		done; \
 	else \
 		echo "Dev environment not running"; \
+	fi
+
+dev-connect: ## Attach to one dev process terminal (default: SERVICE=newsrag)
+	$(call require_command,overmind)
+	@if [ -S $(SOCKET) ] && overmind ps -s $(SOCKET) > /dev/null 2>&1; then \
+		overmind connect -s $(SOCKET) $(SERVICE); \
+	else \
+		echo "Dev environment not running"; \
+		exit 1; \
 	fi
 
 check: ## Run formatting checks, linting, type checking, and tests

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,1 @@
-# Replace the placeholder command below with `uv run newsrag daemon run` once the daemon entrypoint exists.
-newsrag: ./scripts/dev-placeholder.sh
+newsrag: uv run newsrag daemon run

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ uv run newsrag status --initialize
 make dev
 ```
 
-This starts all processes defined in `Procfile.dev`. Right now the Procfile runs a placeholder long-lived process until `newsrag daemon run` exists.
+This starts all processes defined in `Procfile.dev`, including the foreground `newsrag daemon run` process managed by Overmind.
 
 ### View logs
 
@@ -47,6 +47,9 @@ make dev-logs
 
 # Quick peek at recent logs
 make dev-tail
+
+# Attach to one service terminal (default: SERVICE=newsrag)
+make dev-connect
 ```
 
 ### Check status

--- a/docs/development.md
+++ b/docs/development.md
@@ -76,6 +76,14 @@ Start the development environment:
 make dev
 ```
 
+Attach to one service terminal:
+
+```bash
+make dev-connect
+# or choose a different process name
+make dev-connect SERVICE=newsrag
+```
+
 Check status:
 
 ```bash
@@ -90,8 +98,7 @@ make dev-stop
 
 Current behavior:
 - `Procfile.dev` is present and wired into `make dev`.
-- The long-running process is a placeholder until `newsrag daemon run` is implemented.
-- When the daemon entrypoint lands, replace `./scripts/dev-placeholder.sh` in `Procfile.dev` with the real command.
+- The long-running process is `uv run newsrag daemon run` managed by Overmind.
 
 ## Verification commands
 

--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -13,7 +14,9 @@ from newsrag.config import (
     load_config,
     resolve_data_dir,
 )
+from newsrag.daemon import DaemonConfig, run_daemon
 from newsrag.doctor import format_report, run_doctor
+from newsrag.jobs import list_jobs
 from newsrag.storage import (
     StorageError,
     format_status_report,
@@ -37,6 +40,10 @@ DATA_DIR_OPTION = typer.Option(
 )
 
 app = typer.Typer(help="Local-first evidence retrieval for city hall PDFs.")
+daemon_app = typer.Typer(help="Run the NewsRAG background daemon.")
+jobs_app = typer.Typer(help="Inspect durable NewsRAG jobs.")
+app.add_typer(daemon_app, name="daemon")
+app.add_typer(jobs_app, name="jobs")
 
 
 @dataclass(frozen=True)
@@ -102,6 +109,48 @@ def status(
 
     if report.has_errors:
         raise typer.Exit(code=1)
+
+
+@daemon_app.command("run")
+def daemon_run(
+    ctx: typer.Context,
+    poll_interval: float = typer.Option(0.5, help="Seconds to wait between queue polls."),
+    max_loops: int | None = typer.Option(None, hidden=True),
+) -> None:
+    """Run the foreground NewsRAG daemon loop."""
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    typer.echo(f"NewsRAG daemon running for {settings.data_dir}")
+    asyncio.run(
+        run_daemon(
+            DaemonConfig(
+                data_dir=settings.data_dir,
+                poll_interval=poll_interval,
+                max_loops=max_loops,
+            )
+        )
+    )
+
+
+@jobs_app.command("list")
+def jobs_list_command(ctx: typer.Context) -> None:
+    """List durable NewsRAG jobs."""
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    database_path = initialize_storage(settings.data_dir).database
+    jobs = list_jobs(database_path)
+
+    typer.echo("NewsRAG Jobs")
+    typer.echo(f"data_dir: {settings.data_dir}")
+    if not jobs:
+        typer.echo("jobs: none")
+        return
+
+    for job in jobs:
+        line = f"{job.id} {job.status} {job.kind}"
+        if job.error is not None:
+            line = f"{line} error={job.error}"
+        typer.echo(line)
 
 
 def run() -> None:

--- a/newsrag/daemon.py
+++ b/newsrag/daemon.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from newsrag.jobs import Job, claim_next_job, mark_job_done, mark_job_failed
+from newsrag.storage import initialize_storage
+
+JobHandler = Callable[[Job], Awaitable[None]]
+
+
+class UnknownJobKindError(Exception):
+    """Raised when no handler exists for a durable job kind."""
+
+
+@dataclass(frozen=True)
+class DaemonConfig:
+    """Runtime settings for the NewsRAG daemon loop."""
+
+    data_dir: Path
+    poll_interval: float = 0.5
+    max_loops: int | None = None
+
+
+class DaemonRunner:
+    """Async worker loop for durable NewsRAG jobs."""
+
+    def __init__(
+        self,
+        *,
+        database_path: Path,
+        handlers: Mapping[str, JobHandler] | None = None,
+        poll_interval: float = 0.5,
+    ) -> None:
+        self.database_path = database_path
+        self.handlers = dict(handlers or {})
+        self.poll_interval = poll_interval
+
+    async def run(self, *, max_loops: int | None = None) -> None:
+        loops = 0
+        while True:
+            await self.run_cycle()
+            loops += 1
+            if max_loops is not None and loops >= max_loops:
+                return
+            await asyncio.sleep(self.poll_interval)
+
+    async def run_cycle(self) -> bool:
+        job = await asyncio.to_thread(claim_next_job, self.database_path)
+        if job is None:
+            return False
+
+        try:
+            await self._handle_job(job)
+        except Exception as exc:
+            await asyncio.to_thread(mark_job_failed, self.database_path, job.id, error=str(exc))
+        else:
+            await asyncio.to_thread(mark_job_done, self.database_path, job.id)
+        return True
+
+    async def _handle_job(self, job: Job) -> None:
+        handler = self.handlers.get(job.kind)
+        if handler is None:
+            raise UnknownJobKindError(f"No handler registered for job kind '{job.kind}'")
+        await handler(job)
+
+
+async def run_daemon(
+    config: DaemonConfig,
+    *,
+    handlers: Mapping[str, JobHandler] | None = None,
+) -> None:
+    """Start the foreground daemon loop."""
+
+    storage_paths = initialize_storage(config.data_dir)
+    runner = DaemonRunner(
+        database_path=storage_paths.database,
+        handlers=handlers,
+        poll_interval=config.poll_interval,
+    )
+    await runner.run(max_loops=config.max_loops)

--- a/newsrag/jobs.py
+++ b/newsrag/jobs.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+JobStatus = str
+PENDING: JobStatus = "pending"
+RUNNING: JobStatus = "running"
+DONE: JobStatus = "done"
+FAILED: JobStatus = "failed"
+
+
+@dataclass(frozen=True)
+class Job:
+    """One durable NewsRAG job."""
+
+    id: str
+    kind: str
+    status: JobStatus
+    payload: dict[str, Any]
+    error: str | None
+    created_at: str
+    updated_at: str
+
+
+def create_job(
+    database_path: Path,
+    *,
+    kind: str,
+    payload: dict[str, Any] | None = None,
+    job_id: str | None = None,
+) -> Job:
+    """Insert a durable pending job into SQLite."""
+
+    resolved_job_id = job_id or f"job-{uuid.uuid4().hex[:8]}"
+    payload_json = json.dumps(payload or {}, sort_keys=True)
+
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO jobs(id, kind, status, payload_json, error)
+            VALUES(?, ?, ?, ?, NULL)
+            """,
+            (resolved_job_id, kind, PENDING, payload_json),
+        )
+        connection.commit()
+
+    return get_job(database_path, resolved_job_id)
+
+
+def get_job(database_path: Path, job_id: str) -> Job:
+    """Load one durable job by ID."""
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        row = connection.execute(
+            """
+            SELECT id, kind, status, payload_json, error, created_at, updated_at
+            FROM jobs
+            WHERE id = ?
+            """,
+            (job_id,),
+        ).fetchone()
+
+    if row is None:
+        raise KeyError(job_id)
+    return _row_to_job(row)
+
+
+def list_jobs(database_path: Path) -> list[Job]:
+    """Return all durable jobs ordered by creation time."""
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(
+            """
+            SELECT id, kind, status, payload_json, error, created_at, updated_at
+            FROM jobs
+            ORDER BY created_at ASC, id ASC
+            """
+        ).fetchall()
+
+    return [_row_to_job(row) for row in rows]
+
+
+def claim_next_job(database_path: Path) -> Job | None:
+    """Claim the next pending job and mark it running."""
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        connection.execute("BEGIN IMMEDIATE")
+        row = connection.execute(
+            """
+            SELECT id
+            FROM jobs
+            WHERE status = ?
+            ORDER BY created_at ASC, id ASC
+            LIMIT 1
+            """,
+            (PENDING,),
+        ).fetchone()
+
+        if row is None:
+            connection.commit()
+            return None
+
+        job_id = str(row["id"])
+        connection.execute(
+            """
+            UPDATE jobs
+            SET status = ?, error = NULL, updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (RUNNING, job_id),
+        )
+        connection.commit()
+
+    return get_job(database_path, job_id)
+
+
+def mark_job_done(database_path: Path, job_id: str) -> Job:
+    """Mark a running job done."""
+
+    return _set_job_status(database_path, job_id, status=DONE, error=None)
+
+
+def mark_job_failed(database_path: Path, job_id: str, *, error: str) -> Job:
+    """Mark a running job failed with context."""
+
+    return _set_job_status(database_path, job_id, status=FAILED, error=error)
+
+
+def set_job_status(
+    database_path: Path,
+    job_id: str,
+    *,
+    status: JobStatus,
+    error: str | None = None,
+) -> Job:
+    """Set one job status directly.
+
+    This is primarily useful for deterministic tests and status shaping.
+    """
+
+    return _set_job_status(database_path, job_id, status=status, error=error)
+
+
+def _set_job_status(
+    database_path: Path,
+    job_id: str,
+    *,
+    status: JobStatus,
+    error: str | None,
+) -> Job:
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            UPDATE jobs
+            SET status = ?, error = ?, updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (status, error, job_id),
+        )
+        connection.commit()
+
+    return get_job(database_path, job_id)
+
+
+def _row_to_job(row: sqlite3.Row) -> Job:
+    payload = json.loads(str(row["payload_json"]))
+    if not isinstance(payload, dict):
+        payload = {}
+    return Job(
+        id=str(row["id"]),
+        kind=str(row["kind"]),
+        status=str(row["status"]),
+        payload=payload,
+        error=str(row["error"]) if row["error"] is not None else None,
+        created_at=str(row["created_at"]),
+        updated_at=str(row["updated_at"]),
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,8 @@ def test_help_shows_cli_commands() -> None:
     assert result.exit_code == 0
     assert "doctor" in result.stdout
     assert "status" in result.stdout
+    assert "daemon" in result.stdout
+    assert "jobs" in result.stdout
 
 
 def test_doctor_runs_without_crashing(tmp_path: Path) -> None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from newsrag.cli import app
+from newsrag.daemon import DaemonRunner
+from newsrag.jobs import DONE, FAILED, RUNNING, Job, create_job, get_job, set_job_status
+from newsrag.storage import initialize_storage
+
+runner = CliRunner()
+
+
+def test_daemon_run_command_starts_against_initialized_storage(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    initialize_storage(data_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            "--data-dir",
+            str(data_dir),
+            "daemon",
+            "run",
+            "--poll-interval",
+            "0",
+            "--max-loops",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "NewsRAG daemon running" in result.stdout
+
+
+def test_mocked_job_moves_from_pending_to_running_to_done(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    paths = initialize_storage(data_dir)
+    seen_running_statuses: list[str] = []
+
+    job = create_job(paths.database, kind="mock")
+
+    async def handler(_: Job) -> None:
+        current = get_job(paths.database, job.id)
+        seen_running_statuses.append(current.status)
+
+    runner_instance = DaemonRunner(
+        database_path=paths.database,
+        handlers={"mock": handler},
+        poll_interval=0,
+    )
+
+    processed = asyncio.run(runner_instance.run_cycle())
+
+    assert processed is True
+    assert seen_running_statuses == [RUNNING]
+    assert get_job(paths.database, job.id).status == DONE
+
+
+def test_failing_mocked_job_records_failed_state_and_error(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    paths = initialize_storage(data_dir)
+    job = create_job(paths.database, kind="mock")
+
+    async def handler(_: Job) -> None:
+        raise RuntimeError("boom")
+
+    runner_instance = DaemonRunner(
+        database_path=paths.database,
+        handlers={"mock": handler},
+        poll_interval=0,
+    )
+
+    processed = asyncio.run(runner_instance.run_cycle())
+    updated_job = get_job(paths.database, job.id)
+
+    assert processed is True
+    assert updated_job.status == FAILED
+    assert updated_job.error == "boom"
+
+
+def test_jobs_list_shows_all_job_statuses(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    paths = initialize_storage(data_dir)
+
+    pending_job = create_job(paths.database, kind="pending-job", job_id="job-pending")
+    running_job = create_job(paths.database, kind="running-job", job_id="job-running")
+    done_job = create_job(paths.database, kind="done-job", job_id="job-done")
+    failed_job = create_job(paths.database, kind="failed-job", job_id="job-failed")
+
+    set_job_status(paths.database, running_job.id, status=RUNNING)
+    set_job_status(paths.database, done_job.id, status=DONE)
+    set_job_status(paths.database, failed_job.id, status=FAILED, error="boom")
+
+    result = runner.invoke(app, ["--data-dir", str(data_dir), "jobs", "list"])
+
+    assert result.exit_code == 0
+    assert "NewsRAG Jobs" in result.stdout
+    assert pending_job.id in result.stdout
+    assert "pending" in result.stdout
+    assert running_job.id in result.stdout
+    assert "running" in result.stdout
+    assert done_job.id in result.stdout
+    assert "done" in result.stdout
+    assert failed_job.id in result.stdout
+    assert "failed" in result.stdout
+    assert "boom" in result.stdout


### PR DESCRIPTION
## Summary

Add the first daemon and durable job queue slice for NewsRAG with a foreground `newsrag daemon run` command, SQLite-backed job state transitions, and a `newsrag jobs list` view.

## Task

- #task-6142564f

## Changes

- add a durable jobs module for creating, claiming, updating, and listing SQLite-backed jobs
- add an async daemon runner with handler registration, pending→running→done transitions, and failure recording
- add `newsrag daemon run` and `newsrag jobs list` CLI commands
- update `Procfile.dev` and docs to run the real daemon instead of the placeholder script
- include the previously requested `make dev-connect` workflow helper in the same branch
- add direct tests for daemon startup, successful job processing, failed job recording, and jobs list output shaping

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
