### PR TITLE
feat: add direct pdf url ingest

### DIFF
--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -17,7 +17,7 @@ from newsrag.config import (
 )
 from newsrag.daemon import DaemonConfig, run_daemon
 from newsrag.doctor import format_report, run_doctor
-from newsrag.ingest import IngestError, enqueue_ingest_jobs
+from newsrag.ingest import IngestError, enqueue_ingest_jobs, enqueue_ingest_url_job
 from newsrag.jobs import list_jobs
 from newsrag.storage import (
     StorageError,
@@ -191,17 +191,13 @@ def ingest_command(
 
     settings, _ = _resolve_runtime_settings(ctx)
     database_path = initialize_storage(settings.data_dir).database
-    metadata = {
-        key: value
-        for key, value in {
-            "title": title,
-            "body": body,
-            "document_type": document_type,
-            "meeting_date": meeting_date,
-            "jurisdiction": jurisdiction,
-        }.items()
-        if value is not None
-    }
+    metadata = _build_document_metadata_options(
+        title=title,
+        body=body,
+        document_type=document_type,
+        meeting_date=meeting_date,
+        jurisdiction=jurisdiction,
+    )
 
     try:
         jobs = enqueue_ingest_jobs(database_path, source_path=path, metadata=metadata)
@@ -212,6 +208,54 @@ def ingest_command(
     typer.echo(f"Enqueued {len(jobs)} ingest job(s)")
     for job in jobs:
         typer.echo(f"{job.id} {job.payload['path']}")
+
+
+@app.command("ingest-url")
+def ingest_url_command(
+    ctx: typer.Context,
+    url: str,
+    title: str | None = typer.Option(None, help="Document title override for the downloaded PDF."),
+    body: str | None = typer.Option(None, help="Civic body metadata for the downloaded PDF."),
+    document_type: str | None = typer.Option(
+        None,
+        "--document-type",
+        help="Document type metadata for the downloaded PDF.",
+    ),
+    meeting_date: str | None = typer.Option(
+        None,
+        "--meeting-date",
+        help="Meeting date metadata for the downloaded PDF.",
+    ),
+    jurisdiction: str | None = typer.Option(
+        None,
+        help="Jurisdiction metadata for the downloaded PDF.",
+    ),
+) -> None:
+    """Download one direct PDF URL and enqueue it for ingestion."""
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    storage_paths = initialize_storage(settings.data_dir)
+    metadata = _build_document_metadata_options(
+        title=title,
+        body=body,
+        document_type=document_type,
+        meeting_date=meeting_date,
+        jurisdiction=jurisdiction,
+    )
+
+    try:
+        job = enqueue_ingest_url_job(
+            storage_paths.database,
+            storage_paths=storage_paths,
+            url=url,
+            metadata=metadata,
+        )
+    except IngestError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    typer.echo("Enqueued 1 ingest job(s)")
+    typer.echo(f"{job.id} {job.payload['path']}")
 
 
 @jobs_app.command("list")
@@ -298,6 +342,27 @@ def run() -> None:
     """Run the Typer application."""
 
     app()
+
+
+def _build_document_metadata_options(
+    *,
+    title: str | None,
+    body: str | None,
+    document_type: str | None,
+    meeting_date: str | None,
+    jurisdiction: str | None,
+) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in {
+            "title": title,
+            "body": body,
+            "document_type": document_type,
+            "meeting_date": meeting_date,
+            "jurisdiction": jurisdiction,
+        }.items()
+        if value is not None
+    }
 
 
 def _resolve_runtime_settings(

--- a/newsrag/ingest.py
+++ b/newsrag/ingest.py
@@ -9,10 +9,13 @@ import subprocess
 import uuid
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Protocol
+from urllib.parse import unquote, urlparse
 
 import fitz  # type: ignore[import-untyped]
+import httpx
 import lancedb  # type: ignore[import-untyped]
 
 from newsrag.config import EmbeddingConfig
@@ -30,6 +33,7 @@ INGEST_JOB_KIND = "ingest-file"
 DEFAULT_EMBEDDING_PROVIDER = "ollama"
 DEFAULT_CHUNK_MAX_CHARS = 2000
 DEFAULT_CHUNK_OVERLAP_CHARS = 200
+DEFAULT_DOWNLOAD_TIMEOUT_SECONDS = 30.0
 VECTOR_TABLE_NAME = "chunk_embeddings"
 
 
@@ -104,6 +108,23 @@ class ChunkVectorRecord:
     metadata: EmbeddingMetadata
 
 
+@dataclass(frozen=True)
+class DownloadedPdf:
+    """One downloaded direct-PDF artifact."""
+
+    path: Path
+    source_url: str
+    retrieved_at: str
+    content_hash: str
+
+
+class PdfDownloader(Protocol):
+    """Protocol for direct PDF downloads."""
+
+    def download_pdf(self, url: str, destination_dir: Path) -> DownloadedPdf:
+        """Download one direct PDF into the corpus data directory."""
+
+
 class OcrRunner(Protocol):
     """Protocol for OCR normalization."""
 
@@ -130,6 +151,38 @@ class VectorStore(Protocol):
 
     def add_chunks(self, chunks: Sequence[ChunkVectorRecord]) -> None:
         """Persist embedded chunk vectors."""
+
+
+@dataclass(frozen=True)
+class HttpxPdfDownloader:
+    """Direct-PDF downloader backed by `httpx`."""
+
+    timeout_seconds: float = DEFAULT_DOWNLOAD_TIMEOUT_SECONDS
+
+    def download_pdf(self, url: str, destination_dir: Path) -> DownloadedPdf:
+        try:
+            response = httpx.get(url, follow_redirects=True, timeout=self.timeout_seconds)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise IngestError(f"Failed downloading {url}: {exc}") from exc
+
+        content = response.content
+        if not _looks_like_pdf(response.headers.get("Content-Type"), content):
+            raise IngestError(f"URL did not return a PDF-like response: {url}")
+
+        content_hash = _hash_bytes(content)
+        filename = _download_filename(response.url)
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        destination_path = destination_dir / f"{content_hash}-{filename}"
+        if not destination_path.exists():
+            destination_path.write_bytes(content)
+
+        return DownloadedPdf(
+            path=destination_path,
+            source_url=url,
+            retrieved_at=_current_timestamp(),
+            content_hash=content_hash,
+        )
 
 
 @dataclass(frozen=True)
@@ -270,6 +323,7 @@ class IngestionPipeline:
     def process_job(self, job: Job) -> None:
         source_path = _payload_path(job.payload)
         metadata = _payload_metadata(job.payload)
+        source_url = _metadata_source_url(metadata)
 
         try:
             source_hash = _hash_file(source_path)
@@ -307,6 +361,7 @@ class IngestionPipeline:
                 self.storage_paths.database,
                 document_id=document_id,
                 source_path=source_path,
+                source_url=source_url,
                 title=_resolve_document_title(metadata, source_path),
                 source_hash=source_hash,
                 normalized_path=normalized_path,
@@ -344,6 +399,33 @@ def enqueue_ingest_jobs(
             )
         )
     return jobs
+
+
+def enqueue_ingest_url_job(
+    database_path: Path,
+    *,
+    storage_paths: StoragePaths,
+    url: str,
+    metadata: dict[str, Any] | None = None,
+    downloader: PdfDownloader | None = None,
+) -> Job:
+    """Download one direct PDF URL and enqueue it for ingestion."""
+
+    resolved_downloader = downloader or HttpxPdfDownloader()
+    downloaded_pdf = resolved_downloader.download_pdf(url, storage_paths.downloaded_pdfs)
+    payload_metadata = dict(metadata or {})
+    payload_metadata["source_url"] = downloaded_pdf.source_url
+    payload_metadata["retrieved_at"] = downloaded_pdf.retrieved_at
+
+    return create_job(
+        database_path,
+        kind=INGEST_JOB_KIND,
+        payload={
+            "path": str(downloaded_pdf.path),
+            "metadata": payload_metadata,
+            "source": "ingest-url",
+        },
+    )
 
 
 def build_ingest_handler(
@@ -546,12 +628,40 @@ def _payload_metadata(payload: dict[str, Any]) -> dict[str, Any]:
     return {}
 
 
+def _metadata_source_url(metadata: dict[str, Any]) -> str | None:
+    source_url = metadata.get("source_url")
+    if isinstance(source_url, str) and source_url.strip():
+        return source_url.strip()
+    return None
+
+
+def _hash_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
 def _hash_file(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as file_handle:
         for chunk in iter(lambda: file_handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _current_timestamp() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _looks_like_pdf(content_type: str | None, content: bytes) -> bool:
+    normalized_content_type = (content_type or "").lower()
+    return "application/pdf" in normalized_content_type or content.startswith(b"%PDF-")
+
+
+def _download_filename(final_url: httpx.URL) -> str:
+    parsed_path = urlparse(str(final_url)).path
+    candidate_name = Path(unquote(parsed_path)).name or "downloaded.pdf"
+    if not candidate_name.lower().endswith(".pdf"):
+        return f"{candidate_name}.pdf"
+    return candidate_name
 
 
 def _copy_source_pdf(storage_paths: StoragePaths, source_path: Path, source_hash: str) -> Path:
@@ -623,6 +733,7 @@ def _persist_document_bundle(
     *,
     document_id: str,
     source_path: Path,
+    source_url: str | None,
     title: str,
     source_hash: str,
     normalized_path: Path,
@@ -645,11 +756,12 @@ def _persist_document_bundle(
                 normalized_path,
                 metadata_json
             )
-            VALUES(?, ?, NULL, ?, ?, ?, ?)
+            VALUES(?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 document_id,
                 str(source_path),
+                source_url,
                 title,
                 source_hash,
                 str(normalized_path),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,7 @@ def test_help_shows_cli_commands() -> None:
     assert "status" in result.stdout
     assert "daemon" in result.stdout
     assert "ingest" in result.stdout
+    assert "ingest-url" in result.stdout
     assert "jobs" in result.stdout
     assert "watch" in result.stdout
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+import httpx
+import pytest
 from typer.testing import CliRunner
 
 from newsrag.cli import app
@@ -19,8 +21,10 @@ from newsrag.embeddings import (
 from newsrag.ingest import (
     INGEST_JOB_KIND,
     ExtractedPage,
+    IngestError,
     LanceDbVectorStore,
     build_ingest_handler,
+    enqueue_ingest_url_job,
     list_chunk_vectors,
     list_chunks,
     list_documents,
@@ -64,6 +68,138 @@ def test_ingest_command_enqueues_local_pdf_jobs(tmp_path: Path) -> None:
     assert jobs[0].payload["metadata"]["body"] == "City Council"
     assert jobs[0].payload["metadata"]["document_type"] == "agenda_packet"
     assert jobs[1].payload["metadata"]["body"] == "City Council"
+
+
+def test_ingest_url_command_downloads_pdf_and_enqueues_job(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_dir = tmp_path / ".newsrag"
+    url = "https://example.gov/packet.pdf"
+
+    monkeypatch.setattr("newsrag.ingest.httpx.get", _fake_pdf_getter(url, b"%PDF-1.4\nurl-pdf"))
+
+    result = runner.invoke(
+        app,
+        [
+            "--data-dir",
+            str(data_dir),
+            "ingest-url",
+            url,
+            "--body",
+            "City Council",
+            "--document-type",
+            "agenda_packet",
+        ],
+    )
+
+    paths = initialize_storage(data_dir)
+    jobs = list_jobs(paths.database)
+
+    assert result.exit_code == 0
+    assert "Enqueued 1 ingest job(s)" in result.stdout
+    assert len(jobs) == 1
+    assert jobs[0].kind == INGEST_JOB_KIND
+    assert Path(jobs[0].payload["path"]).parent == paths.downloaded_pdfs
+    assert Path(jobs[0].payload["path"]).is_file()
+    assert jobs[0].payload["metadata"]["body"] == "City Council"
+    assert jobs[0].payload["metadata"]["document_type"] == "agenda_packet"
+    assert jobs[0].payload["metadata"]["source_url"] == url
+    assert "retrieved_at" in jobs[0].payload["metadata"]
+
+
+def test_enqueue_ingest_url_job_reuses_hash_named_download_for_unchanged_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = initialize_storage(tmp_path / ".newsrag")
+    url = "https://example.gov/packet.pdf"
+
+    monkeypatch.setattr("newsrag.ingest.httpx.get", _fake_pdf_getter(url, b"%PDF-1.4\nunchanged"))
+
+    first_job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
+    second_job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
+
+    assert first_job.payload["path"] == second_job.payload["path"]
+    assert Path(first_job.payload["path"]).is_file()
+
+
+def test_url_ingest_stores_source_url_and_retrieved_at(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_dir = tmp_path / ".newsrag"
+    paths = initialize_storage(data_dir)
+    url = "https://example.gov/packet.pdf"
+
+    monkeypatch.setattr("newsrag.ingest.httpx.get", _fake_pdf_getter(url, b"%PDF-1.4\nurl-pdf"))
+
+    job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
+    retrieved_at = str(job.payload["metadata"]["retrieved_at"])
+
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        ocr_runner=FakeOcrRunner(),
+        text_extractor=FakeTextExtractor(pages=[ExtractedPage(page_number=1, text="Agenda")]),
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+
+    asyncio.run(
+        DaemonRunner(
+            database_path=paths.database,
+            handlers={INGEST_JOB_KIND: handler},
+            poll_interval=0,
+        ).run_cycle()
+    )
+
+    documents = list_documents(paths.database)
+
+    assert len(documents) == 1
+    assert documents[0].source_url == url
+    assert documents[0].metadata["retrieved_at"] == retrieved_at
+
+
+def test_ingest_url_rejects_non_pdf_responses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = initialize_storage(tmp_path / ".newsrag")
+    url = "https://example.gov/not-a-pdf"
+
+    def fake_get(target_url: str, *, follow_redirects: bool, timeout: float) -> httpx.Response:
+        del follow_redirects, timeout
+        request = httpx.Request("GET", target_url)
+        return httpx.Response(
+            200,
+            request=request,
+            headers={"Content-Type": "text/html"},
+            content=b"<html>nope</html>",
+        )
+
+    monkeypatch.setattr("newsrag.ingest.httpx.get", fake_get)
+
+    with pytest.raises(IngestError, match="PDF-like response"):
+        enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
+
+
+def test_ingest_url_download_failures_fail_clearly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = initialize_storage(tmp_path / ".newsrag")
+    url = "https://example.gov/packet.pdf"
+
+    def fake_get(target_url: str, *, follow_redirects: bool, timeout: float) -> httpx.Response:
+        del follow_redirects, timeout
+        request = httpx.Request("GET", target_url)
+        raise httpx.ConnectError("boom", request=request)
+
+    monkeypatch.setattr("newsrag.ingest.httpx.get", fake_get)
+
+    with pytest.raises(IngestError, match="Failed downloading"):
+        enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
 
 
 def test_mocked_local_pdf_job_creates_document_pages_chunks_and_vector_records(
@@ -248,3 +384,21 @@ class FakeEmbeddingProvider:
             )
             for index, text in enumerate(texts)
         ]
+
+
+def _fake_pdf_getter(
+    url: str,
+    content: bytes,
+) -> Callable[..., httpx.Response]:
+    def fake_get(target_url: str, *, follow_redirects: bool, timeout: float) -> httpx.Response:
+        del follow_redirects, timeout
+        assert target_url == url
+        request = httpx.Request("GET", target_url)
+        return httpx.Response(
+            200,
+            request=request,
+            headers={"Content-Type": "application/pdf"},
+            content=content,
+        )
+
+    return fake_get


### PR DESCRIPTION
## Summary

Add direct PDF URL ingestion so NewsRAG can download a remote PDF into the active corpus, preserve URL retrieval provenance, and enqueue the existing ingest pipeline against the downloaded file.

## Task

- #task-44db91c8

## Changes

- add `newsrag ingest-url <url>` with the same civic metadata flags as local ingest
- download direct PDF URLs into `downloaded-pdfs/` using content-hash-based filenames
- preserve `source_url` and `retrieved_at` on created documents
- reuse the existing `ingest-file` daemon pipeline for downloaded PDFs
- fail clearly for non-PDF responses and download failures
- add mocked HTTP tests for URL ingest success, hash-path reuse, provenance persistence, and failure paths

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [ ] Documentation updated (if needed)
- [x] No unrelated changes included
