### PR TITLE
feat: add embedding provider integration

### DIFF
--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -11,6 +11,7 @@ from newsrag.config import (
     AppConfig,
     ConfigError,
     RuntimeSettings,
+    apply_embedding_overrides,
     load_config,
     resolve_data_dir,
 )
@@ -72,10 +73,38 @@ def main(
 
 
 @app.command()
-def doctor(ctx: typer.Context) -> None:
+def doctor(
+    ctx: typer.Context,
+    embedding_provider: str | None = typer.Option(
+        None,
+        "--embedding-provider",
+        help="Override the embedding provider for this doctor run.",
+    ),
+    embedding_base_url: str | None = typer.Option(
+        None,
+        "--embedding-base-url",
+        help="Override the embedding provider base URL for this doctor run.",
+    ),
+    embedding_model: str | None = typer.Option(
+        None,
+        "--embedding-model",
+        help="Override the embedding model for this doctor run.",
+    ),
+    embedding_api_key_env: str | None = typer.Option(
+        None,
+        "--embedding-api-key-env",
+        help="Override the embedding API key environment variable for this doctor run.",
+    ),
+) -> None:
     """Validate the local NewsRAG environment and configuration."""
 
-    settings, config_error = _resolve_runtime_settings(ctx)
+    settings, config_error = _resolve_runtime_settings(
+        ctx,
+        embedding_provider=embedding_provider,
+        embedding_base_url=embedding_base_url,
+        embedding_model=embedding_model,
+        embedding_api_key_env=embedding_api_key_env,
+    )
     report = run_doctor(settings, config_error=config_error)
     typer.echo(format_report(report, settings=settings))
 
@@ -221,7 +250,14 @@ def run() -> None:
     app()
 
 
-def _resolve_runtime_settings(ctx: typer.Context) -> tuple[RuntimeSettings, str | None]:
+def _resolve_runtime_settings(
+    ctx: typer.Context,
+    *,
+    embedding_provider: str | None = None,
+    embedding_base_url: str | None = None,
+    embedding_model: str | None = None,
+    embedding_api_key_env: str | None = None,
+) -> tuple[RuntimeSettings, str | None]:
     state = _get_state(ctx)
     config_error: str | None = None
 
@@ -230,6 +266,28 @@ def _resolve_runtime_settings(ctx: typer.Context) -> tuple[RuntimeSettings, str 
     except ConfigError as exc:
         config = AppConfig(source_path=state.config_path)
         config_error = str(exc)
+
+    if any(
+        override is not None
+        for override in (
+            embedding_provider,
+            embedding_base_url,
+            embedding_model,
+            embedding_api_key_env,
+        )
+    ):
+        config = AppConfig(
+            source_path=config.source_path,
+            data_dir=config.data_dir,
+            embedding=apply_embedding_overrides(
+                config.embedding,
+                provider=embedding_provider,
+                base_url=embedding_base_url,
+                model=embedding_model,
+                api_key_env=embedding_api_key_env,
+            ),
+            daemon=config.daemon,
+        )
 
     settings = RuntimeSettings(
         config_path=state.config_path,

--- a/newsrag/config.py
+++ b/newsrag/config.py
@@ -132,6 +132,24 @@ def resolve_runtime_settings(
     )
 
 
+def apply_embedding_overrides(
+    embedding: EmbeddingConfig,
+    *,
+    provider: str | None = None,
+    base_url: str | None = None,
+    model: str | None = None,
+    api_key_env: str | None = None,
+) -> EmbeddingConfig:
+    """Apply optional CLI-style overrides to embedding configuration."""
+
+    return EmbeddingConfig(
+        provider=provider if provider is not None else embedding.provider,
+        base_url=base_url if base_url is not None else embedding.base_url,
+        model=model if model is not None else embedding.model,
+        api_key_env=api_key_env if api_key_env is not None else embedding.api_key_env,
+    )
+
+
 def _load_embedding_config(embedding_data: Mapping[str, object]) -> EmbeddingConfig:
     return EmbeddingConfig(
         provider=_optional_string(embedding_data.get("provider"), field_name="embedding.provider"),

--- a/newsrag/embeddings.py
+++ b/newsrag/embeddings.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+import httpx
+
+from newsrag.config import EmbeddingConfig
+
+DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434"
+DEFAULT_OLLAMA_MODEL = "nomic-embed-text"
+EMBEDDING_PROVIDER_OLLAMA = "ollama"
+
+
+class EmbeddingError(Exception):
+    """Raised when embedding provider setup or execution fails."""
+
+
+@dataclass(frozen=True)
+class EmbeddingMetadata:
+    """Identity metadata for one embedding provider/model pair."""
+
+    provider: str
+    model: str
+    version: str
+
+
+@dataclass(frozen=True)
+class QueryEmbedding:
+    """One embedded query vector."""
+
+    text: str
+    vector: tuple[float, ...]
+    metadata: EmbeddingMetadata
+
+
+@dataclass(frozen=True)
+class ChunkEmbedding:
+    """One embedded chunk vector."""
+
+    text: str
+    vector: tuple[float, ...]
+    metadata: EmbeddingMetadata
+
+
+class EmbeddingProvider(Protocol):
+    """Provider interface for query and chunk embeddings."""
+
+    def embed_query(self, text: str) -> QueryEmbedding:
+        """Embed one search query string."""
+
+    def embed_chunks(self, texts: Sequence[str]) -> list[ChunkEmbedding]:
+        """Embed one or more chunk strings."""
+
+
+@dataclass(frozen=True)
+class OllamaEmbeddingProvider:
+    """Embedding provider backed by the Ollama HTTP API."""
+
+    model: str = DEFAULT_OLLAMA_MODEL
+    base_url: str = DEFAULT_OLLAMA_BASE_URL
+
+    @property
+    def metadata(self) -> EmbeddingMetadata:
+        model_name, version = _split_model_identity(self.model)
+        return EmbeddingMetadata(
+            provider=EMBEDDING_PROVIDER_OLLAMA,
+            model=model_name,
+            version=version,
+        )
+
+    def embed_query(self, text: str) -> QueryEmbedding:
+        vectors = self._embed_inputs([text])
+        if len(vectors) != 1:
+            raise EmbeddingError(f"Ollama returned {len(vectors)} vectors for 1 query")
+        return QueryEmbedding(text=text, vector=vectors[0], metadata=self.metadata)
+
+    def embed_chunks(self, texts: Sequence[str]) -> list[ChunkEmbedding]:
+        resolved_texts = list(texts)
+        if not resolved_texts:
+            return []
+
+        vectors = self._embed_inputs(resolved_texts)
+        if len(vectors) != len(resolved_texts):
+            raise EmbeddingError(
+                f"Ollama returned {len(vectors)} vectors for {len(resolved_texts)} inputs"
+            )
+
+        metadata = self.metadata
+        return [
+            ChunkEmbedding(text=text, vector=vector, metadata=metadata)
+            for text, vector in zip(resolved_texts, vectors, strict=True)
+        ]
+
+    def _embed_inputs(self, texts: list[str]) -> list[tuple[float, ...]]:
+        endpoint = f"{self.base_url.rstrip('/')}/api/embed"
+        try:
+            response = httpx.post(
+                endpoint, json={"model": self.model, "input": texts}, timeout=30.0
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except httpx.HTTPError as exc:
+            raise EmbeddingError(f"Ollama embedding request failed: {exc}") from exc
+        except ValueError as exc:
+            raise EmbeddingError("Ollama embedding response was not valid JSON") from exc
+
+        return _extract_embedding_vectors(payload)
+
+
+@dataclass(frozen=True)
+class EmbeddingRecord:
+    """One durable embedding provenance record."""
+
+    id: str
+    source_kind: str
+    source_key: str
+    provider: str
+    model: str
+    version: str
+    dimensions: int
+    created_at: str
+
+
+def build_embedding_provider(config: EmbeddingConfig) -> EmbeddingProvider:
+    """Build an embedding provider from resolved config."""
+
+    provider = config.provider
+    if provider is None:
+        raise EmbeddingError("No embedding provider configured")
+
+    normalized_provider = provider.lower()
+    if normalized_provider == EMBEDDING_PROVIDER_OLLAMA:
+        return OllamaEmbeddingProvider(
+            model=config.model or DEFAULT_OLLAMA_MODEL,
+            base_url=config.base_url or DEFAULT_OLLAMA_BASE_URL,
+        )
+
+    raise EmbeddingError(f"Embedding provider '{provider}' is not implemented")
+
+
+def create_embedding_record(
+    database_path: Path,
+    *,
+    source_kind: str,
+    source_key: str,
+    embedding: QueryEmbedding | ChunkEmbedding,
+    record_id: str | None = None,
+) -> EmbeddingRecord:
+    """Persist provider/model/version provenance for one embedding result."""
+
+    resolved_record_id = record_id or f"embedding-{uuid.uuid4().hex[:8]}"
+    metadata = embedding.metadata
+
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO embedding_records(
+                id,
+                source_kind,
+                source_key,
+                provider,
+                model,
+                version,
+                dimensions
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                resolved_record_id,
+                source_kind,
+                source_key,
+                metadata.provider,
+                metadata.model,
+                metadata.version,
+                len(embedding.vector),
+            ),
+        )
+        connection.commit()
+
+    return get_embedding_record(database_path, resolved_record_id)
+
+
+def get_embedding_record(database_path: Path, record_id: str) -> EmbeddingRecord:
+    """Load one embedding provenance record by ID."""
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        row = connection.execute(
+            """
+            SELECT id, source_kind, source_key, provider, model, version, dimensions, created_at
+            FROM embedding_records
+            WHERE id = ?
+            """,
+            (record_id,),
+        ).fetchone()
+
+    if row is None:
+        raise KeyError(record_id)
+    return _row_to_embedding_record(row)
+
+
+def list_embedding_records(database_path: Path) -> list[EmbeddingRecord]:
+    """List durable embedding provenance records."""
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(
+            """
+            SELECT id, source_kind, source_key, provider, model, version, dimensions, created_at
+            FROM embedding_records
+            ORDER BY created_at ASC, id ASC
+            """
+        ).fetchall()
+
+    return [_row_to_embedding_record(row) for row in rows]
+
+
+def _extract_embedding_vectors(payload: Any) -> list[tuple[float, ...]]:
+    if not isinstance(payload, dict):
+        raise EmbeddingError("Ollama embedding response had an unexpected payload shape")
+
+    embeddings = payload.get("embeddings")
+    if not isinstance(embeddings, list):
+        raise EmbeddingError("Ollama embedding response is missing an embeddings list")
+
+    vectors: list[tuple[float, ...]] = []
+    for embedding in embeddings:
+        if not isinstance(embedding, list):
+            raise EmbeddingError("Ollama embedding response contained a non-list embedding")
+
+        vector = tuple(_coerce_vector_value(value) for value in embedding)
+        if not vector:
+            raise EmbeddingError("Ollama embedding response contained an empty embedding vector")
+        vectors.append(vector)
+
+    if not vectors:
+        raise EmbeddingError("Ollama embedding response did not return any vectors")
+    return vectors
+
+
+def _coerce_vector_value(value: object) -> float:
+    if isinstance(value, int | float):
+        return float(value)
+    raise EmbeddingError("Ollama embedding response contained a non-numeric value")
+
+
+def _split_model_identity(model: str) -> tuple[str, str]:
+    if ":" not in model:
+        return model, "latest"
+
+    base_model, _, version = model.partition(":")
+    if not version:
+        return base_model, "latest"
+    return base_model, version
+
+
+def _row_to_embedding_record(row: sqlite3.Row) -> EmbeddingRecord:
+    return EmbeddingRecord(
+        id=str(row["id"]),
+        source_kind=str(row["source_kind"]),
+        source_key=str(row["source_key"]),
+        provider=str(row["provider"]),
+        model=str(row["model"]),
+        version=str(row["version"]),
+        dimensions=int(row["dimensions"]),
+        created_at=str(row["created_at"]),
+    )

--- a/newsrag/storage.py
+++ b/newsrag/storage.py
@@ -73,6 +73,7 @@ REQUIRED_TABLES = {
     "jobs",
     "watches",
     "watch_files",
+    "embedding_records",
     "metadata",
 }
 SCHEMA_STATEMENTS = (
@@ -138,6 +139,18 @@ SCHEMA_STATEMENTS = (
         content_signature TEXT NOT NULL,
         updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY(watch_id) REFERENCES watches(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS embedding_records (
+        id TEXT PRIMARY KEY,
+        source_kind TEXT NOT NULL,
+        source_key TEXT NOT NULL,
+        provider TEXT NOT NULL,
+        model TEXT NOT NULL,
+        version TEXT NOT NULL,
+        dimensions INTEGER NOT NULL,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
     )
     """,
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
+import pytest
 from typer.testing import CliRunner
 
 from newsrag.cli import app
+from newsrag.config import EmbeddingConfig
+from newsrag.doctor import DoctorCheck, DoctorReport
 
 runner = CliRunner()
 
@@ -29,3 +33,50 @@ def test_doctor_runs_without_crashing(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert "NewsRAG Doctor" in result.stdout
     assert "summary:" in result.stdout
+
+
+def test_doctor_command_applies_embedding_overrides(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen_embedding: list[EmbeddingConfig] = []
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("", encoding="utf-8")
+
+    def fake_run_doctor(
+        settings: Any,
+        *,
+        config_error: str | None = None,
+        timeout_seconds: float = 2.0,
+    ) -> DoctorReport:
+        del config_error, timeout_seconds
+        embedding = settings.config.embedding
+        seen_embedding.append(embedding)
+        return DoctorReport(checks=(DoctorCheck("embedding", "ok", "mock"),))
+
+    monkeypatch.setattr("newsrag.cli.run_doctor", fake_run_doctor)
+
+    result = runner.invoke(
+        app,
+        [
+            "--config-path",
+            str(config_path),
+            "doctor",
+            "--embedding-provider",
+            "ollama",
+            "--embedding-base-url",
+            "http://localhost:11434",
+            "--embedding-model",
+            "nomic-embed-text",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert seen_embedding == [
+        EmbeddingConfig(
+            provider="ollama",
+            base_url="http://localhost:11434",
+            model="nomic-embed-text",
+            api_key_env=None,
+        )
+    ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from newsrag.config import (
     AppConfig,
     ConfigError,
     EmbeddingConfig,
+    apply_embedding_overrides,
     load_config,
     resolve_data_dir,
     resolve_runtime_settings,
@@ -93,3 +94,25 @@ def test_resolve_data_dir_defaults_to_local_newsrag(tmp_path: Path) -> None:
     data_dir = resolve_data_dir(None, config, cwd=tmp_path)
 
     assert data_dir == (tmp_path / ".newsrag").resolve()
+
+
+def test_apply_embedding_overrides_replaces_selected_fields() -> None:
+    embedding = EmbeddingConfig(
+        provider="openai_compatible",
+        base_url="http://localhost:1234/v1",
+        model="text-embedding-3-small",
+        api_key_env="OPENAI_API_KEY",
+    )
+
+    updated = apply_embedding_overrides(
+        embedding,
+        provider="ollama",
+        model="nomic-embed-text",
+    )
+
+    assert updated == EmbeddingConfig(
+        provider="ollama",
+        base_url="http://localhost:1234/v1",
+        model="nomic-embed-text",
+        api_key_env="OPENAI_API_KEY",
+    )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -110,6 +110,53 @@ def test_run_doctor_checks_generic_openai_compatible_provider(
     assert "provider=openai_compatible" in embedding_check.detail
 
 
+def test_run_doctor_warns_when_ollama_model_is_missing(tmp_path: Path) -> None:
+    settings = RuntimeSettings(
+        config_path=tmp_path / "config.yaml",
+        data_dir=tmp_path / ".newsrag",
+        config=AppConfig(
+            source_path=tmp_path / "config.yaml",
+            embedding=EmbeddingConfig(provider="ollama"),
+        ),
+    )
+
+    report = run_doctor(settings)
+
+    embedding_check = next(check for check in report.checks if check.name == "embedding")
+    assert embedding_check.status == "warn"
+    assert "embedding.model is missing" in embedding_check.detail
+
+
+def test_run_doctor_warns_when_ollama_is_unreachable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = RuntimeSettings(
+        config_path=tmp_path / "config.yaml",
+        data_dir=tmp_path / ".newsrag",
+        config=AppConfig(
+            source_path=tmp_path / "config.yaml",
+            embedding=EmbeddingConfig(
+                provider="ollama",
+                base_url="http://127.0.0.1:11434",
+                model="nomic-embed-text",
+            ),
+        ),
+    )
+
+    def fake_get(url: str, timeout: float, headers: dict[str, str] | None = None) -> httpx.Response:
+        request = httpx.Request("GET", url, headers=headers)
+        raise httpx.ConnectError("boom", request=request)
+
+    monkeypatch.setattr("newsrag.doctor.httpx.get", fake_get)
+
+    report = run_doctor(settings)
+
+    embedding_check = next(check for check in report.checks if check.name == "embedding")
+    assert embedding_check.status == "warn"
+    assert "is unreachable" in embedding_check.detail
+
+
 def test_run_doctor_checks_ollama_provider_when_selected(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from newsrag.config import EmbeddingConfig
+from newsrag.embeddings import (
+    ChunkEmbedding,
+    EmbeddingError,
+    EmbeddingMetadata,
+    EmbeddingProvider,
+    QueryEmbedding,
+    build_embedding_provider,
+    create_embedding_record,
+    list_embedding_records,
+)
+from newsrag.storage import initialize_storage
+
+
+def test_ollama_provider_supports_query_and_chunk_embeddings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = build_embedding_provider(EmbeddingConfig(provider="ollama"))
+
+    def fake_post(url: str, *, json: dict[str, object], timeout: float) -> httpx.Response:
+        del timeout
+        assert url == "http://127.0.0.1:11434/api/embed"
+        assert json["model"] == "nomic-embed-text"
+        inputs = json["input"]
+        assert isinstance(inputs, list)
+
+        request = httpx.Request("POST", url)
+        if len(inputs) == 1:
+            return httpx.Response(200, request=request, json={"embeddings": [[0.1, 0.2]]})
+        return httpx.Response(
+            200,
+            request=request,
+            json={"embeddings": [[0.3, 0.4], [0.5, 0.6]]},
+        )
+
+    monkeypatch.setattr("newsrag.embeddings.httpx.post", fake_post)
+
+    query_embedding, chunk_embeddings = _exercise_provider(provider)
+
+    assert query_embedding.vector == (0.1, 0.2)
+    assert query_embedding.metadata.provider == "ollama"
+    assert query_embedding.metadata.model == "nomic-embed-text"
+    assert query_embedding.metadata.version == "latest"
+    assert [chunk.text for chunk in chunk_embeddings] == ["chunk one", "chunk two"]
+    assert [chunk.vector for chunk in chunk_embeddings] == [(0.3, 0.4), (0.5, 0.6)]
+
+
+def test_ollama_provider_raises_for_malformed_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = build_embedding_provider(
+        EmbeddingConfig(provider="ollama", model="nomic-embed-text")
+    )
+
+    def fake_post(url: str, *, json: dict[str, object], timeout: float) -> httpx.Response:
+        del json, timeout
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, request=request, json={"embeddings": ["bad"]})
+
+    monkeypatch.setattr("newsrag.embeddings.httpx.post", fake_post)
+
+    with pytest.raises(EmbeddingError, match="non-list embedding"):
+        provider.embed_query("agenda")
+
+
+def test_create_embedding_record_stores_provider_model_and_version(tmp_path: Path) -> None:
+    paths = initialize_storage(tmp_path / ".newsrag")
+    embedding = ChunkEmbedding(
+        text="chunk one",
+        vector=(0.1, 0.2, 0.3),
+        metadata=EmbeddingMetadata(
+            provider="ollama",
+            model="nomic-embed-text",
+            version="latest",
+        ),
+    )
+
+    record = create_embedding_record(
+        paths.database,
+        source_kind="chunk",
+        source_key="chunk-1",
+        embedding=embedding,
+        record_id="embedding-1",
+    )
+
+    assert record.id == "embedding-1"
+    assert record.source_kind == "chunk"
+    assert record.source_key == "chunk-1"
+    assert record.provider == "ollama"
+    assert record.model == "nomic-embed-text"
+    assert record.version == "latest"
+    assert record.dimensions == 3
+    assert list_embedding_records(paths.database) == [record]
+
+
+def _exercise_provider(
+    provider: EmbeddingProvider,
+) -> tuple[QueryEmbedding, list[ChunkEmbedding]]:
+    query_embedding = provider.embed_query("city council agenda")
+    chunk_embeddings = provider.embed_chunks(["chunk one", "chunk two"])
+    return query_embedding, chunk_embeddings


### PR DESCRIPTION
## Summary

Add the first pluggable embedding runtime so NewsRAG can build Ollama-backed query/chunk embeddings, persist embedding provenance metadata, and override embedding settings during doctor runs.

## Task

- #task-241cdb95

## Changes

- add `newsrag.embeddings` with an embedding provider interface and Ollama implementation for `nomic-embed-text`
- add durable `embedding_records` storage for provider/model/version provenance metadata
- add `doctor` embedding override flags and config helpers for one-off provider/model/base URL checks
- expand doctor coverage for missing Ollama model and unreachable Ollama cases
- add tests for provider behavior, CLI overrides, and embedding metadata persistence

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [ ] Documentation updated (if needed)
- [x] No unrelated changes included
