### PR TITLE
feat: add yaml manifest ingest

### DIFF
--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -19,6 +19,7 @@ from newsrag.daemon import DaemonConfig, run_daemon
 from newsrag.doctor import format_report, run_doctor
 from newsrag.ingest import IngestError, enqueue_ingest_jobs, enqueue_ingest_url_job
 from newsrag.jobs import list_jobs
+from newsrag.manifests import ManifestError, load_manifest
 from newsrag.storage import (
     StorageError,
     format_status_report,
@@ -256,6 +257,39 @@ def ingest_url_command(
 
     typer.echo("Enqueued 1 ingest job(s)")
     typer.echo(f"{job.id} {job.payload['path']}")
+
+
+@app.command("ingest-manifest")
+def ingest_manifest_command(ctx: typer.Context, path: Path) -> None:
+    """Load a YAML manifest and enqueue one URL-ingest job per document."""
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    storage_paths = initialize_storage(settings.data_dir)
+
+    try:
+        manifest = load_manifest(path)
+    except ManifestError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    jobs = []
+    try:
+        for document in manifest.documents:
+            jobs.append(
+                enqueue_ingest_url_job(
+                    storage_paths.database,
+                    storage_paths=storage_paths,
+                    url=document.url,
+                    metadata=document.metadata,
+                )
+            )
+    except IngestError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(f"Enqueued {len(jobs)} ingest job(s)")
+    for job in jobs:
+        typer.echo(f"{job.id} {job.payload['path']}")
 
 
 @jobs_app.command("list")

--- a/newsrag/manifests.py
+++ b/newsrag/manifests.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+import yaml
+
+from newsrag.ingest import IngestError
+
+ALLOWED_DOCUMENT_FIELDS = {
+    "url",
+    "title",
+    "meeting_date",
+    "body",
+    "document_type",
+    "jurisdiction",
+}
+
+
+@dataclass(frozen=True)
+class ManifestDocument:
+    """One validated document entry from a YAML manifest."""
+
+    url: str
+    metadata: dict[str, str]
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """Validated YAML manifest content."""
+
+    documents: tuple[ManifestDocument, ...]
+
+
+class ManifestError(IngestError):
+    """Raised when a YAML ingest manifest is invalid."""
+
+
+def load_manifest(path: Path) -> Manifest:
+    """Load and validate one YAML ingest manifest."""
+
+    resolved_path = path.expanduser().resolve()
+    if not resolved_path.exists():
+        raise ManifestError(f"Manifest path does not exist: {resolved_path}")
+    if not resolved_path.is_file():
+        raise ManifestError(f"Manifest path is not a file: {resolved_path}")
+
+    raw_content = resolved_path.read_text(encoding="utf-8")
+    try:
+        loaded = yaml.safe_load(raw_content)
+    except yaml.YAMLError as exc:
+        raise ManifestError(f"Invalid YAML in {resolved_path}: {exc}") from exc
+
+    if not isinstance(loaded, dict):
+        raise ManifestError("Manifest must contain a top-level mapping")
+
+    extra_top_level_keys = set(loaded) - {"documents"}
+    if extra_top_level_keys:
+        raise ManifestError(
+            "Unsupported top-level manifest fields: " + ", ".join(sorted(extra_top_level_keys))
+        )
+
+    raw_documents = loaded.get("documents")
+    if not isinstance(raw_documents, list):
+        raise ManifestError("Manifest field 'documents' must be a list")
+    if not raw_documents:
+        raise ManifestError("Manifest field 'documents' must not be empty")
+
+    seen_urls: set[str] = set()
+    documents: list[ManifestDocument] = []
+    for index, raw_document in enumerate(raw_documents, start=1):
+        documents.append(_validate_document(raw_document, index=index, seen_urls=seen_urls))
+
+    return Manifest(documents=tuple(documents))
+
+
+def _validate_document(
+    raw_document: object,
+    *,
+    index: int,
+    seen_urls: set[str],
+) -> ManifestDocument:
+    if not isinstance(raw_document, dict):
+        raise ManifestError(f"Manifest document #{index} must be a mapping")
+
+    extra_fields = set(raw_document) - ALLOWED_DOCUMENT_FIELDS
+    if extra_fields:
+        raise ManifestError(
+            f"Manifest document #{index} has unsupported fields: " + ", ".join(sorted(extra_fields))
+        )
+
+    raw_url = raw_document.get("url")
+    if not isinstance(raw_url, str) or not raw_url.strip():
+        raise ManifestError(f"Manifest document #{index} is missing a non-empty 'url'")
+    url = raw_url.strip()
+    if url in seen_urls:
+        raise ManifestError(f"Manifest contains duplicate URL: {url}")
+    seen_urls.add(url)
+
+    metadata: dict[str, str] = {}
+    for key in ("title", "body", "document_type", "jurisdiction"):
+        value = raw_document.get(key)
+        if value is None:
+            continue
+        if not isinstance(value, str) or not value.strip():
+            raise ManifestError(
+                f"Manifest document #{index} field '{key}' must be a non-empty string"
+            )
+        metadata[key] = value.strip()
+
+    meeting_date = raw_document.get("meeting_date")
+    if meeting_date is not None:
+        if isinstance(meeting_date, date):
+            normalized_meeting_date = meeting_date.isoformat()
+        elif isinstance(meeting_date, str) and meeting_date.strip():
+            normalized_meeting_date = meeting_date.strip()
+            try:
+                date.fromisoformat(normalized_meeting_date)
+            except ValueError as exc:
+                raise ManifestError(
+                    f"Manifest document #{index} field 'meeting_date' must be YYYY-MM-DD"
+                ) from exc
+        else:
+            raise ManifestError(
+                f"Manifest document #{index} field 'meeting_date' must be a non-empty string"
+            )
+
+        metadata["meeting_date"] = normalized_meeting_date
+
+    return ManifestDocument(url=url, metadata=metadata)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,7 @@ def test_help_shows_cli_commands() -> None:
     assert "daemon" in result.stdout
     assert "ingest" in result.stdout
     assert "ingest-url" in result.stdout
+    assert "ingest-manifest" in result.stdout
     assert "jobs" in result.stdout
     assert "watch" in result.stdout
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -31,6 +31,7 @@ from newsrag.ingest import (
     list_pages,
 )
 from newsrag.jobs import FAILED, create_job, get_job, list_jobs
+from newsrag.manifests import ManifestError, load_manifest
 from newsrag.storage import initialize_storage
 
 runner = CliRunner()
@@ -61,7 +62,7 @@ def test_ingest_command_enqueues_local_pdf_jobs(tmp_path: Path) -> None:
     paths = initialize_storage(data_dir)
     jobs = list_jobs(paths.database)
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.stdout
     assert "Enqueued 2 ingest job(s)" in result.stdout
     assert len(jobs) == 2
     assert all(job.kind == INGEST_JOB_KIND for job in jobs)
@@ -182,6 +183,192 @@ def test_ingest_url_rejects_non_pdf_responses(
 
     with pytest.raises(IngestError, match="PDF-like response"):
         enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
+
+
+def test_ingest_manifest_enqueues_one_job_per_document(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_dir = tmp_path / ".newsrag"
+    manifest_path = tmp_path / "sources.yaml"
+    manifest_path.write_text(
+        """
+        documents:
+          - url: https://example.gov/packet-1.pdf
+            title: Packet One
+            meeting_date: 2026-05-01
+            body: City Council
+            document_type: agenda_packet
+          - url: https://example.gov/packet-2.pdf
+            jurisdiction: Example City
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "newsrag.ingest.httpx.get",
+        _fake_pdf_url_map_getter(
+            {
+                "https://example.gov/packet-1.pdf": b"%PDF-1.4\npacket-1",
+                "https://example.gov/packet-2.pdf": b"%PDF-1.4\npacket-2",
+            }
+        ),
+    )
+
+    result = runner.invoke(
+        app, ["--data-dir", str(data_dir), "ingest-manifest", str(manifest_path)]
+    )
+
+    paths = initialize_storage(data_dir)
+    jobs = list_jobs(paths.database)
+
+    assert result.exit_code == 0
+    assert "Enqueued 2 ingest job(s)" in result.stdout
+    assert len(jobs) == 2
+
+    jobs_by_url = {str(job.payload["metadata"]["source_url"]): job for job in jobs}
+    first_job = jobs_by_url["https://example.gov/packet-1.pdf"]
+    second_job = jobs_by_url["https://example.gov/packet-2.pdf"]
+
+    assert first_job.payload["metadata"]["title"] == "Packet One"
+    assert first_job.payload["metadata"]["meeting_date"] == "2026-05-01"
+    assert second_job.payload["metadata"]["jurisdiction"] == "Example City"
+
+
+def test_invalid_manifest_missing_url_fails_without_enqueuing(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    manifest_path = tmp_path / "sources.yaml"
+    manifest_path.write_text(
+        """
+        documents:
+          - title: Missing URL
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app, ["--data-dir", str(data_dir), "ingest-manifest", str(manifest_path)]
+    )
+    paths = initialize_storage(data_dir)
+
+    assert result.exit_code == 1
+    assert "missing a non-empty 'url'" in result.stdout
+    assert list_jobs(paths.database) == []
+
+
+def test_invalid_manifest_invalid_meeting_date_fails_without_enqueuing(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    manifest_path = tmp_path / "sources.yaml"
+    manifest_path.write_text(
+        """
+        documents:
+          - url: https://example.gov/packet.pdf
+            meeting_date: 05-01-2026
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app, ["--data-dir", str(data_dir), "ingest-manifest", str(manifest_path)]
+    )
+    paths = initialize_storage(data_dir)
+
+    assert result.exit_code == 1
+    assert "must be YYYY-MM-DD" in result.stdout
+    assert list_jobs(paths.database) == []
+
+
+def test_invalid_manifest_duplicate_urls_fail_without_partial_work(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    manifest_path = tmp_path / "sources.yaml"
+    manifest_path.write_text(
+        """
+        documents:
+          - url: https://example.gov/packet.pdf
+          - url: https://example.gov/packet.pdf
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app, ["--data-dir", str(data_dir), "ingest-manifest", str(manifest_path)]
+    )
+    paths = initialize_storage(data_dir)
+
+    assert result.exit_code == 1
+    assert "duplicate URL" in result.stdout
+    assert list_jobs(paths.database) == []
+
+
+def test_invalid_manifest_unsupported_fields_fail(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "sources.yaml"
+    manifest_path.write_text(
+        """
+        documents:
+          - url: https://example.gov/packet.pdf
+            committee: Finance
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ManifestError, match="unsupported fields"):
+        load_manifest(manifest_path)
+
+
+def test_manifest_metadata_is_preserved_on_created_documents(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_dir = tmp_path / ".newsrag"
+    manifest_path = tmp_path / "sources.yaml"
+    manifest_path.write_text(
+        """
+        documents:
+          - url: https://example.gov/packet.pdf
+            title: Manifest Packet
+            meeting_date: 2026-05-01
+            body: City Council
+            document_type: agenda_packet
+            jurisdiction: Example City
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "newsrag.ingest.httpx.get",
+        _fake_pdf_getter("https://example.gov/packet.pdf", b"%PDF-1.4\nmanifest"),
+    )
+
+    result = runner.invoke(
+        app, ["--data-dir", str(data_dir), "ingest-manifest", str(manifest_path)]
+    )
+    assert result.exit_code == 0, result.stdout
+
+    paths = initialize_storage(data_dir)
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        ocr_runner=FakeOcrRunner(),
+        text_extractor=FakeTextExtractor(pages=[ExtractedPage(page_number=1, text="Agenda")]),
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+
+    asyncio.run(
+        DaemonRunner(
+            database_path=paths.database,
+            handlers={INGEST_JOB_KIND: handler},
+            poll_interval=0,
+        ).run_cycle()
+    )
+
+    documents = list_documents(paths.database)
+    assert len(documents) == 1
+    assert documents[0].title == "Manifest Packet"
+    assert documents[0].metadata["meeting_date"] == "2026-05-01"
+    assert documents[0].metadata["body"] == "City Council"
+    assert documents[0].metadata["document_type"] == "agenda_packet"
+    assert documents[0].metadata["jurisdiction"] == "Example City"
 
 
 def test_ingest_url_download_failures_fail_clearly(
@@ -399,6 +586,23 @@ def _fake_pdf_getter(
             request=request,
             headers={"Content-Type": "application/pdf"},
             content=content,
+        )
+
+    return fake_get
+
+
+def _fake_pdf_url_map_getter(
+    url_map: dict[str, bytes],
+) -> Callable[..., httpx.Response]:
+    def fake_get(target_url: str, *, follow_redirects: bool, timeout: float) -> httpx.Response:
+        del follow_redirects, timeout
+        assert target_url in url_map
+        request = httpx.Request("GET", target_url)
+        return httpx.Response(
+            200,
+            request=request,
+            headers={"Content-Type": "application/pdf"},
+            content=url_map[target_url],
         )
 
     return fake_get


### PR DESCRIPTION
## Summary

Add YAML manifest ingestion so NewsRAG can validate a curated batch of PDF URLs and enqueue one direct-URL ingest job per manifest document while preserving per-document metadata.

## Task

- #task-9b0e618d

## Changes

- add `newsrag ingest-manifest <path>`
- add strict YAML manifest parsing and validation for the supported document fields
- accept one `documents` list entry per direct PDF URL and reuse existing URL-ingest behavior
- reject missing URLs, invalid meeting dates, unsupported fields, and duplicate URLs without partial enqueue work
- add tests for valid manifests, invalid manifests, duplicate URLs, and metadata preservation through processing

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [ ] Documentation updated (if needed)
- [x] No unrelated changes included
