### PR TITLE
chore: add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  check:
+    name: check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Sync dependencies
+        run: uv sync --dev
+
+      - name: Run checks
+        run: make check


### PR DESCRIPTION
## Summary

Add a minimal GitHub Actions CI workflow so pull requests and main-branch pushes get an automated `make check` signal.

## Changes

- add `.github/workflows/ci.yml`
- run on pull requests and pushes to `main`
- set up Python 3.11 and `uv`
- run `uv sync --dev`
- run `make check`

## Testing

- [x] Manual testing performed

## Checklist

- [x] `make check` passes locally
- [x] No unrelated changes included
