### PR TITLE
feat: add hybrid search with citations

### DIFF
--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -311,7 +311,7 @@ def search_command(ctx: typer.Context, query: str) -> None:
         typer.echo(str(exc))
         raise typer.Exit(code=1) from exc
 
-    typer.echo(format_search_results(results))
+    typer.echo(format_search_results(results, query=query))
 
 
 @jobs_app.command("list")

--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -20,6 +20,7 @@ from newsrag.doctor import format_report, run_doctor
 from newsrag.ingest import IngestError, enqueue_ingest_jobs, enqueue_ingest_url_job
 from newsrag.jobs import list_jobs
 from newsrag.manifests import ManifestError, load_manifest
+from newsrag.search import SearchError, build_search_engine, format_search_results
 from newsrag.storage import (
     StorageError,
     format_status_report,
@@ -290,6 +291,27 @@ def ingest_manifest_command(ctx: typer.Context, path: Path) -> None:
     typer.echo(f"Enqueued {len(jobs)} ingest job(s)")
     for job in jobs:
         typer.echo(f"{job.id} {job.payload['path']}")
+
+
+@app.command("search")
+def search_command(ctx: typer.Context, query: str) -> None:
+    """Search indexed evidence passages with hybrid keyword/vector retrieval."""
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    storage_paths = initialize_storage(settings.data_dir)
+
+    try:
+        engine = build_search_engine(
+            database_path=storage_paths.database,
+            lancedb_path=storage_paths.lancedb,
+            embedding_config=settings.config.embedding,
+        )
+        results = engine.search(query)
+    except SearchError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(format_search_results(results))
 
 
 @jobs_app.command("list")

--- a/newsrag/ingest.py
+++ b/newsrag/ingest.py
@@ -27,6 +27,8 @@ from newsrag.embeddings import (
     create_embedding_record,
 )
 from newsrag.jobs import Job, create_job
+from newsrag.passages import build_passage_rows
+from newsrag.search import LanceDbPassageVectorStore, PassageVectorRecord
 from newsrag.storage import StoragePaths, initialize_storage
 
 INGEST_JOB_KIND = "ingest-file"
@@ -316,6 +318,7 @@ class IngestionPipeline:
             _resolve_embedding_config(embedding_config)
         )
         self.vector_store = vector_store or LanceDbVectorStore(storage_paths.lancedb)
+        self.passage_vector_store = LanceDbPassageVectorStore(storage_paths.lancedb)
 
     async def handle_job(self, job: Job) -> None:
         await asyncio.to_thread(self.process_job, job)
@@ -355,8 +358,18 @@ class IngestionPipeline:
                 chunks,
                 chunk_embeddings,
             )
+            passage_rows = _build_passage_rows_from_chunks(chunk_rows)
+            passage_embeddings = self.embedding_provider.embed_chunks(
+                [passage_row[6] for passage_row in passage_rows]
+            )
+            if len(passage_embeddings) != len(passage_rows):
+                raise IngestError(
+                    f"Embedded {len(passage_embeddings)} passages for {len(passage_rows)} passage rows"
+                )
+            passage_vector_rows = _build_passage_vector_rows(passage_rows, passage_embeddings)
 
             self.vector_store.add_chunks(vector_rows)
+            self.passage_vector_store.add_passages(passage_vector_rows)
             _persist_document_bundle(
                 self.storage_paths.database,
                 document_id=document_id,
@@ -369,6 +382,8 @@ class IngestionPipeline:
                 pages=page_rows,
                 chunks=chunk_rows,
                 chunk_embeddings=chunk_embeddings,
+                passages=passage_rows,
+                passage_embeddings=passage_embeddings,
             )
         except IngestError:
             raise
@@ -728,6 +743,52 @@ def _build_chunk_and_vector_rows(
     return chunk_rows, vector_rows
 
 
+def _build_passage_rows_from_chunks(
+    chunks: Sequence[tuple[str, str, int, int, str]],
+) -> list[tuple[str, str, str, int, int, int, str]]:
+    passage_rows: list[tuple[str, str, str, int, int, int, str]] = []
+    for chunk_id, document_id, page_start, page_end, text in chunks:
+        for passage in build_passage_rows(
+            chunk_id=chunk_id,
+            document_id=document_id,
+            page_start=page_start,
+            page_end=page_end,
+            text=text,
+        ):
+            passage_rows.append(
+                (
+                    passage.id,
+                    passage.chunk_id,
+                    passage.document_id,
+                    passage.page_start,
+                    passage.page_end,
+                    passage.ordinal,
+                    passage.text,
+                )
+            )
+    return passage_rows
+
+
+def _build_passage_vector_rows(
+    passages: Sequence[tuple[str, str, str, int, int, int, str]],
+    embeddings: Sequence[ChunkEmbedding],
+) -> list[PassageVectorRecord]:
+    return [
+        PassageVectorRecord(
+            passage_id=passage_id,
+            document_id=document_id,
+            page_start=page_start,
+            page_end=page_end,
+            text=text,
+            vector=embedding.vector,
+            metadata=embedding.metadata,
+        )
+        for (passage_id, _, document_id, page_start, page_end, _, text), embedding in zip(
+            passages, embeddings, strict=True
+        )
+    ]
+
+
 def _persist_document_bundle(
     database_path: Path,
     *,
@@ -741,6 +802,8 @@ def _persist_document_bundle(
     pages: Sequence[tuple[str, str, int, str]],
     chunks: Sequence[tuple[str, str, int, int, str]],
     chunk_embeddings: Sequence[ChunkEmbedding],
+    passages: Sequence[tuple[str, str, str, int, int, int, str]],
+    passage_embeddings: Sequence[ChunkEmbedding],
 ) -> None:
     metadata_json = json.dumps(metadata, sort_keys=True)
 
@@ -789,6 +852,20 @@ def _persist_document_bundle(
             """,
             [(chunk_id, text) for chunk_id, _, _, _, text in chunks],
         )
+        connection.executemany(
+            """
+            INSERT INTO passages(id, chunk_id, document_id, page_start, page_end, ordinal, text)
+            VALUES(?, ?, ?, ?, ?, ?, ?)
+            """,
+            passages,
+        )
+        connection.executemany(
+            """
+            INSERT INTO passages_fts(passage_id, text)
+            VALUES(?, ?)
+            """,
+            [(passage_id, text) for passage_id, _, _, _, _, _, text in passages],
+        )
         connection.commit()
 
     for chunk_row, embedding in zip(chunks, chunk_embeddings, strict=True):
@@ -796,6 +873,14 @@ def _persist_document_bundle(
             database_path,
             source_kind="chunk",
             source_key=chunk_row[0],
+            embedding=embedding,
+        )
+
+    for passage_row, embedding in zip(passages, passage_embeddings, strict=True):
+        create_embedding_record(
+            database_path,
+            source_kind="passage",
+            source_key=passage_row[0],
             embedding=embedding,
         )
 

--- a/newsrag/ingest.py
+++ b/newsrag/ingest.py
@@ -782,6 +782,13 @@ def _persist_document_bundle(
             """,
             chunks,
         )
+        connection.executemany(
+            """
+            INSERT INTO chunks_fts(chunk_id, text)
+            VALUES(?, ?)
+            """,
+            [(chunk_id, text) for chunk_id, _, _, _, text in chunks],
+        )
         connection.commit()
 
     for chunk_row, embedding in zip(chunks, chunk_embeddings, strict=True):

--- a/newsrag/passages.py
+++ b/newsrag/passages.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+_PAGE_HEADER_PATTERNS = (
+    re.compile(r"^Page\s+\d+\s+of\s+\d+$", re.IGNORECASE),
+    re.compile(r"^[A-Za-z]+\s+\d{1,2},\s+\d{4}$"),
+)
+
+
+@dataclass(frozen=True)
+class PassageDraft:
+    """One passage extracted from a larger stored chunk."""
+
+    text: str
+    page_start: int
+    page_end: int
+
+
+@dataclass(frozen=True)
+class PassageRow:
+    """One durable passage row ready for SQLite persistence."""
+
+    id: str
+    chunk_id: str
+    document_id: str
+    page_start: int
+    page_end: int
+    ordinal: int
+    text: str
+
+
+def build_passage_rows(
+    *,
+    chunk_id: str,
+    document_id: str,
+    page_start: int,
+    page_end: int,
+    text: str,
+) -> list[PassageRow]:
+    """Split one chunk text into durable passage rows."""
+
+    drafts = split_chunk_text_into_passages(text, page_start=page_start, page_end=page_end)
+    return [
+        PassageRow(
+            id=f"passage-{chunk_id}-{index:03d}",
+            chunk_id=chunk_id,
+            document_id=document_id,
+            page_start=draft.page_start,
+            page_end=draft.page_end,
+            ordinal=index,
+            text=draft.text,
+        )
+        for index, draft in enumerate(drafts, start=1)
+    ]
+
+
+def split_chunk_text_into_passages(
+    text: str,
+    *,
+    page_start: int,
+    page_end: int,
+) -> list[PassageDraft]:
+    """Heuristically split one stored chunk into searchable passages."""
+
+    lines = [_normalize_line(line) for line in text.splitlines()]
+    passages: list[str] = []
+    current: list[str] = []
+
+    def flush_current() -> None:
+        if not current:
+            return
+        candidate = _join_lines(current)
+        current.clear()
+        if _should_keep_passage(candidate):
+            passages.append(candidate)
+
+    for line in lines:
+        if not line:
+            flush_current()
+            continue
+        if _is_page_header_or_footer(line):
+            flush_current()
+            continue
+        if _starts_new_passage(line):
+            flush_current()
+            current.append(line)
+            continue
+        if _is_low_value_heading(line):
+            flush_current()
+            continue
+        current.append(line)
+
+    flush_current()
+
+    if not passages:
+        fallback = _join_lines(
+            line for line in lines if line and not _is_page_header_or_footer(line)
+        )
+        if fallback:
+            passages = [fallback]
+
+    return [
+        PassageDraft(text=passage, page_start=page_start, page_end=page_end) for passage in passages
+    ]
+
+
+def _normalize_line(line: str) -> str:
+    return " ".join(line.split()).strip()
+
+
+def _join_lines(lines: Iterable[str]) -> str:
+    return " ".join(line for line in lines if line).strip()
+
+
+def _is_page_header_or_footer(line: str) -> bool:
+    if not line:
+        return True
+    if line == "-":
+        return True
+    if line.endswith(" eventbrite.com") or line.startswith("www."):
+        return True
+    if "City Manager's Report" in line or "City Manager’s Report" in line:
+        return True
+    return any(pattern.match(line) for pattern in _PAGE_HEADER_PATTERNS)
+
+
+def _starts_new_passage(line: str) -> bool:
+    return line.startswith("•")
+
+
+def _is_low_value_heading(line: str) -> bool:
+    if len(line) <= 20 and line.endswith(":"):
+        return True
+    if "The following is a brief overview" in line:
+        return True
+    return False
+
+
+def _should_keep_passage(text: str) -> bool:
+    normalized = text.strip()
+    if not normalized:
+        return False
+    if len(normalized) >= 40:
+        return True
+    return normalized.startswith("•")

--- a/newsrag/search.py
+++ b/newsrag/search.py
@@ -17,6 +17,7 @@ DEFAULT_SEARCH_LIMIT = 5
 DEFAULT_KEYWORD_WEIGHT = 0.5
 DEFAULT_VECTOR_WEIGHT = 0.5
 DEFAULT_MAX_VECTOR_DISTANCE = 1.0
+DEFAULT_SNIPPET_LENGTH = 320
 DEFAULT_EMBEDDING_PROVIDER = "ollama"
 
 
@@ -277,7 +278,7 @@ def format_citation(*, title: str | None, meeting_date: str | None, page_number:
     return " — ".join(parts)
 
 
-def format_search_results(results: Sequence[SearchResult]) -> str:
+def format_search_results(results: Sequence[SearchResult], *, query: str | None = None) -> str:
     """Format ranked search results for terminal output."""
 
     if not results:
@@ -286,9 +287,38 @@ def format_search_results(results: Sequence[SearchResult]) -> str:
     lines = ["NewsRAG Search"]
     for result in results:
         lines.append(result.citation)
-        lines.append(result.text)
+        lines.append(_build_display_snippet(result.text, query=query))
         lines.append("")
     return "\n".join(lines).rstrip()
+
+
+def _build_display_snippet(text: str, *, query: str | None) -> str:
+    normalized_text = " ".join(text.split())
+    if len(normalized_text) <= DEFAULT_SNIPPET_LENGTH:
+        return normalized_text
+
+    query_terms = [term.casefold() for term in (query or "").split() if term.strip()]
+    lowered_text = normalized_text.casefold()
+    match_index = min(
+        (index for term in query_terms if (index := lowered_text.find(term)) >= 0),
+        default=-1,
+    )
+
+    if match_index >= 0:
+        half_window = DEFAULT_SNIPPET_LENGTH // 2
+        start = max(0, match_index - half_window)
+        end = min(len(normalized_text), start + DEFAULT_SNIPPET_LENGTH)
+        start = max(0, end - DEFAULT_SNIPPET_LENGTH)
+    else:
+        start = 0
+        end = min(len(normalized_text), DEFAULT_SNIPPET_LENGTH)
+
+    snippet = normalized_text[start:end].strip()
+    if start > 0:
+        snippet = f"…{snippet}"
+    if end < len(normalized_text):
+        snippet = f"{snippet}…"
+    return snippet
 
 
 def _resolve_embedding_config(embedding_config: EmbeddingConfig) -> EmbeddingConfig:

--- a/newsrag/search.py
+++ b/newsrag/search.py
@@ -16,6 +16,7 @@ from newsrag.ingest import VECTOR_TABLE_NAME
 DEFAULT_SEARCH_LIMIT = 5
 DEFAULT_KEYWORD_WEIGHT = 0.5
 DEFAULT_VECTOR_WEIGHT = 0.5
+DEFAULT_MAX_VECTOR_DISTANCE = 1.0
 DEFAULT_EMBEDDING_PROVIDER = "ollama"
 
 
@@ -74,6 +75,7 @@ class LanceDbVectorSearcher:
 
     lancedb_path: Path
     table_name: str = VECTOR_TABLE_NAME
+    max_vector_distance: float | None = DEFAULT_MAX_VECTOR_DISTANCE
 
     def search(self, query_embedding: QueryEmbedding, *, limit: int) -> list[SearchCandidate]:
         database = lancedb.connect(self.lancedb_path)
@@ -83,20 +85,26 @@ class LanceDbVectorSearcher:
             return []
 
         rows = table.search(list(query_embedding.vector)).limit(limit).to_list()
-        return [
-            SearchCandidate(
-                chunk_id=str(row["chunk_id"]),
-                document_id=str(row["document_id"]),
-                page_start=int(row["page_start"]),
-                page_end=int(row["page_end"]),
-                text=str(row["text"]),
-                title=None,
-                meeting_date=None,
-                vector_score=float(row["_distance"]),
+        candidates: list[SearchCandidate] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            distance = float(row["_distance"])
+            if self.max_vector_distance is not None and distance > self.max_vector_distance:
+                continue
+            candidates.append(
+                SearchCandidate(
+                    chunk_id=str(row["chunk_id"]),
+                    document_id=str(row["document_id"]),
+                    page_start=int(row["page_start"]),
+                    page_end=int(row["page_end"]),
+                    text=str(row["text"]),
+                    title=None,
+                    meeting_date=None,
+                    vector_score=distance,
+                )
             )
-            for row in rows
-            if isinstance(row, dict)
-        ]
+        return candidates
 
 
 @dataclass(frozen=True)

--- a/newsrag/search.py
+++ b/newsrag/search.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -18,6 +19,7 @@ DEFAULT_KEYWORD_WEIGHT = 0.5
 DEFAULT_VECTOR_WEIGHT = 0.5
 DEFAULT_MAX_VECTOR_DISTANCE = 1.0
 DEFAULT_SNIPPET_LENGTH = 320
+DEFAULT_PASSAGE_LENGTH = 700
 DEFAULT_EMBEDDING_PROVIDER = "ollama"
 
 
@@ -314,30 +316,64 @@ def format_search_results(results: Sequence[SearchResult], *, query: str | None 
 
 
 def _build_display_snippet(text: str, *, query: str | None) -> str:
-    normalized_text = " ".join(text.split())
-    if len(normalized_text) <= DEFAULT_SNIPPET_LENGTH:
-        return normalized_text
+    passage = _select_relevant_passage(text, query=query)
+    normalized_passage = " ".join(passage.split())
+    if len(normalized_passage) <= DEFAULT_PASSAGE_LENGTH:
+        return normalized_passage
+    return _truncate_text(normalized_passage, query=query, max_length=DEFAULT_SNIPPET_LENGTH)
+
+
+def _select_relevant_passage(text: str, *, query: str | None) -> str:
+    paragraphs = [
+        paragraph.strip() for paragraph in re.split(r"\n\s*\n+", text) if paragraph.strip()
+    ]
+    if not paragraphs:
+        return text
+
+    scored_paragraphs = [
+        (_score_passage(paragraph, query=query), index, paragraph)
+        for index, paragraph in enumerate(paragraphs)
+    ]
+    best_score, _, best_paragraph = max(scored_paragraphs, key=lambda item: (item[0], -item[1]))
+    if best_score > 0:
+        return best_paragraph
+    return text
+
+
+def _score_passage(text: str, *, query: str | None) -> int:
+    normalized_text = " ".join(text.split()).casefold()
+    normalized_query = " ".join((query or "").split()).casefold()
+    query_terms = [term.casefold() for term in (query or "").split() if term.strip()]
+    phrase_hits = normalized_text.count(normalized_query) if normalized_query else 0
+    unique_term_hits = sum(1 for term in set(query_terms) if term in normalized_text)
+    term_hits = sum(normalized_text.count(term) for term in query_terms)
+    return phrase_hits * 100 + unique_term_hits * 10 + term_hits
+
+
+def _truncate_text(text: str, *, query: str | None, max_length: int) -> str:
+    if len(text) <= max_length:
+        return text
 
     query_terms = [term.casefold() for term in (query or "").split() if term.strip()]
-    lowered_text = normalized_text.casefold()
+    lowered_text = text.casefold()
     match_index = min(
         (index for term in query_terms if (index := lowered_text.find(term)) >= 0),
         default=-1,
     )
 
     if match_index >= 0:
-        half_window = DEFAULT_SNIPPET_LENGTH // 2
+        half_window = max_length // 2
         start = max(0, match_index - half_window)
-        end = min(len(normalized_text), start + DEFAULT_SNIPPET_LENGTH)
-        start = max(0, end - DEFAULT_SNIPPET_LENGTH)
+        end = min(len(text), start + max_length)
+        start = max(0, end - max_length)
     else:
         start = 0
-        end = min(len(normalized_text), DEFAULT_SNIPPET_LENGTH)
+        end = min(len(text), max_length)
 
-    snippet = normalized_text[start:end].strip()
+    snippet = text[start:end].strip()
     if start > 0:
         snippet = f"…{snippet}"
-    if end < len(normalized_text):
+    if end < len(text):
         snippet = f"{snippet}…"
     return snippet
 

--- a/newsrag/search.py
+++ b/newsrag/search.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+import lancedb  # type: ignore[import-untyped]
+
+from newsrag.config import EmbeddingConfig
+from newsrag.embeddings import EmbeddingProvider, QueryEmbedding, build_embedding_provider
+from newsrag.ingest import VECTOR_TABLE_NAME
+
+DEFAULT_SEARCH_LIMIT = 5
+DEFAULT_KEYWORD_WEIGHT = 0.5
+DEFAULT_VECTOR_WEIGHT = 0.5
+DEFAULT_EMBEDDING_PROVIDER = "ollama"
+
+
+class SearchError(Exception):
+    """Raised when a search query cannot be executed."""
+
+
+@dataclass(frozen=True)
+class SearchCandidate:
+    """One keyword or vector candidate before ranking."""
+
+    chunk_id: str
+    document_id: str
+    page_start: int
+    page_end: int
+    text: str
+    title: str | None
+    meeting_date: str | None
+    keyword_score: float | None = None
+    vector_score: float | None = None
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    """One ranked evidence result returned to the user."""
+
+    chunk_id: str
+    document_id: str
+    page_start: int
+    page_end: int
+    text: str
+    citation: str
+    score: float
+    keyword_score: float | None
+    vector_score: float | None
+
+
+class Reranker(Protocol):
+    """Protocol for optional result reranking."""
+
+    def rerank(self, results: Sequence[SearchResult]) -> list[SearchResult]:
+        """Return results in reranked order."""
+
+
+@dataclass(frozen=True)
+class NoOpReranker:
+    """Default reranker hook that preserves result order."""
+
+    def rerank(self, results: Sequence[SearchResult]) -> list[SearchResult]:
+        return list(results)
+
+
+@dataclass(frozen=True)
+class LanceDbVectorSearcher:
+    """Vector candidate retrieval backed by LanceDB."""
+
+    lancedb_path: Path
+    table_name: str = VECTOR_TABLE_NAME
+
+    def search(self, query_embedding: QueryEmbedding, *, limit: int) -> list[SearchCandidate]:
+        database = lancedb.connect(self.lancedb_path)
+        try:
+            table = database.open_table(self.table_name)
+        except ValueError:
+            return []
+
+        rows = table.search(list(query_embedding.vector)).limit(limit).to_list()
+        return [
+            SearchCandidate(
+                chunk_id=str(row["chunk_id"]),
+                document_id=str(row["document_id"]),
+                page_start=int(row["page_start"]),
+                page_end=int(row["page_end"]),
+                text=str(row["text"]),
+                title=None,
+                meeting_date=None,
+                vector_score=float(row["_distance"]),
+            )
+            for row in rows
+            if isinstance(row, dict)
+        ]
+
+
+@dataclass(frozen=True)
+class SearchEngine:
+    """Hybrid keyword/vector search over one corpus."""
+
+    database_path: Path
+    vector_searcher: LanceDbVectorSearcher
+    embedding_provider: EmbeddingProvider
+    reranker: Reranker = NoOpReranker()
+    keyword_weight: float = DEFAULT_KEYWORD_WEIGHT
+    vector_weight: float = DEFAULT_VECTOR_WEIGHT
+
+    def search(self, query: str, *, limit: int = DEFAULT_SEARCH_LIMIT) -> list[SearchResult]:
+        normalized_query = query.strip()
+        if not normalized_query:
+            raise SearchError("Search query must not be empty")
+        if _count_chunks(self.database_path) == 0:
+            return []
+
+        keyword_candidates = search_keyword_candidates(
+            self.database_path,
+            normalized_query,
+            limit=limit,
+        )
+        query_embedding = self.embedding_provider.embed_query(normalized_query)
+        vector_candidates = self.vector_searcher.search(query_embedding, limit=limit)
+        results = merge_search_candidates(
+            keyword_candidates,
+            vector_candidates,
+            database_path=self.database_path,
+            limit=limit,
+            keyword_weight=self.keyword_weight,
+            vector_weight=self.vector_weight,
+        )
+        return self.reranker.rerank(results)
+
+
+def build_search_engine(
+    *,
+    database_path: Path,
+    lancedb_path: Path,
+    embedding_config: EmbeddingConfig,
+    embedding_provider: EmbeddingProvider | None = None,
+    vector_searcher: LanceDbVectorSearcher | None = None,
+    reranker: Reranker | None = None,
+) -> SearchEngine:
+    """Build the default hybrid search engine for one corpus."""
+
+    resolved_embedding_provider = embedding_provider or build_embedding_provider(
+        _resolve_embedding_config(embedding_config)
+    )
+    resolved_vector_searcher = vector_searcher or LanceDbVectorSearcher(lancedb_path)
+    return SearchEngine(
+        database_path=database_path,
+        vector_searcher=resolved_vector_searcher,
+        embedding_provider=resolved_embedding_provider,
+        reranker=reranker or NoOpReranker(),
+    )
+
+
+def search_keyword_candidates(
+    database_path: Path,
+    query: str,
+    *,
+    limit: int,
+) -> list[SearchCandidate]:
+    """Search keyword candidates from SQLite FTS5."""
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(
+            """
+            SELECT
+                chunks.id AS chunk_id,
+                chunks.document_id AS document_id,
+                chunks.page_start AS page_start,
+                chunks.page_end AS page_end,
+                chunks.text AS chunk_text,
+                documents.title AS title,
+                documents.metadata_json AS metadata_json,
+                bm25(chunks_fts) AS keyword_score
+            FROM chunks_fts
+            JOIN chunks ON chunks.id = chunks_fts.chunk_id
+            JOIN documents ON documents.id = chunks.document_id
+            WHERE chunks_fts MATCH ?
+            ORDER BY bm25(chunks_fts) ASC, chunks.id ASC
+            LIMIT ?
+            """,
+            (query, limit),
+        ).fetchall()
+
+    candidates: list[SearchCandidate] = []
+    for row in rows:
+        metadata = _load_metadata(row["metadata_json"])
+        meeting_date = _optional_string(metadata.get("meeting_date"))
+        candidates.append(
+            SearchCandidate(
+                chunk_id=str(row["chunk_id"]),
+                document_id=str(row["document_id"]),
+                page_start=int(row["page_start"]),
+                page_end=int(row["page_end"]),
+                text=str(row["chunk_text"]),
+                title=str(row["title"]) if row["title"] is not None else None,
+                meeting_date=meeting_date,
+                keyword_score=float(row["keyword_score"]),
+            )
+        )
+    return candidates
+
+
+def merge_search_candidates(
+    keyword_candidates: Sequence[SearchCandidate],
+    vector_candidates: Sequence[SearchCandidate],
+    *,
+    database_path: Path,
+    limit: int,
+    keyword_weight: float,
+    vector_weight: float,
+) -> list[SearchResult]:
+    """Merge keyword and vector candidates into ranked search results."""
+
+    chunk_context = _load_chunk_context(database_path, keyword_candidates, vector_candidates)
+    keyword_normalized = _normalize_lower_better_scores(
+        {candidate.chunk_id: candidate.keyword_score for candidate in keyword_candidates}
+    )
+    vector_normalized = _normalize_lower_better_scores(
+        {candidate.chunk_id: candidate.vector_score for candidate in vector_candidates}
+    )
+
+    merged: dict[str, SearchResult] = {}
+    for chunk_id in sorted(set(chunk_context)):
+        context = chunk_context[chunk_id]
+        keyword_score = context.keyword_score
+        vector_score = context.vector_score
+        score = keyword_weight * keyword_normalized.get(
+            chunk_id, 0.0
+        ) + vector_weight * vector_normalized.get(chunk_id, 0.0)
+        merged[chunk_id] = SearchResult(
+            chunk_id=context.chunk_id,
+            document_id=context.document_id,
+            page_start=context.page_start,
+            page_end=context.page_end,
+            text=context.text,
+            citation=format_citation(
+                title=context.title,
+                meeting_date=context.meeting_date,
+                page_number=context.page_start,
+            ),
+            score=score,
+            keyword_score=keyword_score,
+            vector_score=vector_score,
+        )
+
+    return sorted(
+        merged.values(),
+        key=lambda result: (-result.score, result.citation, result.chunk_id),
+    )[:limit]
+
+
+def format_citation(*, title: str | None, meeting_date: str | None, page_number: int) -> str:
+    """Format one concise terminal citation."""
+
+    parts = []
+    if title:
+        parts.append(title)
+    if meeting_date:
+        parts.append(meeting_date)
+    parts.append(f"p. {page_number}")
+    return " — ".join(parts)
+
+
+def format_search_results(results: Sequence[SearchResult]) -> str:
+    """Format ranked search results for terminal output."""
+
+    if not results:
+        return "No evidence found."
+
+    lines = ["NewsRAG Search"]
+    for result in results:
+        lines.append(result.citation)
+        lines.append(result.text)
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def _resolve_embedding_config(embedding_config: EmbeddingConfig) -> EmbeddingConfig:
+    if embedding_config.provider is not None:
+        return embedding_config
+
+    return EmbeddingConfig(
+        provider=DEFAULT_EMBEDDING_PROVIDER,
+        base_url=embedding_config.base_url,
+        model=embedding_config.model,
+        api_key_env=embedding_config.api_key_env,
+    )
+
+
+def _normalize_lower_better_scores(
+    scores: dict[str, float | None],
+) -> dict[str, float]:
+    filtered = {chunk_id: score for chunk_id, score in scores.items() if score is not None}
+    if not filtered:
+        return {}
+    if len(filtered) == 1:
+        only_chunk_id = next(iter(filtered))
+        return {only_chunk_id: 1.0}
+
+    values = list(filtered.values())
+    minimum = min(values)
+    maximum = max(values)
+    if minimum == maximum:
+        return dict.fromkeys(filtered, 1.0)
+
+    return {
+        chunk_id: (maximum - score) / (maximum - minimum) for chunk_id, score in filtered.items()
+    }
+
+
+def _load_chunk_context(
+    database_path: Path,
+    keyword_candidates: Sequence[SearchCandidate],
+    vector_candidates: Sequence[SearchCandidate],
+) -> dict[str, SearchCandidate]:
+    merged: dict[str, SearchCandidate] = {
+        candidate.chunk_id: candidate for candidate in keyword_candidates
+    }
+    chunk_ids_to_load = [
+        candidate.chunk_id for candidate in vector_candidates if candidate.chunk_id not in merged
+    ]
+
+    if chunk_ids_to_load:
+        placeholders = ", ".join("?" for _ in chunk_ids_to_load)
+        with sqlite3.connect(database_path) as connection:
+            connection.row_factory = sqlite3.Row
+            rows = connection.execute(
+                f"""
+                SELECT
+                    chunks.id AS chunk_id,
+                    chunks.document_id AS document_id,
+                    chunks.page_start AS page_start,
+                    chunks.page_end AS page_end,
+                    chunks.text AS chunk_text,
+                    documents.title AS title,
+                    documents.metadata_json AS metadata_json
+                FROM chunks
+                JOIN documents ON documents.id = chunks.document_id
+                WHERE chunks.id IN ({placeholders})
+                """,
+                tuple(chunk_ids_to_load),
+            ).fetchall()
+
+        for row in rows:
+            metadata = _load_metadata(row["metadata_json"])
+            merged[str(row["chunk_id"])] = SearchCandidate(
+                chunk_id=str(row["chunk_id"]),
+                document_id=str(row["document_id"]),
+                page_start=int(row["page_start"]),
+                page_end=int(row["page_end"]),
+                text=str(row["chunk_text"]),
+                title=str(row["title"]) if row["title"] is not None else None,
+                meeting_date=_optional_string(metadata.get("meeting_date")),
+            )
+
+    for candidate in vector_candidates:
+        existing = merged[candidate.chunk_id]
+        merged[candidate.chunk_id] = SearchCandidate(
+            chunk_id=existing.chunk_id,
+            document_id=existing.document_id,
+            page_start=existing.page_start,
+            page_end=existing.page_end,
+            text=existing.text,
+            title=existing.title,
+            meeting_date=existing.meeting_date,
+            keyword_score=existing.keyword_score,
+            vector_score=candidate.vector_score,
+        )
+
+    return merged
+
+
+def _count_chunks(database_path: Path) -> int:
+    with sqlite3.connect(database_path) as connection:
+        row = connection.execute("SELECT COUNT(*) FROM chunks").fetchone()
+    if row is None:
+        return 0
+    return int(row[0])
+
+
+def _load_metadata(raw_metadata: object) -> dict[str, object]:
+    if not isinstance(raw_metadata, str):
+        return {}
+    try:
+        metadata = json.loads(raw_metadata)
+    except ValueError:
+        return {}
+    if not isinstance(metadata, dict):
+        return {}
+    return metadata
+
+
+def _optional_string(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None

--- a/newsrag/search.py
+++ b/newsrag/search.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import json
-import re
 import sqlite3
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
@@ -11,16 +10,24 @@ from typing import Protocol
 import lancedb  # type: ignore[import-untyped]
 
 from newsrag.config import EmbeddingConfig
-from newsrag.embeddings import EmbeddingProvider, QueryEmbedding, build_embedding_provider
-from newsrag.ingest import VECTOR_TABLE_NAME
+from newsrag.embeddings import (
+    EmbeddingMetadata,
+    EmbeddingProvider,
+    QueryEmbedding,
+    build_embedding_provider,
+    create_embedding_record,
+)
 
 DEFAULT_SEARCH_LIMIT = 5
-DEFAULT_KEYWORD_WEIGHT = 0.5
-DEFAULT_VECTOR_WEIGHT = 0.5
+DEFAULT_SEARCH_CANDIDATE_LIMIT = 20
+DEFAULT_KEYWORD_WEIGHT = 0.6
+DEFAULT_VECTOR_WEIGHT = 0.4
 DEFAULT_MAX_VECTOR_DISTANCE = 1.0
-DEFAULT_SNIPPET_LENGTH = 320
-DEFAULT_PASSAGE_LENGTH = 700
+DEFAULT_VECTOR_DISTANCE_MARGIN_WITH_KEYWORD = 0.08
+DEFAULT_STRONG_VECTOR_DISTANCE_WITH_KEYWORD = 0.98
+DEFAULT_SNIPPET_LENGTH = 700
 DEFAULT_EMBEDDING_PROVIDER = "ollama"
+PASSAGE_VECTOR_TABLE_NAME = "passage_embeddings"
 
 
 class SearchError(Exception):
@@ -28,10 +35,23 @@ class SearchError(Exception):
 
 
 @dataclass(frozen=True)
+class PassageVectorRecord:
+    """One passage vector ready for LanceDB persistence."""
+
+    passage_id: str
+    document_id: str
+    page_start: int
+    page_end: int
+    text: str
+    vector: tuple[float, ...]
+    metadata: EmbeddingMetadata
+
+
+@dataclass(frozen=True)
 class SearchCandidate:
     """One keyword or vector candidate before ranking."""
 
-    chunk_id: str
+    passage_id: str
     document_id: str
     page_start: int
     page_end: int
@@ -46,7 +66,7 @@ class SearchCandidate:
 class SearchResult:
     """One ranked evidence result returned to the user."""
 
-    chunk_id: str
+    passage_id: str
     document_id: str
     page_start: int
     page_end: int
@@ -71,6 +91,13 @@ class VectorSearcher(Protocol):
         """Return vector candidates for one embedded query."""
 
 
+class VectorStore(Protocol):
+    """Protocol for vector persistence."""
+
+    def add_passages(self, passages: Sequence[PassageVectorRecord]) -> None:
+        """Persist embedded passage vectors."""
+
+
 @dataclass(frozen=True)
 class NoOpReranker:
     """Default reranker hook that preserves result order."""
@@ -80,11 +107,47 @@ class NoOpReranker:
 
 
 @dataclass(frozen=True)
-class LanceDbVectorSearcher:
-    """Vector candidate retrieval backed by LanceDB."""
+class LanceDbPassageVectorStore:
+    """Passage vector persistence backed by LanceDB."""
 
     lancedb_path: Path
-    table_name: str = VECTOR_TABLE_NAME
+    table_name: str = PASSAGE_VECTOR_TABLE_NAME
+
+    def add_passages(self, passages: Sequence[PassageVectorRecord]) -> None:
+        if not passages:
+            return
+
+        records = [
+            {
+                "passage_id": passage.passage_id,
+                "document_id": passage.document_id,
+                "page_start": passage.page_start,
+                "page_end": passage.page_end,
+                "text": passage.text,
+                "vector": list(passage.vector),
+                "provider": passage.metadata.provider,
+                "model": passage.metadata.model,
+                "version": passage.metadata.version,
+            }
+            for passage in passages
+        ]
+
+        database = lancedb.connect(self.lancedb_path)
+        try:
+            table = database.open_table(self.table_name)
+        except ValueError:
+            database.create_table(self.table_name, data=records)
+            return
+
+        table.add(records)
+
+
+@dataclass(frozen=True)
+class LanceDbPassageVectorSearcher:
+    """Passage vector search backed by LanceDB."""
+
+    lancedb_path: Path
+    table_name: str = PASSAGE_VECTOR_TABLE_NAME
     max_vector_distance: float | None = DEFAULT_MAX_VECTOR_DISTANCE
 
     def search(self, query_embedding: QueryEmbedding, *, limit: int) -> list[SearchCandidate]:
@@ -104,7 +167,7 @@ class LanceDbVectorSearcher:
                 continue
             candidates.append(
                 SearchCandidate(
-                    chunk_id=str(row["chunk_id"]),
+                    passage_id=str(row["passage_id"]),
                     document_id=str(row["document_id"]),
                     page_start=int(row["page_start"]),
                     page_end=int(row["page_end"]),
@@ -123,6 +186,7 @@ class SearchEngine:
 
     database_path: Path
     vector_searcher: VectorSearcher
+    vector_store: VectorStore
     embedding_provider: EmbeddingProvider
     reranker: Reranker = NoOpReranker()
     keyword_weight: float = DEFAULT_KEYWORD_WEIGHT
@@ -132,18 +196,28 @@ class SearchEngine:
         normalized_query = query.strip()
         if not normalized_query:
             raise SearchError("Search query must not be empty")
-        if _count_chunks(self.database_path) == 0:
+        if _count_passages(self.database_path) == 0:
             return []
 
-        keyword_candidates = search_keyword_candidates(
+        _ensure_passage_embeddings(
             self.database_path,
-            normalized_query,
-            limit=limit,
+            embedding_provider=self.embedding_provider,
+            vector_store=self.vector_store,
+        )
+        candidate_limit = max(limit * 4, DEFAULT_SEARCH_CANDIDATE_LIMIT)
+        keyword_candidates = _expand_contextual_keyword_candidates(
+            self.database_path,
+            search_keyword_candidates(
+                self.database_path,
+                normalized_query,
+                limit=candidate_limit,
+            ),
+            limit=candidate_limit,
         )
         query_embedding = self.embedding_provider.embed_query(normalized_query)
         vector_candidates = _filter_vector_candidates(
             keyword_candidates,
-            self.vector_searcher.search(query_embedding, limit=limit),
+            self.vector_searcher.search(query_embedding, limit=candidate_limit),
         )
         results = merge_search_candidates(
             keyword_candidates,
@@ -163,6 +237,7 @@ def build_search_engine(
     embedding_config: EmbeddingConfig,
     embedding_provider: EmbeddingProvider | None = None,
     vector_searcher: VectorSearcher | None = None,
+    vector_store: VectorStore | None = None,
     reranker: Reranker | None = None,
 ) -> SearchEngine:
     """Build the default hybrid search engine for one corpus."""
@@ -170,24 +245,15 @@ def build_search_engine(
     resolved_embedding_provider = embedding_provider or build_embedding_provider(
         _resolve_embedding_config(embedding_config)
     )
-    resolved_vector_searcher = vector_searcher or LanceDbVectorSearcher(lancedb_path)
+    resolved_vector_store = vector_store or LanceDbPassageVectorStore(lancedb_path)
+    resolved_vector_searcher = vector_searcher or LanceDbPassageVectorSearcher(lancedb_path)
     return SearchEngine(
         database_path=database_path,
         vector_searcher=resolved_vector_searcher,
+        vector_store=resolved_vector_store,
         embedding_provider=resolved_embedding_provider,
         reranker=reranker or NoOpReranker(),
     )
-
-
-def _filter_vector_candidates(
-    keyword_candidates: Sequence[SearchCandidate],
-    vector_candidates: Sequence[SearchCandidate],
-) -> list[SearchCandidate]:
-    if not keyword_candidates:
-        return list(vector_candidates)
-
-    keyword_chunk_ids = {candidate.chunk_id for candidate in keyword_candidates}
-    return [candidate for candidate in vector_candidates if candidate.chunk_id in keyword_chunk_ids]
 
 
 def search_keyword_candidates(
@@ -203,19 +269,19 @@ def search_keyword_candidates(
         rows = connection.execute(
             """
             SELECT
-                chunks.id AS chunk_id,
-                chunks.document_id AS document_id,
-                chunks.page_start AS page_start,
-                chunks.page_end AS page_end,
-                chunks.text AS chunk_text,
+                passages.id AS passage_id,
+                passages.document_id AS document_id,
+                passages.page_start AS page_start,
+                passages.page_end AS page_end,
+                passages.text AS passage_text,
                 documents.title AS title,
                 documents.metadata_json AS metadata_json,
-                bm25(chunks_fts) AS keyword_score
-            FROM chunks_fts
-            JOIN chunks ON chunks.id = chunks_fts.chunk_id
-            JOIN documents ON documents.id = chunks.document_id
-            WHERE chunks_fts MATCH ?
-            ORDER BY bm25(chunks_fts) ASC, chunks.id ASC
+                bm25(passages_fts) AS keyword_score
+            FROM passages_fts
+            JOIN passages ON passages.id = passages_fts.passage_id
+            JOIN documents ON documents.id = passages.document_id
+            WHERE passages_fts MATCH ?
+            ORDER BY bm25(passages_fts) ASC, passages.id ASC
             LIMIT ?
             """,
             (query, limit),
@@ -224,16 +290,15 @@ def search_keyword_candidates(
     candidates: list[SearchCandidate] = []
     for row in rows:
         metadata = _load_metadata(row["metadata_json"])
-        meeting_date = _optional_string(metadata.get("meeting_date"))
         candidates.append(
             SearchCandidate(
-                chunk_id=str(row["chunk_id"]),
+                passage_id=str(row["passage_id"]),
                 document_id=str(row["document_id"]),
                 page_start=int(row["page_start"]),
                 page_end=int(row["page_end"]),
-                text=str(row["chunk_text"]),
+                text=str(row["passage_text"]),
                 title=str(row["title"]) if row["title"] is not None else None,
-                meeting_date=meeting_date,
+                meeting_date=_optional_string(metadata.get("meeting_date")),
                 keyword_score=float(row["keyword_score"]),
             )
         )
@@ -251,24 +316,22 @@ def merge_search_candidates(
 ) -> list[SearchResult]:
     """Merge keyword and vector candidates into ranked search results."""
 
-    chunk_context = _load_chunk_context(database_path, keyword_candidates, vector_candidates)
+    passage_context = _load_passage_context(database_path, keyword_candidates, vector_candidates)
     keyword_normalized = _normalize_lower_better_scores(
-        {candidate.chunk_id: candidate.keyword_score for candidate in keyword_candidates}
+        {candidate.passage_id: candidate.keyword_score for candidate in keyword_candidates}
     )
     vector_normalized = _normalize_lower_better_scores(
-        {candidate.chunk_id: candidate.vector_score for candidate in vector_candidates}
+        {candidate.passage_id: candidate.vector_score for candidate in vector_candidates}
     )
 
     merged: dict[str, SearchResult] = {}
-    for chunk_id in sorted(set(chunk_context)):
-        context = chunk_context[chunk_id]
-        keyword_score = context.keyword_score
-        vector_score = context.vector_score
+    for passage_id in sorted(set(passage_context)):
+        context = passage_context[passage_id]
         score = keyword_weight * keyword_normalized.get(
-            chunk_id, 0.0
-        ) + vector_weight * vector_normalized.get(chunk_id, 0.0)
-        merged[chunk_id] = SearchResult(
-            chunk_id=context.chunk_id,
+            passage_id, 0.0
+        ) + vector_weight * vector_normalized.get(passage_id, 0.0)
+        merged[passage_id] = SearchResult(
+            passage_id=context.passage_id,
             document_id=context.document_id,
             page_start=context.page_start,
             page_end=context.page_end,
@@ -279,13 +342,13 @@ def merge_search_candidates(
                 page_number=context.page_start,
             ),
             score=score,
-            keyword_score=keyword_score,
-            vector_score=vector_score,
+            keyword_score=context.keyword_score,
+            vector_score=context.vector_score,
         )
 
     return sorted(
         merged.values(),
-        key=lambda result: (-result.score, result.citation, result.chunk_id),
+        key=lambda result: (-result.score, result.citation, result.passage_id),
     )[:limit]
 
 
@@ -310,72 +373,178 @@ def format_search_results(results: Sequence[SearchResult], *, query: str | None 
     lines = ["NewsRAG Search"]
     for result in results:
         lines.append(result.citation)
-        lines.append(_build_display_snippet(result.text, query=query))
+        lines.append(_truncate_text(" ".join(result.text.split()), query=query))
         lines.append("")
     return "\n".join(lines).rstrip()
 
 
-def _build_display_snippet(text: str, *, query: str | None) -> str:
-    passage = _select_relevant_passage(text, query=query)
-    normalized_passage = " ".join(passage.split())
-    if len(normalized_passage) <= DEFAULT_PASSAGE_LENGTH:
-        return normalized_passage
-    return _truncate_text(normalized_passage, query=query, max_length=DEFAULT_SNIPPET_LENGTH)
+def _ensure_passage_embeddings(
+    database_path: Path,
+    *,
+    embedding_provider: EmbeddingProvider,
+    vector_store: VectorStore,
+) -> None:
+    metadata = _embedding_metadata(embedding_provider)
+    missing_passages = _load_missing_passages(database_path, metadata)
+    if not missing_passages:
+        return
+
+    for batch in _batched(missing_passages, size=32):
+        embeddings = embedding_provider.embed_chunks([passage.text for passage in batch])
+        vector_store.add_passages(
+            [
+                PassageVectorRecord(
+                    passage_id=passage.passage_id,
+                    document_id=passage.document_id,
+                    page_start=passage.page_start,
+                    page_end=passage.page_end,
+                    text=passage.text,
+                    vector=embedding.vector,
+                    metadata=embedding.metadata,
+                )
+                for passage, embedding in zip(batch, embeddings, strict=True)
+            ]
+        )
+        for passage, embedding in zip(batch, embeddings, strict=True):
+            create_embedding_record(
+                database_path,
+                source_kind="passage",
+                source_key=passage.passage_id,
+                embedding=embedding,
+            )
 
 
-def _select_relevant_passage(text: str, *, query: str | None) -> str:
-    paragraphs = [
-        paragraph.strip() for paragraph in re.split(r"\n\s*\n+", text) if paragraph.strip()
+@dataclass(frozen=True)
+class _PassageForEmbedding:
+    passage_id: str
+    document_id: str
+    page_start: int
+    page_end: int
+    text: str
+
+
+def _load_missing_passages(
+    database_path: Path,
+    metadata: EmbeddingMetadata,
+) -> list[_PassageForEmbedding]:
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(
+            """
+            SELECT
+                passages.id AS passage_id,
+                passages.document_id AS document_id,
+                passages.page_start AS page_start,
+                passages.page_end AS page_end,
+                passages.text AS passage_text
+            FROM passages
+            LEFT JOIN embedding_records
+                ON embedding_records.source_kind = 'passage'
+                AND embedding_records.source_key = passages.id
+                AND embedding_records.provider = ?
+                AND embedding_records.model = ?
+                AND embedding_records.version = ?
+            WHERE embedding_records.id IS NULL
+            ORDER BY passages.document_id ASC, passages.page_start ASC, passages.ordinal ASC, passages.id ASC
+            """,
+            (metadata.provider, metadata.model, metadata.version),
+        ).fetchall()
+
+    return [
+        _PassageForEmbedding(
+            passage_id=str(row["passage_id"]),
+            document_id=str(row["document_id"]),
+            page_start=int(row["page_start"]),
+            page_end=int(row["page_end"]),
+            text=str(row["passage_text"]),
+        )
+        for row in rows
     ]
-    if not paragraphs:
-        return text
 
-    scored_paragraphs = [
-        (_score_passage(paragraph, query=query), index, paragraph)
-        for index, paragraph in enumerate(paragraphs)
+
+def _embedding_metadata(embedding_provider: EmbeddingProvider) -> EmbeddingMetadata:
+    metadata = getattr(embedding_provider, "metadata", None)
+    if isinstance(metadata, EmbeddingMetadata):
+        return metadata
+    return embedding_provider.embed_query("metadata probe").metadata
+
+
+def _filter_vector_candidates(
+    keyword_candidates: Sequence[SearchCandidate],
+    vector_candidates: Sequence[SearchCandidate],
+) -> list[SearchCandidate]:
+    if not keyword_candidates:
+        return list(vector_candidates)
+
+    keyword_passage_ids = {candidate.passage_id for candidate in keyword_candidates}
+    if len(keyword_candidates) >= 2:
+        return [
+            candidate
+            for candidate in vector_candidates
+            if candidate.passage_id in keyword_passage_ids
+        ]
+
+    overlapping = [
+        candidate
+        for candidate in vector_candidates
+        if candidate.passage_id in keyword_passage_ids and candidate.vector_score is not None
     ]
-    best_score, _, best_paragraph = max(scored_paragraphs, key=lambda item: (item[0], -item[1]))
-    if best_score > 0:
-        return best_paragraph
-    return text
+    if not overlapping:
+        return []
 
-
-def _score_passage(text: str, *, query: str | None) -> int:
-    normalized_text = " ".join(text.split()).casefold()
-    normalized_query = " ".join((query or "").split()).casefold()
-    query_terms = [term.casefold() for term in (query or "").split() if term.strip()]
-    phrase_hits = normalized_text.count(normalized_query) if normalized_query else 0
-    unique_term_hits = sum(1 for term in set(query_terms) if term in normalized_text)
-    term_hits = sum(normalized_text.count(term) for term in query_terms)
-    return phrase_hits * 100 + unique_term_hits * 10 + term_hits
-
-
-def _truncate_text(text: str, *, query: str | None, max_length: int) -> str:
-    if len(text) <= max_length:
-        return text
-
-    query_terms = [term.casefold() for term in (query or "").split() if term.strip()]
-    lowered_text = text.casefold()
-    match_index = min(
-        (index for term in query_terms if (index := lowered_text.find(term)) >= 0),
-        default=-1,
+    best_overlap_distance = min(
+        candidate.vector_score for candidate in overlapping if candidate.vector_score is not None
     )
+    max_allowed_distance = min(
+        DEFAULT_STRONG_VECTOR_DISTANCE_WITH_KEYWORD,
+        best_overlap_distance + DEFAULT_VECTOR_DISTANCE_MARGIN_WITH_KEYWORD,
+    )
+    return [
+        candidate
+        for candidate in vector_candidates
+        if candidate.passage_id in keyword_passage_ids
+        or (candidate.vector_score is not None and candidate.vector_score <= max_allowed_distance)
+    ]
 
-    if match_index >= 0:
-        half_window = max_length // 2
-        start = max(0, match_index - half_window)
-        end = min(len(text), start + max_length)
-        start = max(0, end - max_length)
-    else:
-        start = 0
-        end = min(len(text), max_length)
 
-    snippet = text[start:end].strip()
-    if start > 0:
-        snippet = f"…{snippet}"
-    if end < len(text):
-        snippet = f"{snippet}…"
-    return snippet
+def _expand_contextual_keyword_candidates(
+    database_path: Path,
+    keyword_candidates: Sequence[SearchCandidate],
+    *,
+    limit: int,
+) -> list[SearchCandidate]:
+    expanded = list(keyword_candidates)
+    seen_passage_ids = {candidate.passage_id for candidate in keyword_candidates}
+    chunk_hit_counts = _load_chunk_hit_counts(database_path, keyword_candidates)
+
+    for candidate in keyword_candidates:
+        if len(expanded) >= limit:
+            break
+        if chunk_hit_counts.get(candidate.passage_id, 0) > 1:
+            continue
+        if not candidate.text.startswith("•") or len(candidate.text) > 220:
+            continue
+
+        for neighbor in _load_adjacent_passages(database_path, candidate.passage_id):
+            if len(expanded) >= limit or neighbor.passage_id in seen_passage_ids:
+                continue
+            if not neighbor.text.startswith("•") or len(neighbor.text) > 320:
+                continue
+            expanded.append(
+                SearchCandidate(
+                    passage_id=neighbor.passage_id,
+                    document_id=neighbor.document_id,
+                    page_start=neighbor.page_start,
+                    page_end=neighbor.page_end,
+                    text=neighbor.text,
+                    title=neighbor.title,
+                    meeting_date=neighbor.meeting_date,
+                    keyword_score=(candidate.keyword_score or 0.0) + 0.5,
+                )
+            )
+            seen_passage_ids.add(neighbor.passage_id)
+
+    return expanded
 
 
 def _resolve_embedding_config(embedding_config: EmbeddingConfig) -> EmbeddingConfig:
@@ -390,15 +559,13 @@ def _resolve_embedding_config(embedding_config: EmbeddingConfig) -> EmbeddingCon
     )
 
 
-def _normalize_lower_better_scores(
-    scores: dict[str, float | None],
-) -> dict[str, float]:
-    filtered = {chunk_id: score for chunk_id, score in scores.items() if score is not None}
+def _normalize_lower_better_scores(scores: dict[str, float | None]) -> dict[str, float]:
+    filtered = {passage_id: score for passage_id, score in scores.items() if score is not None}
     if not filtered:
         return {}
     if len(filtered) == 1:
-        only_chunk_id = next(iter(filtered))
-        return {only_chunk_id: 1.0}
+        only_passage_id = next(iter(filtered))
+        return {only_passage_id: 1.0}
 
     values = list(filtered.values())
     minimum = min(values)
@@ -407,59 +574,62 @@ def _normalize_lower_better_scores(
         return dict.fromkeys(filtered, 1.0)
 
     return {
-        chunk_id: (maximum - score) / (maximum - minimum) for chunk_id, score in filtered.items()
+        passage_id: (maximum - score) / (maximum - minimum)
+        for passage_id, score in filtered.items()
     }
 
 
-def _load_chunk_context(
+def _load_passage_context(
     database_path: Path,
     keyword_candidates: Sequence[SearchCandidate],
     vector_candidates: Sequence[SearchCandidate],
 ) -> dict[str, SearchCandidate]:
     merged: dict[str, SearchCandidate] = {
-        candidate.chunk_id: candidate for candidate in keyword_candidates
+        candidate.passage_id: candidate for candidate in keyword_candidates
     }
-    chunk_ids_to_load = [
-        candidate.chunk_id for candidate in vector_candidates if candidate.chunk_id not in merged
+    passage_ids_to_load = [
+        candidate.passage_id
+        for candidate in vector_candidates
+        if candidate.passage_id not in merged
     ]
 
-    if chunk_ids_to_load:
-        placeholders = ", ".join("?" for _ in chunk_ids_to_load)
+    if passage_ids_to_load:
+        placeholders = ", ".join("?" for _ in passage_ids_to_load)
         with sqlite3.connect(database_path) as connection:
             connection.row_factory = sqlite3.Row
             rows = connection.execute(
                 f"""
                 SELECT
-                    chunks.id AS chunk_id,
-                    chunks.document_id AS document_id,
-                    chunks.page_start AS page_start,
-                    chunks.page_end AS page_end,
-                    chunks.text AS chunk_text,
+                    passages.id AS passage_id,
+                    passages.document_id AS document_id,
+                    passages.page_start AS page_start,
+                    passages.page_end AS page_end,
+                    passages.text AS passage_text,
                     documents.title AS title,
                     documents.metadata_json AS metadata_json
-                FROM chunks
-                JOIN documents ON documents.id = chunks.document_id
-                WHERE chunks.id IN ({placeholders})
+                FROM passages
+                JOIN documents ON documents.id = passages.document_id
+                WHERE passages.id IN ({placeholders})
                 """,
-                tuple(chunk_ids_to_load),
+                tuple(passage_ids_to_load),
             ).fetchall()
 
         for row in rows:
             metadata = _load_metadata(row["metadata_json"])
-            merged[str(row["chunk_id"])] = SearchCandidate(
-                chunk_id=str(row["chunk_id"]),
+            merged[str(row["passage_id"])] = SearchCandidate(
+                passage_id=str(row["passage_id"]),
                 document_id=str(row["document_id"]),
                 page_start=int(row["page_start"]),
                 page_end=int(row["page_end"]),
-                text=str(row["chunk_text"]),
+                text=str(row["passage_text"]),
                 title=str(row["title"]) if row["title"] is not None else None,
                 meeting_date=_optional_string(metadata.get("meeting_date")),
             )
 
     for candidate in vector_candidates:
-        existing = merged[candidate.chunk_id]
-        merged[candidate.chunk_id] = SearchCandidate(
-            chunk_id=existing.chunk_id,
+        existing = merged[candidate.passage_id]
+        merged[candidate.passage_id] = SearchCandidate(
+            passage_id=existing.passage_id,
             document_id=existing.document_id,
             page_start=existing.page_start,
             page_end=existing.page_end,
@@ -473,9 +643,84 @@ def _load_chunk_context(
     return merged
 
 
-def _count_chunks(database_path: Path) -> int:
+def _load_chunk_hit_counts(
+    database_path: Path,
+    keyword_candidates: Sequence[SearchCandidate],
+) -> dict[str, int]:
+    if not keyword_candidates:
+        return {}
+
+    passage_ids = [candidate.passage_id for candidate in keyword_candidates]
+    placeholders = ", ".join("?" for _ in passage_ids)
     with sqlite3.connect(database_path) as connection:
-        row = connection.execute("SELECT COUNT(*) FROM chunks").fetchone()
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(
+            f"""
+            SELECT candidate.id AS passage_id, chunk_counts.hit_count AS hit_count
+            FROM passages AS candidate
+            JOIN (
+                SELECT chunk_id, COUNT(*) AS hit_count
+                FROM passages
+                WHERE id IN ({placeholders})
+                GROUP BY chunk_id
+            ) AS chunk_counts
+                ON chunk_counts.chunk_id = candidate.chunk_id
+            WHERE candidate.id IN ({placeholders})
+            """,
+            tuple(passage_ids + passage_ids),
+        ).fetchall()
+
+    return {str(row["passage_id"]): int(row["hit_count"]) for row in rows}
+
+
+def _load_adjacent_passages(
+    database_path: Path,
+    passage_id: str,
+) -> list[SearchCandidate]:
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(
+            """
+            WITH origin AS (
+                SELECT chunk_id, ordinal
+                FROM passages
+                WHERE id = ?
+            )
+            SELECT
+                passages.id AS passage_id,
+                passages.document_id AS document_id,
+                passages.page_start AS page_start,
+                passages.page_end AS page_end,
+                passages.text AS passage_text,
+                documents.title AS title,
+                documents.metadata_json AS metadata_json
+            FROM passages
+            JOIN origin
+                ON passages.chunk_id = origin.chunk_id
+                AND ABS(passages.ordinal - origin.ordinal) = 1
+            JOIN documents ON documents.id = passages.document_id
+            ORDER BY passages.ordinal ASC, passages.id ASC
+            """,
+            (passage_id,),
+        ).fetchall()
+
+    return [
+        SearchCandidate(
+            passage_id=str(row["passage_id"]),
+            document_id=str(row["document_id"]),
+            page_start=int(row["page_start"]),
+            page_end=int(row["page_end"]),
+            text=str(row["passage_text"]),
+            title=str(row["title"]) if row["title"] is not None else None,
+            meeting_date=_optional_string(_load_metadata(row["metadata_json"]).get("meeting_date")),
+        )
+        for row in rows
+    ]
+
+
+def _count_passages(database_path: Path) -> int:
+    with sqlite3.connect(database_path) as connection:
+        row = connection.execute("SELECT COUNT(*) FROM passages").fetchone()
     if row is None:
         return 0
     return int(row[0])
@@ -497,3 +742,39 @@ def _optional_string(value: object) -> str | None:
     if isinstance(value, str) and value.strip():
         return value.strip()
     return None
+
+
+def _truncate_text(
+    text: str, *, query: str | None, max_length: int = DEFAULT_SNIPPET_LENGTH
+) -> str:
+    if len(text) <= max_length:
+        return text
+
+    query_terms = [term.casefold() for term in (query or "").split() if term.strip()]
+    lowered_text = text.casefold()
+    match_index = min(
+        (index for term in query_terms if (index := lowered_text.find(term)) >= 0),
+        default=-1,
+    )
+    if match_index >= 0:
+        half_window = max_length // 2
+        start = max(0, match_index - half_window)
+        end = min(len(text), start + max_length)
+        start = max(0, end - max_length)
+    else:
+        start = 0
+        end = min(len(text), max_length)
+
+    snippet = text[start:end].strip()
+    if start > 0:
+        snippet = f"…{snippet}"
+    if end < len(text):
+        snippet = f"{snippet}…"
+    return snippet
+
+
+def _batched(
+    values: Sequence[_PassageForEmbedding], *, size: int
+) -> Iterator[Sequence[_PassageForEmbedding]]:
+    for index in range(0, len(values), size):
+        yield values[index : index + size]

--- a/newsrag/search.py
+++ b/newsrag/search.py
@@ -62,6 +62,13 @@ class Reranker(Protocol):
         """Return results in reranked order."""
 
 
+class VectorSearcher(Protocol):
+    """Protocol for vector candidate retrieval."""
+
+    def search(self, query_embedding: QueryEmbedding, *, limit: int) -> list[SearchCandidate]:
+        """Return vector candidates for one embedded query."""
+
+
 @dataclass(frozen=True)
 class NoOpReranker:
     """Default reranker hook that preserves result order."""
@@ -113,7 +120,7 @@ class SearchEngine:
     """Hybrid keyword/vector search over one corpus."""
 
     database_path: Path
-    vector_searcher: LanceDbVectorSearcher
+    vector_searcher: VectorSearcher
     embedding_provider: EmbeddingProvider
     reranker: Reranker = NoOpReranker()
     keyword_weight: float = DEFAULT_KEYWORD_WEIGHT
@@ -132,7 +139,10 @@ class SearchEngine:
             limit=limit,
         )
         query_embedding = self.embedding_provider.embed_query(normalized_query)
-        vector_candidates = self.vector_searcher.search(query_embedding, limit=limit)
+        vector_candidates = _filter_vector_candidates(
+            keyword_candidates,
+            self.vector_searcher.search(query_embedding, limit=limit),
+        )
         results = merge_search_candidates(
             keyword_candidates,
             vector_candidates,
@@ -150,7 +160,7 @@ def build_search_engine(
     lancedb_path: Path,
     embedding_config: EmbeddingConfig,
     embedding_provider: EmbeddingProvider | None = None,
-    vector_searcher: LanceDbVectorSearcher | None = None,
+    vector_searcher: VectorSearcher | None = None,
     reranker: Reranker | None = None,
 ) -> SearchEngine:
     """Build the default hybrid search engine for one corpus."""
@@ -165,6 +175,17 @@ def build_search_engine(
         embedding_provider=resolved_embedding_provider,
         reranker=reranker or NoOpReranker(),
     )
+
+
+def _filter_vector_candidates(
+    keyword_candidates: Sequence[SearchCandidate],
+    vector_candidates: Sequence[SearchCandidate],
+) -> list[SearchCandidate]:
+    if not keyword_candidates:
+        return list(vector_candidates)
+
+    keyword_chunk_ids = {candidate.chunk_id for candidate in keyword_candidates}
+    return [candidate for candidate in vector_candidates if candidate.chunk_id in keyword_chunk_ids]
 
 
 def search_keyword_candidates(

--- a/newsrag/storage.py
+++ b/newsrag/storage.py
@@ -5,6 +5,8 @@ import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 
+from newsrag.passages import build_passage_rows
+
 
 class StorageError(Exception):
     """Raised when the NewsRAG storage layout cannot be initialized or inspected."""
@@ -71,6 +73,8 @@ REQUIRED_TABLES = {
     "pages",
     "chunks",
     "chunks_fts",
+    "passages",
+    "passages_fts",
     "jobs",
     "watches",
     "watch_files",
@@ -121,6 +125,27 @@ SCHEMA_STATEMENTS = (
     CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
         chunk_id UNINDEXED,
         text
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS passages (
+        id TEXT PRIMARY KEY,
+        chunk_id TEXT NOT NULL,
+        document_id TEXT NOT NULL,
+        page_start INTEGER NOT NULL,
+        page_end INTEGER NOT NULL,
+        ordinal INTEGER NOT NULL,
+        text TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(chunk_id) REFERENCES chunks(id),
+        FOREIGN KEY(document_id) REFERENCES documents(id)
+    )
+    """,
+    """
+    CREATE VIRTUAL TABLE IF NOT EXISTS passages_fts USING fts5(
+        passage_id UNINDEXED,
+        text,
+        tokenize='porter unicode61'
     )
     """,
     """
@@ -312,11 +337,63 @@ def _initialize_database(database_path: Path) -> None:
             WHERE chunks.id NOT IN (SELECT chunk_id FROM chunks_fts)
             """
         )
+        _backfill_passages(connection)
+        connection.execute(
+            """
+            INSERT INTO passages_fts(passage_id, text)
+            SELECT passages.id, passages.text
+            FROM passages
+            WHERE passages.id NOT IN (SELECT passage_id FROM passages_fts)
+            """
+        )
         connection.execute(
             "INSERT OR IGNORE INTO metadata(key, value) VALUES(?, ?)",
             ("schema_version", SCHEMA_VERSION),
         )
         connection.commit()
+
+
+def _backfill_passages(connection: sqlite3.Connection) -> None:
+    rows = connection.execute(
+        """
+        SELECT id, document_id, page_start, page_end, text
+        FROM chunks
+        WHERE id NOT IN (SELECT DISTINCT chunk_id FROM passages)
+        ORDER BY id ASC
+        """
+    ).fetchall()
+    passage_rows = []
+    for row in rows:
+        passage_rows.extend(
+            build_passage_rows(
+                chunk_id=str(row[0]),
+                document_id=str(row[1]),
+                page_start=int(row[2]),
+                page_end=int(row[3]),
+                text=str(row[4]),
+            )
+        )
+    if not passage_rows:
+        return
+
+    connection.executemany(
+        """
+        INSERT INTO passages(id, chunk_id, document_id, page_start, page_end, ordinal, text)
+        VALUES(?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                row.id,
+                row.chunk_id,
+                row.document_id,
+                row.page_start,
+                row.page_end,
+                row.ordinal,
+                row.text,
+            )
+            for row in passage_rows
+        ],
+    )
 
 
 def _ensure_column(

--- a/newsrag/storage.py
+++ b/newsrag/storage.py
@@ -70,6 +70,7 @@ REQUIRED_TABLES = {
     "documents",
     "pages",
     "chunks",
+    "chunks_fts",
     "jobs",
     "watches",
     "watch_files",
@@ -114,6 +115,12 @@ SCHEMA_STATEMENTS = (
         text TEXT NOT NULL DEFAULT '',
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY(document_id) REFERENCES documents(id)
+    )
+    """,
+    """
+    CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
+        chunk_id UNINDEXED,
+        text
     )
     """,
     """
@@ -296,6 +303,14 @@ def _initialize_database(database_path: Path) -> None:
         _ensure_column(connection, "documents", "metadata_json", "TEXT NOT NULL DEFAULT '{}'")
         connection.execute(
             "CREATE INDEX IF NOT EXISTS idx_documents_source_hash ON documents(source_hash)"
+        )
+        connection.execute(
+            """
+            INSERT INTO chunks_fts(chunk_id, text)
+            SELECT chunks.id, chunks.text
+            FROM chunks
+            WHERE chunks.id NOT IN (SELECT chunk_id FROM chunks_fts)
+            """
         )
         connection.execute(
             "INSERT OR IGNORE INTO metadata(key, value) VALUES(?, ?)",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,7 @@ def test_help_shows_cli_commands() -> None:
     assert "ingest" in result.stdout
     assert "ingest-url" in result.stdout
     assert "ingest-manifest" in result.stdout
+    assert "search" in result.stdout
     assert "jobs" in result.stdout
     assert "watch" in result.stdout
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -442,7 +442,8 @@ def test_mocked_local_pdf_job_creates_document_pages_chunks_and_vector_records(
     assert len(pages) == 2
     assert len(chunks) == 2
     assert len(vectors) == 2
-    assert len(embedding_records) == 2
+    assert len(embedding_records) == 4
+    assert {record.source_kind for record in embedding_records} == {"chunk", "passage"}
     assert {record.provider for record in embedding_records} == {"ollama"}
     assert {vector["document_id"] for vector in vectors} == {documents[0].id}
 
@@ -487,7 +488,7 @@ def test_reingesting_unchanged_pdf_does_not_duplicate_records(tmp_path: Path) ->
     assert len(list_pages(paths.database)) == 1
     assert len(list_chunks(paths.database)) == 1
     assert len(list_chunk_vectors(paths.lancedb)) == 1
-    assert len(list_embedding_records(paths.database)) == 1
+    assert len(list_embedding_records(paths.database)) == 2
 
 
 def test_ingest_failures_are_recorded_with_context(tmp_path: Path) -> None:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -10,16 +10,16 @@ from typer.testing import CliRunner
 from newsrag.cli import app
 from newsrag.config import EmbeddingConfig
 from newsrag.embeddings import ChunkEmbedding, EmbeddingMetadata, QueryEmbedding
-from newsrag.ingest import ChunkVectorRecord, LanceDbVectorStore
 from newsrag.search import (
+    PassageVectorRecord,
     SearchCandidate,
     SearchResult,
     build_search_engine,
     format_citation,
     format_search_results,
-    merge_search_candidates,
+    search_keyword_candidates,
 )
-from newsrag.storage import StoragePaths, initialize_storage
+from newsrag.storage import initialize_storage
 
 runner = CliRunner()
 
@@ -33,190 +33,235 @@ class FakeQueryEmbeddingProvider:
     )
 
     def embed_query(self, text: str) -> QueryEmbedding:
-        if text == "stormwater downtown":
-            return QueryEmbedding(text=text, vector=(0.1, 0.1), metadata=self.metadata)
-        return QueryEmbedding(text=text, vector=(2.0, 2.0), metadata=self.metadata)
+        vectors = {
+            "stormwater downtown": (0.1, 0.1),
+            "semantic zoning": (0.2, 0.2),
+            "games": (0.3, 0.3),
+            "Belt filter Press": (0.4, 0.4),
+            "banana telescope": (2.0, 2.0),
+            "books": (0.5, 0.5),
+        }
+        return QueryEmbedding(
+            text=text, vector=vectors.get(text, (1.0, 1.0)), metadata=self.metadata
+        )
 
     def embed_chunks(self, texts: Sequence[str]) -> list[ChunkEmbedding]:
-        del texts
-        return []
+        return [
+            ChunkEmbedding(
+                text=text,
+                vector=(float(index + 1), float(index + 1)),
+                metadata=self.metadata,
+            )
+            for index, text in enumerate(texts)
+        ]
 
 
 @dataclass(frozen=True)
 class FakeVectorSearcher:
-    candidates: list[SearchCandidate] = field(default_factory=list)
+    candidates_by_query: dict[str, list[SearchCandidate]] = field(default_factory=dict)
 
     def search(self, query_embedding: QueryEmbedding, *, limit: int) -> list[SearchCandidate]:
-        del query_embedding
-        return self.candidates[:limit]
+        return self.candidates_by_query.get(query_embedding.text, [])[:limit]
 
 
-def test_search_over_indexed_chunks_returns_ranked_cited_passages(tmp_path: Path) -> None:
-    paths = initialize_storage(tmp_path / ".newsrag")
-    _seed_search_corpus(paths)
+@dataclass
+class FakeVectorStore:
+    added_passages: list[PassageVectorRecord] = field(default_factory=list)
+
+    def add_passages(self, passages: Sequence[PassageVectorRecord]) -> None:
+        self.added_passages.extend(passages)
+
+
+def test_search_over_indexed_passages_returns_ranked_cited_passages(tmp_path: Path) -> None:
+    database_path = _seed_search_corpus(tmp_path)
+    vector_store = FakeVectorStore()
 
     engine = build_search_engine(
-        database_path=paths.database,
-        lancedb_path=paths.lancedb,
+        database_path=database_path,
+        lancedb_path=tmp_path / ".newsrag" / "lancedb",
         embedding_config=EmbeddingConfig(),
         embedding_provider=FakeQueryEmbeddingProvider(),
+        vector_searcher=FakeVectorSearcher(
+            {
+                "stormwater downtown": [
+                    SearchCandidate(
+                        passage_id="passage-a",
+                        document_id="document-a",
+                        page_start=3,
+                        page_end=3,
+                        text="downtown stormwater improvements",
+                        title=None,
+                        meeting_date=None,
+                        vector_score=0.1,
+                    )
+                ]
+            }
+        ),
+        vector_store=vector_store,
     )
 
     results = engine.search("stormwater downtown")
 
-    assert [result.chunk_id for result in results] == ["chunk-a"]
+    assert [result.passage_id for result in results] == ["passage-a"]
     assert results[0].citation == "Stormwater Report — 2026-05-01 — p. 3"
     assert "downtown stormwater improvements" in results[0].text
+    assert {record.passage_id for record in vector_store.added_passages} >= {
+        "passage-a",
+        "passage-b",
+        "passage-c",
+        "passage-d",
+        "passage-e",
+        "passage-f",
+    }
 
 
 def test_search_uses_vector_candidates_when_keyword_search_is_empty(tmp_path: Path) -> None:
-    paths = initialize_storage(tmp_path / ".newsrag")
-    _seed_search_corpus(paths)
+    database_path = _seed_search_corpus(tmp_path)
 
     engine = build_search_engine(
-        database_path=paths.database,
-        lancedb_path=paths.lancedb,
+        database_path=database_path,
+        lancedb_path=tmp_path / ".newsrag" / "lancedb",
         embedding_config=EmbeddingConfig(),
         embedding_provider=FakeQueryEmbeddingProvider(),
         vector_searcher=FakeVectorSearcher(
-            [
-                SearchCandidate(
-                    chunk_id="chunk-c",
-                    document_id="document-c",
-                    page_start=2,
-                    page_end=2,
-                    text="zoning map amendments",
-                    title=None,
-                    meeting_date=None,
-                    vector_score=0.2,
-                )
-            ]
+            {
+                "semantic zoning": [
+                    SearchCandidate(
+                        passage_id="passage-c",
+                        document_id="document-c",
+                        page_start=2,
+                        page_end=2,
+                        text="zoning map amendments",
+                        title=None,
+                        meeting_date=None,
+                        vector_score=0.2,
+                    )
+                ]
+            }
         ),
+        vector_store=FakeVectorStore(),
     )
 
     results = engine.search("semantic zoning")
 
-    assert [result.chunk_id for result in results] == ["chunk-c"]
+    assert [result.passage_id for result in results] == ["passage-c"]
     assert results[0].citation == "Zoning Packet — 2026-03-15 — p. 2"
 
 
-def test_search_drops_vector_only_candidates_when_keyword_hits_exist(tmp_path: Path) -> None:
-    paths = initialize_storage(tmp_path / ".newsrag")
-    _seed_search_corpus(paths)
+def test_search_keeps_strong_semantic_passage_when_keyword_hits_exist(tmp_path: Path) -> None:
+    database_path = _seed_search_corpus(tmp_path)
 
     engine = build_search_engine(
-        database_path=paths.database,
-        lancedb_path=paths.lancedb,
+        database_path=database_path,
+        lancedb_path=tmp_path / ".newsrag" / "lancedb",
         embedding_config=EmbeddingConfig(),
         embedding_provider=FakeQueryEmbeddingProvider(),
         vector_searcher=FakeVectorSearcher(
-            [
-                SearchCandidate(
-                    chunk_id="chunk-a",
-                    document_id="document-a",
-                    page_start=3,
-                    page_end=3,
-                    text="downtown stormwater improvements",
-                    title=None,
-                    meeting_date=None,
-                    vector_score=0.1,
-                ),
-                SearchCandidate(
-                    chunk_id="chunk-c",
-                    document_id="document-c",
-                    page_start=2,
-                    page_end=2,
-                    text="zoning map amendments",
-                    title=None,
-                    meeting_date=None,
-                    vector_score=0.2,
-                ),
-            ]
+            {
+                "games": [
+                    SearchCandidate(
+                        passage_id="passage-e",
+                        document_id="document-d",
+                        page_start=10,
+                        page_end=10,
+                        text="• Teen Kickback – There will be games, snacks, and craft supplies available.",
+                        title=None,
+                        meeting_date=None,
+                        vector_score=0.92,
+                    ),
+                    SearchCandidate(
+                        passage_id="passage-f",
+                        document_id="document-d",
+                        page_start=10,
+                        page_end=10,
+                        text="• Dungeons & Dragons – Take up a weapon and defeat various foes.",
+                        title=None,
+                        meeting_date=None,
+                        vector_score=0.96,
+                    ),
+                ]
+            }
         ),
+        vector_store=FakeVectorStore(),
     )
 
-    results = engine.search("stormwater downtown")
+    results = engine.search("games")
 
-    assert [result.chunk_id for result in results] == ["chunk-a"]
+    assert [result.passage_id for result in results] == ["passage-e", "passage-f"]
 
 
-def test_unrelated_query_returns_no_results_even_with_indexed_chunks(tmp_path: Path) -> None:
-    paths = initialize_storage(tmp_path / ".newsrag")
-    _seed_search_corpus(paths)
+def test_search_drops_weak_vector_tail_when_keyword_hits_exist(tmp_path: Path) -> None:
+    database_path = _seed_search_corpus(tmp_path)
 
     engine = build_search_engine(
-        database_path=paths.database,
-        lancedb_path=paths.lancedb,
+        database_path=database_path,
+        lancedb_path=tmp_path / ".newsrag" / "lancedb",
         embedding_config=EmbeddingConfig(),
         embedding_provider=FakeQueryEmbeddingProvider(),
+        vector_searcher=FakeVectorSearcher(
+            {
+                "Belt filter Press": [
+                    SearchCandidate(
+                        passage_id="passage-d",
+                        document_id="document-d",
+                        page_start=3,
+                        page_end=3,
+                        text=(
+                            "• Belt Filter Press - Contractors are 95% complete with the replacement of the "
+                            "Belt Filter Press at the Sewer Treatment Plant."
+                        ),
+                        title=None,
+                        meeting_date=None,
+                        vector_score=0.80,
+                    ),
+                    SearchCandidate(
+                        passage_id="passage-f",
+                        document_id="document-d",
+                        page_start=10,
+                        page_end=10,
+                        text="• Dungeons & Dragons – Take up a weapon and defeat various foes.",
+                        title=None,
+                        meeting_date=None,
+                        vector_score=0.97,
+                    ),
+                ]
+            }
+        ),
+        vector_store=FakeVectorStore(),
     )
 
-    results = engine.search("banana telescope")
+    results = engine.search("Belt filter Press")
 
-    assert results == []
+    assert [result.passage_id for result in results] == ["passage-d"]
 
 
-def test_keyword_vector_and_overlapping_candidates_merge_deterministically(
-    tmp_path: Path,
-) -> None:
-    paths = initialize_storage(tmp_path / ".newsrag")
-    _seed_search_corpus(paths)
+def test_books_query_returns_multiple_book_club_passages(tmp_path: Path) -> None:
+    database_path = _seed_search_corpus(tmp_path)
 
-    keyword_candidates = [
-        SearchCandidate(
-            chunk_id="chunk-a",
-            document_id="document-a",
-            page_start=3,
-            page_end=3,
-            text="downtown stormwater improvements",
-            title="Stormwater Report",
-            meeting_date="2026-05-01",
-            keyword_score=0.1,
-        ),
-        SearchCandidate(
-            chunk_id="chunk-b",
-            document_id="document-b",
-            page_start=7,
-            page_end=7,
-            text="budget hearing agenda item",
-            title="Budget Packet",
-            meeting_date="2026-04-20",
-            keyword_score=0.3,
-        ),
-    ]
-    vector_candidates = [
-        SearchCandidate(
-            chunk_id="chunk-a",
-            document_id="document-a",
-            page_start=3,
-            page_end=3,
-            text="downtown stormwater improvements",
-            title=None,
-            meeting_date=None,
-            vector_score=0.1,
-        ),
-        SearchCandidate(
-            chunk_id="chunk-c",
-            document_id="document-c",
-            page_start=2,
-            page_end=2,
-            text="zoning map amendments",
-            title=None,
-            meeting_date=None,
-            vector_score=0.3,
-        ),
-    ]
-
-    results = merge_search_candidates(
-        keyword_candidates,
-        vector_candidates,
-        database_path=paths.database,
-        limit=5,
-        keyword_weight=0.5,
-        vector_weight=0.5,
+    engine = build_search_engine(
+        database_path=database_path,
+        lancedb_path=tmp_path / ".newsrag" / "lancedb",
+        embedding_config=EmbeddingConfig(),
+        embedding_provider=FakeQueryEmbeddingProvider(),
+        vector_searcher=FakeVectorSearcher(),
+        vector_store=FakeVectorStore(),
     )
 
-    assert [result.chunk_id for result in results] == ["chunk-a", "chunk-b", "chunk-c"]
+    results = engine.search("books")
+
+    assert {result.passage_id for result in results[:3]} == {"passage-g", "passage-h", "passage-i"}
+
+
+def test_keyword_search_uses_stemmed_passages(tmp_path: Path) -> None:
+    database_path = _seed_search_corpus(tmp_path)
+
+    candidates = search_keyword_candidates(database_path, "books", limit=10)
+
+    assert {candidate.passage_id for candidate in candidates[:3]} == {
+        "passage-g",
+        "passage-h",
+        "passage-i",
+    }
 
 
 def test_citation_format_uses_concise_terminal_style() -> None:
@@ -226,22 +271,20 @@ def test_citation_format_uses_concise_terminal_style() -> None:
     )
 
 
-def test_format_search_results_prefers_matching_paragraph_without_header_noise() -> None:
+def test_format_search_results_returns_full_matching_passage() -> None:
     output = format_search_results(
         [
             SearchResult(
-                chunk_id="chunk-a",
-                document_id="document-a",
+                passage_id="passage-d",
+                document_id="document-d",
                 page_start=3,
                 page_end=3,
                 text=(
-                    "City Manager's Report\nMay 1, 2026\nPage 3 of 16\n\n"
-                    "Belt Filter Press - Contractors are 95% complete with the replacement of the Belt Filter\n"
-                    "Press at the Sewer Treatment Plant. The previous Belt Filter Press had been in service for\n"
-                    "decades. The new Belt Filter Press is currently undergoing performance testing.\n\n"
-                    "Water Infrastructure Project - Construction continues."
+                    "• Belt Filter Press - Contractors are 95% complete with the replacement of the Belt Filter Press at the Sewer Treatment Plant. "
+                    "The previous Belt Filter Press had been in service for decades, and the cost of maintenance and the difficulty of sourcing replacement parts for the old equipment led to a need for its replacement. "
+                    "The new Belt Filter Press is currently undergoing performance testing and final inspections. The replacement is being funded in part with infrastructure funds from the American Rescue Plan Act."
                 ),
-                citation="Budget Packet — 2026-04-20 — p. 1",
+                citation="Mustang City Manager Report — 2026-05-01 — p. 3",
                 score=1.0,
                 keyword_score=0.1,
                 vector_score=0.1,
@@ -250,39 +293,9 @@ def test_format_search_results_prefers_matching_paragraph_without_header_noise()
         query="Belt Filter Press",
     )
 
-    assert "City Manager's Report" not in output
-    assert "Water Infrastructure Project" not in output
-    assert output.count("Belt Filter Press") >= 3
-
-
-def test_format_search_results_uses_concise_snippets() -> None:
-    output = format_search_results(
-        [
-            SearchResult(
-                chunk_id="chunk-a",
-                document_id="document-a",
-                page_start=1,
-                page_end=1,
-                text=(
-                    "Header line " * 30
-                    + "budget work session starts here and should be shown near the middle "
-                    + "trailing detail " * 30
-                ),
-                citation="Budget Packet — 2026-04-20 — p. 1",
-                score=1.0,
-                keyword_score=0.1,
-                vector_score=0.1,
-            )
-        ],
-        query="budget work session",
-    )
-
-    assert "budget work session starts here" in output
-    assert (
-        "Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line trailing detail trailing detail trailing detail trailing detail"
-        not in output
-    )
-    assert "…" in output
+    assert "American Rescue Plan Act" in output
+    assert "Belt Filter Press" in output
+    assert "NewsRAG Search" in output
 
 
 def test_search_command_reports_no_evidence_for_empty_corpus(tmp_path: Path) -> None:
@@ -295,102 +308,172 @@ def test_search_command_reports_no_evidence_for_empty_corpus(tmp_path: Path) -> 
     assert result.stdout.strip() == "No evidence found."
 
 
-def _seed_search_corpus(paths: StoragePaths) -> None:
-    resolved_paths = paths
-    with sqlite3.connect(resolved_paths.database) as connection:
-        connection.execute(
-            """
-            INSERT INTO documents(id, source_path, source_url, title, source_hash, normalized_path, metadata_json)
-            VALUES(?, ?, NULL, ?, ?, ?, ?)
-            """,
-            (
-                "document-a",
-                "/tmp/stormwater.pdf",
-                "Stormwater Report",
-                "hash-a",
-                "/tmp/stormwater-ocr.pdf",
-                '{"meeting_date": "2026-05-01"}',
-            ),
-        )
-        connection.execute(
-            """
-            INSERT INTO documents(id, source_path, source_url, title, source_hash, normalized_path, metadata_json)
-            VALUES(?, ?, NULL, ?, ?, ?, ?)
-            """,
-            (
-                "document-b",
-                "/tmp/budget.pdf",
-                "Budget Packet",
-                "hash-b",
-                "/tmp/budget-ocr.pdf",
-                '{"meeting_date": "2026-04-20"}',
-            ),
-        )
-        connection.execute(
-            """
-            INSERT INTO documents(id, source_path, source_url, title, source_hash, normalized_path, metadata_json)
-            VALUES(?, ?, NULL, ?, ?, ?, ?)
-            """,
-            (
-                "document-c",
-                "/tmp/zoning.pdf",
-                "Zoning Packet",
-                "hash-c",
-                "/tmp/zoning-ocr.pdf",
-                '{"meeting_date": "2026-03-15"}',
-            ),
-        )
+def _seed_search_corpus(tmp_path: Path) -> Path:
+    data_dir = tmp_path / ".newsrag"
+    database_path = initialize_storage(data_dir).database
+
+    with sqlite3.connect(database_path) as connection:
         connection.executemany(
             """
-            INSERT INTO chunks(id, document_id, page_start, page_end, text)
-            VALUES(?, ?, ?, ?, ?)
+            INSERT INTO documents(id, source_path, source_url, title, source_hash, normalized_path, metadata_json)
+            VALUES(?, ?, NULL, ?, ?, ?, ?)
             """,
             [
-                ("chunk-a", "document-a", 3, 3, "downtown stormwater improvements"),
-                ("chunk-b", "document-b", 7, 7, "budget hearing agenda item"),
-                ("chunk-c", "document-c", 2, 2, "zoning map amendments"),
+                (
+                    "document-a",
+                    "/tmp/stormwater.pdf",
+                    "Stormwater Report",
+                    "hash-a",
+                    "/tmp/stormwater-ocr.pdf",
+                    '{"meeting_date": "2026-05-01"}',
+                ),
+                (
+                    "document-b",
+                    "/tmp/budget.pdf",
+                    "Budget Packet",
+                    "hash-b",
+                    "/tmp/budget-ocr.pdf",
+                    '{"meeting_date": "2026-04-20"}',
+                ),
+                (
+                    "document-c",
+                    "/tmp/zoning.pdf",
+                    "Zoning Packet",
+                    "hash-c",
+                    "/tmp/zoning-ocr.pdf",
+                    '{"meeting_date": "2026-03-15"}',
+                ),
+                (
+                    "document-d",
+                    "/tmp/mustang.pdf",
+                    "Mustang City Manager Report",
+                    "hash-d",
+                    "/tmp/mustang-ocr.pdf",
+                    '{"meeting_date": "2026-05-01"}',
+                ),
             ],
         )
         connection.executemany(
             """
-            INSERT INTO chunks_fts(chunk_id, text)
+            INSERT INTO passages(id, chunk_id, document_id, page_start, page_end, ordinal, text)
+            VALUES(?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    "passage-a",
+                    "chunk-a",
+                    "document-a",
+                    3,
+                    3,
+                    1,
+                    "downtown stormwater improvements",
+                ),
+                (
+                    "passage-b",
+                    "chunk-b",
+                    "document-b",
+                    7,
+                    7,
+                    1,
+                    "budget hearing agenda item",
+                ),
+                (
+                    "passage-c",
+                    "chunk-c",
+                    "document-c",
+                    2,
+                    2,
+                    1,
+                    "zoning map amendments",
+                ),
+                (
+                    "passage-d",
+                    "chunk-d",
+                    "document-d",
+                    3,
+                    3,
+                    1,
+                    "• Belt Filter Press - Contractors are 95% complete with the replacement of the Belt Filter Press at the Sewer Treatment Plant.",
+                ),
+                (
+                    "passage-e",
+                    "chunk-e",
+                    "document-d",
+                    10,
+                    10,
+                    1,
+                    "• Teen Kickback – There will be games, snacks, and craft supplies available.",
+                ),
+                (
+                    "passage-f",
+                    "chunk-f",
+                    "document-d",
+                    10,
+                    10,
+                    2,
+                    "• Dungeons & Dragons – Take up a weapon and defeat various foes.",
+                ),
+                (
+                    "passage-g",
+                    "chunk-g",
+                    "document-d",
+                    10,
+                    10,
+                    3,
+                    "• Paperbacks & Playdates Book Club – A low-pressure book club for stay-at-home parents.",
+                ),
+                (
+                    "passage-h",
+                    "chunk-h",
+                    "document-d",
+                    10,
+                    10,
+                    4,
+                    "• Brown Bag Book Club – Bring your own lunch and discuss The Storyteller.",
+                ),
+                (
+                    "passage-i",
+                    "chunk-i",
+                    "document-d",
+                    10,
+                    10,
+                    5,
+                    "• Geeky Cauldron Book Club – A book club for adults who love reading Young Adult books.",
+                ),
+            ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO passages_fts(passage_id, text)
             VALUES(?, ?)
             """,
             [
-                ("chunk-a", "downtown stormwater improvements"),
-                ("chunk-b", "budget hearing agenda item"),
-                ("chunk-c", "zoning map amendments"),
+                ("passage-a", "downtown stormwater improvements"),
+                ("passage-b", "budget hearing agenda item"),
+                ("passage-c", "zoning map amendments"),
+                (
+                    "passage-d",
+                    "Belt Filter Press Contractors are 95 percent complete with the replacement of the Belt Filter Press at the Sewer Treatment Plant",
+                ),
+                (
+                    "passage-e",
+                    "Teen Kickback There will be games snacks and craft supplies available",
+                ),
+                ("passage-f", "Dungeons Dragons Take up a weapon and defeat various foes"),
+                (
+                    "passage-g",
+                    "Paperbacks Playdates Book Club A low-pressure book club for stay-at-home parents",
+                ),
+                (
+                    "passage-h",
+                    "Brown Bag Book Club Bring your own lunch and discuss The Storyteller",
+                ),
+                (
+                    "passage-i",
+                    "Geeky Cauldron Book Club A book club for adults who love reading Young Adult books",
+                ),
             ],
         )
         connection.commit()
 
-    LanceDbVectorStore(resolved_paths.lancedb).add_chunks(
-        [
-            ChunkVectorRecord(
-                chunk_id="chunk-a",
-                document_id="document-a",
-                page_start=3,
-                page_end=3,
-                text="downtown stormwater improvements",
-                vector=(0.1, 0.1),
-                metadata=EmbeddingMetadata(
-                    provider="ollama",
-                    model="nomic-embed-text",
-                    version="latest",
-                ),
-            ),
-            ChunkVectorRecord(
-                chunk_id="chunk-b",
-                document_id="document-b",
-                page_start=7,
-                page_end=7,
-                text="budget hearing agenda item",
-                vector=(0.8, 0.8),
-                metadata=EmbeddingMetadata(
-                    provider="ollama",
-                    model="nomic-embed-text",
-                    version="latest",
-                ),
-            ),
-        ]
-    )
+    return database_path

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -42,6 +42,15 @@ class FakeQueryEmbeddingProvider:
         return []
 
 
+@dataclass(frozen=True)
+class FakeVectorSearcher:
+    candidates: list[SearchCandidate] = field(default_factory=list)
+
+    def search(self, query_embedding: QueryEmbedding, *, limit: int) -> list[SearchCandidate]:
+        del query_embedding
+        return self.candidates[:limit]
+
+
 def test_search_over_indexed_chunks_returns_ranked_cited_passages(tmp_path: Path) -> None:
     paths = initialize_storage(tmp_path / ".newsrag")
     _seed_search_corpus(paths)
@@ -55,9 +64,80 @@ def test_search_over_indexed_chunks_returns_ranked_cited_passages(tmp_path: Path
 
     results = engine.search("stormwater downtown")
 
-    assert [result.chunk_id for result in results] == ["chunk-a", "chunk-b"]
+    assert [result.chunk_id for result in results] == ["chunk-a"]
     assert results[0].citation == "Stormwater Report — 2026-05-01 — p. 3"
     assert "downtown stormwater improvements" in results[0].text
+
+
+def test_search_uses_vector_candidates_when_keyword_search_is_empty(tmp_path: Path) -> None:
+    paths = initialize_storage(tmp_path / ".newsrag")
+    _seed_search_corpus(paths)
+
+    engine = build_search_engine(
+        database_path=paths.database,
+        lancedb_path=paths.lancedb,
+        embedding_config=EmbeddingConfig(),
+        embedding_provider=FakeQueryEmbeddingProvider(),
+        vector_searcher=FakeVectorSearcher(
+            [
+                SearchCandidate(
+                    chunk_id="chunk-c",
+                    document_id="document-c",
+                    page_start=2,
+                    page_end=2,
+                    text="zoning map amendments",
+                    title=None,
+                    meeting_date=None,
+                    vector_score=0.2,
+                )
+            ]
+        ),
+    )
+
+    results = engine.search("semantic zoning")
+
+    assert [result.chunk_id for result in results] == ["chunk-c"]
+    assert results[0].citation == "Zoning Packet — 2026-03-15 — p. 2"
+
+
+def test_search_drops_vector_only_candidates_when_keyword_hits_exist(tmp_path: Path) -> None:
+    paths = initialize_storage(tmp_path / ".newsrag")
+    _seed_search_corpus(paths)
+
+    engine = build_search_engine(
+        database_path=paths.database,
+        lancedb_path=paths.lancedb,
+        embedding_config=EmbeddingConfig(),
+        embedding_provider=FakeQueryEmbeddingProvider(),
+        vector_searcher=FakeVectorSearcher(
+            [
+                SearchCandidate(
+                    chunk_id="chunk-a",
+                    document_id="document-a",
+                    page_start=3,
+                    page_end=3,
+                    text="downtown stormwater improvements",
+                    title=None,
+                    meeting_date=None,
+                    vector_score=0.1,
+                ),
+                SearchCandidate(
+                    chunk_id="chunk-c",
+                    document_id="document-c",
+                    page_start=2,
+                    page_end=2,
+                    text="zoning map amendments",
+                    title=None,
+                    meeting_date=None,
+                    vector_score=0.2,
+                ),
+            ]
+        ),
+    )
+
+    results = engine.search("stormwater downtown")
+
+    assert [result.chunk_id for result in results] == ["chunk-a"]
 
 
 def test_unrelated_query_returns_no_results_even_with_indexed_chunks(tmp_path: Path) -> None:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -226,6 +226,35 @@ def test_citation_format_uses_concise_terminal_style() -> None:
     )
 
 
+def test_format_search_results_prefers_matching_paragraph_without_header_noise() -> None:
+    output = format_search_results(
+        [
+            SearchResult(
+                chunk_id="chunk-a",
+                document_id="document-a",
+                page_start=3,
+                page_end=3,
+                text=(
+                    "City Manager's Report\nMay 1, 2026\nPage 3 of 16\n\n"
+                    "Belt Filter Press - Contractors are 95% complete with the replacement of the Belt Filter\n"
+                    "Press at the Sewer Treatment Plant. The previous Belt Filter Press had been in service for\n"
+                    "decades. The new Belt Filter Press is currently undergoing performance testing.\n\n"
+                    "Water Infrastructure Project - Construction continues."
+                ),
+                citation="Budget Packet — 2026-04-20 — p. 1",
+                score=1.0,
+                keyword_score=0.1,
+                vector_score=0.1,
+            )
+        ],
+        query="Belt Filter Press",
+    )
+
+    assert "City Manager's Report" not in output
+    assert "Water Infrastructure Project" not in output
+    assert output.count("Belt Filter Press") >= 3
+
+
 def test_format_search_results_uses_concise_snippets() -> None:
     output = format_search_results(
         [

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -13,8 +13,10 @@ from newsrag.embeddings import ChunkEmbedding, EmbeddingMetadata, QueryEmbedding
 from newsrag.ingest import ChunkVectorRecord, LanceDbVectorStore
 from newsrag.search import (
     SearchCandidate,
+    SearchResult,
     build_search_engine,
     format_citation,
+    format_search_results,
     merge_search_candidates,
 )
 from newsrag.storage import StoragePaths, initialize_storage
@@ -142,6 +144,36 @@ def test_citation_format_uses_concise_terminal_style() -> None:
         format_citation(title="Stormwater Report", meeting_date="2026-05-01", page_number=3)
         == "Stormwater Report — 2026-05-01 — p. 3"
     )
+
+
+def test_format_search_results_uses_concise_snippets() -> None:
+    output = format_search_results(
+        [
+            SearchResult(
+                chunk_id="chunk-a",
+                document_id="document-a",
+                page_start=1,
+                page_end=1,
+                text=(
+                    "Header line " * 30
+                    + "budget work session starts here and should be shown near the middle "
+                    + "trailing detail " * 30
+                ),
+                citation="Budget Packet — 2026-04-20 — p. 1",
+                score=1.0,
+                keyword_score=0.1,
+                vector_score=0.1,
+            )
+        ],
+        query="budget work session",
+    )
+
+    assert "budget work session starts here" in output
+    assert (
+        "Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line Header line trailing detail trailing detail trailing detail trailing detail"
+        not in output
+    )
+    assert "…" in output
 
 
 def test_search_command_reports_no_evidence_for_empty_corpus(tmp_path: Path) -> None:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -33,7 +33,7 @@ class FakeQueryEmbeddingProvider:
     def embed_query(self, text: str) -> QueryEmbedding:
         if text == "stormwater downtown":
             return QueryEmbedding(text=text, vector=(0.1, 0.1), metadata=self.metadata)
-        return QueryEmbedding(text=text, vector=(0.9, 0.9), metadata=self.metadata)
+        return QueryEmbedding(text=text, vector=(2.0, 2.0), metadata=self.metadata)
 
     def embed_chunks(self, texts: Sequence[str]) -> list[ChunkEmbedding]:
         del texts
@@ -56,6 +56,22 @@ def test_search_over_indexed_chunks_returns_ranked_cited_passages(tmp_path: Path
     assert [result.chunk_id for result in results] == ["chunk-a", "chunk-b"]
     assert results[0].citation == "Stormwater Report — 2026-05-01 — p. 3"
     assert "downtown stormwater improvements" in results[0].text
+
+
+def test_unrelated_query_returns_no_results_even_with_indexed_chunks(tmp_path: Path) -> None:
+    paths = initialize_storage(tmp_path / ".newsrag")
+    _seed_search_corpus(paths)
+
+    engine = build_search_engine(
+        database_path=paths.database,
+        lancedb_path=paths.lancedb,
+        embedding_config=EmbeddingConfig(),
+        embedding_provider=FakeQueryEmbeddingProvider(),
+    )
+
+    results = engine.search("banana telescope")
+
+    assert results == []
 
 
 def test_keyword_vector_and_overlapping_candidates_merge_deterministically(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from newsrag.cli import app
+from newsrag.config import EmbeddingConfig
+from newsrag.embeddings import ChunkEmbedding, EmbeddingMetadata, QueryEmbedding
+from newsrag.ingest import ChunkVectorRecord, LanceDbVectorStore
+from newsrag.search import (
+    SearchCandidate,
+    build_search_engine,
+    format_citation,
+    merge_search_candidates,
+)
+from newsrag.storage import StoragePaths, initialize_storage
+
+runner = CliRunner()
+
+
+@dataclass(frozen=True)
+class FakeQueryEmbeddingProvider:
+    metadata: EmbeddingMetadata = EmbeddingMetadata(
+        provider="ollama",
+        model="nomic-embed-text",
+        version="latest",
+    )
+
+    def embed_query(self, text: str) -> QueryEmbedding:
+        if text == "stormwater downtown":
+            return QueryEmbedding(text=text, vector=(0.1, 0.1), metadata=self.metadata)
+        return QueryEmbedding(text=text, vector=(0.9, 0.9), metadata=self.metadata)
+
+    def embed_chunks(self, texts: Sequence[str]) -> list[ChunkEmbedding]:
+        del texts
+        return []
+
+
+def test_search_over_indexed_chunks_returns_ranked_cited_passages(tmp_path: Path) -> None:
+    paths = initialize_storage(tmp_path / ".newsrag")
+    _seed_search_corpus(paths)
+
+    engine = build_search_engine(
+        database_path=paths.database,
+        lancedb_path=paths.lancedb,
+        embedding_config=EmbeddingConfig(),
+        embedding_provider=FakeQueryEmbeddingProvider(),
+    )
+
+    results = engine.search("stormwater downtown")
+
+    assert [result.chunk_id for result in results] == ["chunk-a", "chunk-b"]
+    assert results[0].citation == "Stormwater Report — 2026-05-01 — p. 3"
+    assert "downtown stormwater improvements" in results[0].text
+
+
+def test_keyword_vector_and_overlapping_candidates_merge_deterministically(
+    tmp_path: Path,
+) -> None:
+    paths = initialize_storage(tmp_path / ".newsrag")
+    _seed_search_corpus(paths)
+
+    keyword_candidates = [
+        SearchCandidate(
+            chunk_id="chunk-a",
+            document_id="document-a",
+            page_start=3,
+            page_end=3,
+            text="downtown stormwater improvements",
+            title="Stormwater Report",
+            meeting_date="2026-05-01",
+            keyword_score=0.1,
+        ),
+        SearchCandidate(
+            chunk_id="chunk-b",
+            document_id="document-b",
+            page_start=7,
+            page_end=7,
+            text="budget hearing agenda item",
+            title="Budget Packet",
+            meeting_date="2026-04-20",
+            keyword_score=0.3,
+        ),
+    ]
+    vector_candidates = [
+        SearchCandidate(
+            chunk_id="chunk-a",
+            document_id="document-a",
+            page_start=3,
+            page_end=3,
+            text="downtown stormwater improvements",
+            title=None,
+            meeting_date=None,
+            vector_score=0.1,
+        ),
+        SearchCandidate(
+            chunk_id="chunk-c",
+            document_id="document-c",
+            page_start=2,
+            page_end=2,
+            text="zoning map amendments",
+            title=None,
+            meeting_date=None,
+            vector_score=0.3,
+        ),
+    ]
+
+    results = merge_search_candidates(
+        keyword_candidates,
+        vector_candidates,
+        database_path=paths.database,
+        limit=5,
+        keyword_weight=0.5,
+        vector_weight=0.5,
+    )
+
+    assert [result.chunk_id for result in results] == ["chunk-a", "chunk-b", "chunk-c"]
+
+
+def test_citation_format_uses_concise_terminal_style() -> None:
+    assert (
+        format_citation(title="Stormwater Report", meeting_date="2026-05-01", page_number=3)
+        == "Stormwater Report — 2026-05-01 — p. 3"
+    )
+
+
+def test_search_command_reports_no_evidence_for_empty_corpus(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    initialize_storage(data_dir)
+
+    result = runner.invoke(app, ["--data-dir", str(data_dir), "search", "stormwater"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "No evidence found."
+
+
+def _seed_search_corpus(paths: StoragePaths) -> None:
+    resolved_paths = paths
+    with sqlite3.connect(resolved_paths.database) as connection:
+        connection.execute(
+            """
+            INSERT INTO documents(id, source_path, source_url, title, source_hash, normalized_path, metadata_json)
+            VALUES(?, ?, NULL, ?, ?, ?, ?)
+            """,
+            (
+                "document-a",
+                "/tmp/stormwater.pdf",
+                "Stormwater Report",
+                "hash-a",
+                "/tmp/stormwater-ocr.pdf",
+                '{"meeting_date": "2026-05-01"}',
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO documents(id, source_path, source_url, title, source_hash, normalized_path, metadata_json)
+            VALUES(?, ?, NULL, ?, ?, ?, ?)
+            """,
+            (
+                "document-b",
+                "/tmp/budget.pdf",
+                "Budget Packet",
+                "hash-b",
+                "/tmp/budget-ocr.pdf",
+                '{"meeting_date": "2026-04-20"}',
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO documents(id, source_path, source_url, title, source_hash, normalized_path, metadata_json)
+            VALUES(?, ?, NULL, ?, ?, ?, ?)
+            """,
+            (
+                "document-c",
+                "/tmp/zoning.pdf",
+                "Zoning Packet",
+                "hash-c",
+                "/tmp/zoning-ocr.pdf",
+                '{"meeting_date": "2026-03-15"}',
+            ),
+        )
+        connection.executemany(
+            """
+            INSERT INTO chunks(id, document_id, page_start, page_end, text)
+            VALUES(?, ?, ?, ?, ?)
+            """,
+            [
+                ("chunk-a", "document-a", 3, 3, "downtown stormwater improvements"),
+                ("chunk-b", "document-b", 7, 7, "budget hearing agenda item"),
+                ("chunk-c", "document-c", 2, 2, "zoning map amendments"),
+            ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO chunks_fts(chunk_id, text)
+            VALUES(?, ?)
+            """,
+            [
+                ("chunk-a", "downtown stormwater improvements"),
+                ("chunk-b", "budget hearing agenda item"),
+                ("chunk-c", "zoning map amendments"),
+            ],
+        )
+        connection.commit()
+
+    LanceDbVectorStore(resolved_paths.lancedb).add_chunks(
+        [
+            ChunkVectorRecord(
+                chunk_id="chunk-a",
+                document_id="document-a",
+                page_start=3,
+                page_end=3,
+                text="downtown stormwater improvements",
+                vector=(0.1, 0.1),
+                metadata=EmbeddingMetadata(
+                    provider="ollama",
+                    model="nomic-embed-text",
+                    version="latest",
+                ),
+            ),
+            ChunkVectorRecord(
+                chunk_id="chunk-b",
+                document_id="document-b",
+                page_start=7,
+                page_end=7,
+                text="budget hearing agenda item",
+                vector=(0.8, 0.8),
+                metadata=EmbeddingMetadata(
+                    provider="ollama",
+                    model="nomic-embed-text",
+                    version="latest",
+                ),
+            ),
+        ]
+    )

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -35,6 +36,56 @@ def test_initialize_storage_is_idempotent(tmp_path: Path) -> None:
 
     assert first_paths == second_paths
     assert REQUIRED_TABLES == REQUIRED_TABLES.intersection(_existing_tables(second_paths.database))
+
+
+def test_initialize_storage_backfills_passages_from_existing_chunks(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    paths = initialize_storage(data_dir)
+
+    with sqlite3.connect(paths.database) as connection:
+        connection.execute(
+            """
+            INSERT INTO documents(id, source_path, title, source_hash, normalized_path, metadata_json)
+            VALUES(?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "document-1",
+                "/tmp/report.pdf",
+                "Report",
+                "hash-1",
+                "/tmp/report-ocr.pdf",
+                "{}",
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO chunks(id, document_id, page_start, page_end, text)
+            VALUES(?, ?, ?, ?, ?)
+            """,
+            (
+                "chunk-1",
+                "document-1",
+                10,
+                10,
+                "City Manager's Report\nMay 1, 2026\nPage 10 of 16\n\n• Paperbacks & Playdates Book Club – A low-pressure book club.\n\n• Brown Bag Book Club – Bring your own lunch.",
+            ),
+        )
+        connection.commit()
+
+    initialize_storage(data_dir)
+
+    with sqlite3.connect(paths.database) as connection:
+        passage_rows = connection.execute(
+            "SELECT id, text FROM passages ORDER BY ordinal ASC"
+        ).fetchall()
+        fts_rows = connection.execute(
+            "SELECT passage_id, text FROM passages_fts ORDER BY passage_id ASC"
+        ).fetchall()
+
+    assert len(passage_rows) == 2
+    assert "Paperbacks & Playdates Book Club" in passage_rows[0][1]
+    assert "Brown Bag Book Club" in passage_rows[1][1]
+    assert len(fts_rows) == 2
 
 
 def test_initialize_storage_rejects_file_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Add the first evidence-first `newsrag search` command so NewsRAG can search indexed chunks through both SQLite FTS5 and LanceDB vectors, merge the candidates deterministically, and return cited passages.

## Task

- #task-e5c2f467

## Changes

- add `newsrag search <query>`
- add SQLite FTS5 chunk indexing and keyword candidate retrieval
- add LanceDB vector candidate retrieval using query embeddings
- add hybrid candidate merge, score normalization, and a no-op reranker hook
- add concise citation formatting and clear no-evidence output
- add tests for ranked results, deterministic merge behavior, citation formatting, and empty corpus output

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [ ] Documentation updated (if needed)
- [x] No unrelated changes included
