### PR TITLE
feat: add watched folder ingestion

### DIFF
--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -23,6 +23,7 @@ from newsrag.storage import (
     get_storage_status,
     initialize_storage,
 )
+from newsrag.watches import add_watch, list_watches
 
 CONFIG_PATH_OPTION = typer.Option(
     None,
@@ -42,8 +43,10 @@ DATA_DIR_OPTION = typer.Option(
 app = typer.Typer(help="Local-first evidence retrieval for city hall PDFs.")
 daemon_app = typer.Typer(help="Run the NewsRAG background daemon.")
 jobs_app = typer.Typer(help="Inspect durable NewsRAG jobs.")
+watch_app = typer.Typer(help="Manage watched folders for automatic ingestion.")
 app.add_typer(daemon_app, name="daemon")
 app.add_typer(jobs_app, name="jobs")
+app.add_typer(watch_app, name="watch")
 
 
 @dataclass(frozen=True)
@@ -151,6 +154,65 @@ def jobs_list_command(ctx: typer.Context) -> None:
         if job.error is not None:
             line = f"{line} error={job.error}"
         typer.echo(line)
+
+
+@watch_app.command("add")
+def watch_add_command(
+    ctx: typer.Context,
+    path: Path,
+    body: str | None = typer.Option(None, help="Default civic body for files in this watch."),
+    document_type: str | None = typer.Option(
+        None,
+        "--document-type",
+        help="Default document type for files in this watch.",
+    ),
+    meeting_date_default: str | None = typer.Option(
+        None,
+        "--meeting-date-default",
+        help="Default meeting date metadata for files in this watch.",
+    ),
+    jurisdiction: str | None = typer.Option(
+        None,
+        help="Default jurisdiction metadata for files in this watch.",
+    ),
+) -> None:
+    """Register one watched folder."""
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    database_path = initialize_storage(settings.data_dir).database
+    watch = add_watch(
+        database_path,
+        path=path,
+        metadata={
+            key: value
+            for key, value in {
+                "body": body,
+                "document_type": document_type,
+                "meeting_date_default": meeting_date_default,
+                "jurisdiction": jurisdiction,
+            }.items()
+            if value is not None
+        },
+    )
+    typer.echo(f"Added watch {watch.id} {watch.path}")
+
+
+@watch_app.command("list")
+def watch_list_command(ctx: typer.Context) -> None:
+    """List watched folders."""
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    database_path = initialize_storage(settings.data_dir).database
+    watches = list_watches(database_path)
+
+    typer.echo("NewsRAG Watches")
+    typer.echo(f"data_dir: {settings.data_dir}")
+    if not watches:
+        typer.echo("watches: none")
+        return
+
+    for watch in watches:
+        typer.echo(f"{watch.id} {watch.path} metadata={watch.metadata}")
 
 
 def run() -> None:

--- a/newsrag/daemon.py
+++ b/newsrag/daemon.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
+from watchfiles import awatch
+
 from newsrag.jobs import Job, claim_next_job, mark_job_done, mark_job_failed
 from newsrag.storage import initialize_storage
+from newsrag.watches import enqueue_watch_changes, list_watches
 
 JobHandler = Callable[[Job], Awaitable[None]]
 
@@ -67,10 +70,14 @@ class DaemonRunner:
         await handler(job)
 
 
+WatchStreamFactory = Callable[[tuple[str, ...]], AsyncIterator[set[tuple[object, str]]]]
+
+
 async def run_daemon(
     config: DaemonConfig,
     *,
     handlers: Mapping[str, JobHandler] | None = None,
+    watch_stream_factory: WatchStreamFactory | None = None,
 ) -> None:
     """Start the foreground daemon loop."""
 
@@ -80,4 +87,36 @@ async def run_daemon(
         handlers=handlers,
         poll_interval=config.poll_interval,
     )
-    await runner.run(max_loops=config.max_loops)
+    watches = list_watches(storage_paths.database)
+    if not watches:
+        await runner.run(max_loops=config.max_loops)
+        return
+
+    watch_paths = tuple(str(watch.path) for watch in watches)
+    watch_task = _run_watch_loop(
+        storage_paths.database,
+        watch_paths,
+        watch_stream_factory=watch_stream_factory or _default_watch_stream,
+        max_batches=config.max_loops,
+    )
+    await asyncio.gather(runner.run(max_loops=config.max_loops), watch_task)
+
+
+async def _run_watch_loop(
+    database_path: Path,
+    watch_paths: tuple[str, ...],
+    *,
+    watch_stream_factory: WatchStreamFactory,
+    max_batches: int | None,
+) -> None:
+    batches = 0
+    async for changes in watch_stream_factory(watch_paths):
+        await asyncio.to_thread(enqueue_watch_changes, database_path, changes)
+        batches += 1
+        if max_batches is not None and batches >= max_batches:
+            return
+
+
+async def _default_watch_stream(paths: tuple[str, ...]) -> AsyncIterator[set[tuple[object, str]]]:
+    async for changes in awatch(*paths):
+        yield {(change, str(path)) for change, path in changes}

--- a/newsrag/storage.py
+++ b/newsrag/storage.py
@@ -72,6 +72,7 @@ REQUIRED_TABLES = {
     "chunks",
     "jobs",
     "watches",
+    "watch_files",
     "metadata",
 }
 SCHEMA_STATEMENTS = (
@@ -128,6 +129,15 @@ SCHEMA_STATEMENTS = (
         path TEXT NOT NULL UNIQUE,
         metadata_json TEXT NOT NULL DEFAULT '{}',
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS watch_files (
+        path TEXT PRIMARY KEY,
+        watch_id TEXT NOT NULL,
+        content_signature TEXT NOT NULL,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(watch_id) REFERENCES watches(id)
     )
     """,
 )

--- a/newsrag/watches.py
+++ b/newsrag/watches.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from newsrag.jobs import Job, create_job
+
+WATCH_JOB_KIND = "ingest-file"
+
+
+@dataclass(frozen=True)
+class Watch:
+    """One durable watch registration."""
+
+    id: str
+    path: Path
+    metadata: dict[str, Any]
+    created_at: str
+
+
+def add_watch(
+    database_path: Path,
+    *,
+    path: Path,
+    metadata: dict[str, Any] | None = None,
+    watch_id: str | None = None,
+) -> Watch:
+    """Register one watched folder in durable storage."""
+
+    resolved_path = path.expanduser().resolve()
+    payload = json.dumps(metadata or {}, sort_keys=True)
+    resolved_watch_id = watch_id or f"watch-{uuid.uuid4().hex[:8]}"
+
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO watches(id, path, metadata_json)
+            VALUES(?, ?, ?)
+            """,
+            (resolved_watch_id, str(resolved_path), payload),
+        )
+        connection.commit()
+
+    return get_watch_by_path(database_path, resolved_path)
+
+
+def list_watches(database_path: Path) -> list[Watch]:
+    """List durable watch registrations."""
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(
+            """
+            SELECT id, path, metadata_json, created_at
+            FROM watches
+            ORDER BY created_at ASC, id ASC
+            """
+        ).fetchall()
+
+    return [_row_to_watch(row) for row in rows]
+
+
+def get_watch_by_path(database_path: Path, path: Path) -> Watch:
+    """Load one durable watch by its path."""
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        row = connection.execute(
+            """
+            SELECT id, path, metadata_json, created_at
+            FROM watches
+            WHERE path = ?
+            """,
+            (str(path),),
+        ).fetchone()
+
+    if row is None:
+        raise KeyError(str(path))
+    return _row_to_watch(row)
+
+
+def enqueue_watch_changes(
+    database_path: Path,
+    changes: set[tuple[object, str]],
+) -> list[Job]:
+    """Turn relevant watch-file changes into durable ingestion jobs."""
+
+    watches = list_watches(database_path)
+    enqueued: list[Job] = []
+
+    for _, changed_path_text in sorted(changes, key=lambda item: item[1]):
+        changed_path = Path(changed_path_text).expanduser().resolve()
+        watch = _matching_watch(changed_path, watches)
+        if watch is None:
+            continue
+        if changed_path.suffix.lower() != ".pdf":
+            continue
+        if not changed_path.exists() or not changed_path.is_file():
+            continue
+
+        signature = _file_signature(changed_path)
+        if _seen_signature(database_path, changed_path, signature):
+            continue
+
+        job = create_job(
+            database_path,
+            kind=WATCH_JOB_KIND,
+            payload={
+                "path": str(changed_path),
+                "watch_id": watch.id,
+                "metadata": watch.metadata,
+                "signature": signature,
+                "source": "watch",
+            },
+        )
+        _remember_signature(database_path, changed_path, watch.id, signature)
+        enqueued.append(job)
+
+    return enqueued
+
+
+def _matching_watch(changed_path: Path, watches: list[Watch]) -> Watch | None:
+    for watch in watches:
+        if changed_path.is_relative_to(watch.path):
+            return watch
+    return None
+
+
+def _file_signature(path: Path) -> str:
+    stat_result = path.stat()
+    return f"{stat_result.st_size}:{stat_result.st_mtime_ns}"
+
+
+def _seen_signature(database_path: Path, path: Path, signature: str) -> bool:
+    with sqlite3.connect(database_path) as connection:
+        row = connection.execute(
+            "SELECT content_signature FROM watch_files WHERE path = ?",
+            (str(path),),
+        ).fetchone()
+
+    if row is None:
+        return False
+    return str(row[0]) == signature
+
+
+def _remember_signature(database_path: Path, path: Path, watch_id: str, signature: str) -> None:
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO watch_files(path, watch_id, content_signature)
+            VALUES(?, ?, ?)
+            ON CONFLICT(path) DO UPDATE SET
+                watch_id = excluded.watch_id,
+                content_signature = excluded.content_signature,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (str(path), watch_id, signature),
+        )
+        connection.commit()
+
+
+def _row_to_watch(row: sqlite3.Row) -> Watch:
+    metadata = json.loads(str(row["metadata_json"]))
+    if not isinstance(metadata, dict):
+        metadata = {}
+    return Watch(
+        id=str(row["id"]),
+        path=Path(str(row["path"])),
+        metadata=metadata,
+        created_at=str(row["created_at"]),
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,7 @@ def test_help_shows_cli_commands() -> None:
     assert "status" in result.stdout
     assert "daemon" in result.stdout
     assert "jobs" in result.stdout
+    assert "watch" in result.stdout
 
 
 def test_doctor_runs_without_crashing(tmp_path: Path) -> None:

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from newsrag.cli import app
+from newsrag.daemon import DaemonConfig, run_daemon
+from newsrag.jobs import Job, list_jobs
+from newsrag.storage import initialize_storage
+from newsrag.watches import WATCH_JOB_KIND, add_watch
+
+runner = CliRunner()
+
+
+def test_watch_add_and_list(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    watch_dir = tmp_path / "incoming"
+    watch_dir.mkdir()
+
+    add_result = runner.invoke(
+        app,
+        [
+            "--data-dir",
+            str(data_dir),
+            "watch",
+            "add",
+            str(watch_dir),
+            "--body",
+            "City Council",
+            "--document-type",
+            "agenda_packet",
+        ],
+    )
+    list_result = runner.invoke(app, ["--data-dir", str(data_dir), "watch", "list"])
+
+    assert add_result.exit_code == 0
+    assert "Added watch" in add_result.stdout
+    assert list_result.exit_code == 0
+    assert "NewsRAG Watches" in list_result.stdout
+    assert str(watch_dir.resolve()) in list_result.stdout
+    assert "City Council" in list_result.stdout
+    assert "agenda_packet" in list_result.stdout
+
+
+def test_daemon_enqueues_job_for_pdf_watch_event(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    watch_dir = tmp_path / "incoming"
+    watch_dir.mkdir()
+    pdf_path = watch_dir / "packet.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+
+    paths = initialize_storage(data_dir)
+    add_watch(paths.database, path=watch_dir, metadata={"body": "City Council"})
+
+    async def fake_watch_stream(
+        paths_to_watch: tuple[str, ...],
+    ) -> AsyncIterator[set[tuple[object, str]]]:
+        assert paths_to_watch == (str(watch_dir.resolve()),)
+        yield {("added", str(pdf_path.resolve()))}
+
+    asyncio.run(
+        run_daemon(
+            DaemonConfig(data_dir=data_dir, poll_interval=0, max_loops=1),
+            handlers={WATCH_JOB_KIND: _noop_handler},
+            watch_stream_factory=fake_watch_stream,
+        )
+    )
+
+    jobs = list_jobs(paths.database)
+    assert len(jobs) == 1
+    assert jobs[0].kind == WATCH_JOB_KIND
+    assert jobs[0].payload["path"] == str(pdf_path.resolve())
+    assert jobs[0].payload["metadata"]["body"] == "City Council"
+
+
+def test_non_pdf_files_are_ignored(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    watch_dir = tmp_path / "incoming"
+    watch_dir.mkdir()
+    text_path = watch_dir / "notes.txt"
+    text_path.write_text("ignore me", encoding="utf-8")
+
+    paths = initialize_storage(data_dir)
+    add_watch(paths.database, path=watch_dir)
+
+    async def fake_watch_stream(_: tuple[str, ...]) -> AsyncIterator[set[tuple[object, str]]]:
+        yield {("added", str(text_path.resolve()))}
+
+    asyncio.run(
+        run_daemon(
+            DaemonConfig(data_dir=data_dir, poll_interval=0, max_loops=1),
+            handlers={WATCH_JOB_KIND: _noop_handler},
+            watch_stream_factory=fake_watch_stream,
+        )
+    )
+
+    assert list_jobs(paths.database) == []
+
+
+def test_duplicate_unchanged_pdf_events_do_not_create_duplicate_jobs(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    watch_dir = tmp_path / "incoming"
+    watch_dir.mkdir()
+    pdf_path = watch_dir / "packet.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+
+    paths = initialize_storage(data_dir)
+    add_watch(paths.database, path=watch_dir)
+
+    async def fake_watch_stream(_: tuple[str, ...]) -> AsyncIterator[set[tuple[object, str]]]:
+        change = ("added", str(pdf_path.resolve()))
+        yield {change}
+        yield {change}
+
+    asyncio.run(
+        run_daemon(
+            DaemonConfig(data_dir=data_dir, poll_interval=0, max_loops=2),
+            handlers={WATCH_JOB_KIND: _noop_handler},
+            watch_stream_factory=fake_watch_stream,
+        )
+    )
+
+    jobs = list_jobs(paths.database)
+    assert len(jobs) == 1
+    assert jobs[0].payload["path"] == str(pdf_path.resolve())
+
+
+async def _noop_handler(_: Job) -> None:
+    return None


### PR DESCRIPTION
## Summary

Add watched-folder registration and daemon-side PDF event enqueueing so NewsRAG can register folders, observe them through `watchfiles`, and create durable ingestion jobs for new PDFs.

## Task

- #task-40c08a4f

## Changes

- add durable watch registration storage and change-to-job enqueue logic
- add `newsrag watch add` and `newsrag watch list` CLI commands
- extend the daemon to observe registered folders through `watchfiles` when watches exist
- enqueue `ingest-file` jobs for PDF events with watch metadata attached
- ignore non-PDF file events and dedupe unchanged repeated PDF events
- add direct tests for add/list, mocked filesystem event enqueueing, non-PDF ignore behavior, and duplicate-event dedupe

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [ ] Documentation updated (if needed)
- [x] No unrelated changes included
