### PR TITLE
Add Markdown source packet generation

### DIFF
--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -20,6 +20,7 @@ from newsrag.doctor import format_report, run_doctor
 from newsrag.ingest import IngestError, enqueue_ingest_jobs, enqueue_ingest_url_job
 from newsrag.jobs import list_jobs
 from newsrag.manifests import ManifestError, load_manifest
+from newsrag.packets import PacketError, format_source_packet, write_source_packet
 from newsrag.search import SearchError, SearchFilters, build_search_engine, format_search_results
 from newsrag.storage import (
     StorageError,
@@ -41,6 +42,13 @@ DATA_DIR_OPTION = typer.Option(
     "--data-dir",
     help="Override the active corpus data directory.",
     file_okay=False,
+    resolve_path=False,
+)
+PACKET_OUT_OPTION = typer.Option(
+    ...,
+    "--out",
+    help="Write the Markdown source packet to this path.",
+    dir_okay=False,
     resolve_path=False,
 )
 
@@ -327,7 +335,7 @@ def search_command(
 
     settings, _ = _resolve_runtime_settings(ctx)
     storage_paths = initialize_storage(settings.data_dir)
-    filters = SearchFilters(
+    filters = _build_search_filters(
         body=body,
         document_type=document_type,
         jurisdiction=jurisdiction,
@@ -348,6 +356,74 @@ def search_command(
         raise typer.Exit(code=1) from exc
 
     typer.echo(format_search_results(results, query=query, filters=filters))
+
+
+@app.command("packet")
+def packet_command(
+    ctx: typer.Context,
+    query: str,
+    out: Path = PACKET_OUT_OPTION,
+    overwrite: bool = typer.Option(
+        False,
+        "--overwrite",
+        help="Replace the output file if it already exists.",
+    ),
+    body: str | None = typer.Option(None, help="Only search documents from this civic body."),
+    document_type: str | None = typer.Option(
+        None,
+        "--document-type",
+        help="Only search documents with this document type metadata.",
+    ),
+    jurisdiction: str | None = typer.Option(
+        None,
+        help="Only search documents from this jurisdiction.",
+    ),
+    source_url: str | None = typer.Option(
+        None,
+        "--source-url",
+        help="Only search documents with this source URL.",
+    ),
+    since: str | None = typer.Option(
+        None,
+        "--since",
+        help="Only search documents with meeting dates on or after YYYY-MM-DD.",
+    ),
+    until: str | None = typer.Option(
+        None,
+        "--until",
+        help="Only search documents with meeting dates on or before YYYY-MM-DD.",
+    ),
+) -> None:
+    """Generate an extractive Markdown source packet from retrieved evidence."""
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    storage_paths = initialize_storage(settings.data_dir)
+    filters = _build_search_filters(
+        body=body,
+        document_type=document_type,
+        jurisdiction=jurisdiction,
+        source_url=source_url,
+        since=since,
+        until=until,
+    )
+
+    try:
+        engine = build_search_engine(
+            database_path=storage_paths.database,
+            lancedb_path=storage_paths.lancedb,
+            embedding_config=settings.config.embedding,
+        )
+        results = engine.search(query, filters=filters)
+        write_source_packet(
+            out,
+            format_source_packet(query=query, results=results, filters=filters),
+            overwrite=overwrite,
+        )
+    except (SearchError, PacketError) as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(f"Wrote source packet to {out}")
 
 
 @jobs_app.command("list")
@@ -434,6 +510,25 @@ def run() -> None:
     """Run the Typer application."""
 
     app()
+
+
+def _build_search_filters(
+    *,
+    body: str | None,
+    document_type: str | None,
+    jurisdiction: str | None,
+    source_url: str | None,
+    since: str | None,
+    until: str | None,
+) -> SearchFilters:
+    return SearchFilters(
+        body=body,
+        document_type=document_type,
+        jurisdiction=jurisdiction,
+        source_url=source_url,
+        since=since,
+        until=until,
+    )
 
 
 def _build_document_metadata_options(

--- a/newsrag/packets.py
+++ b/newsrag/packets.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from newsrag.search import SearchFilters, SearchResult
+
+
+class PacketError(Exception):
+    """Raised when a source packet cannot be generated or written."""
+
+
+def format_source_packet(
+    *,
+    query: str,
+    results: Sequence[SearchResult],
+    filters: SearchFilters | None = None,
+) -> str:
+    """Format retrieved evidence as a fixed Markdown source packet."""
+
+    resolved_filters = filters or SearchFilters()
+    lines = [f"# Source Packet: {query}", ""]
+    if resolved_filters.is_active:
+        lines.extend([f"Filters: {', '.join(resolved_filters.labels())}", ""])
+
+    lines.extend(["## Key Evidence", ""])
+    if results:
+        for index, result in enumerate(results, start=1):
+            lines.extend(
+                [
+                    f"{index}. **{result.citation}**",
+                    f"   > {_normalize_text(result.text)}",
+                    "",
+                ]
+            )
+    else:
+        lines.extend(["No evidence found.", ""])
+
+    lines.extend(["## Timeline", ""])
+    dated_results = [result for result in results if result.meeting_date is not None]
+    if dated_results:
+        for result in sorted(
+            dated_results, key=lambda item: (item.meeting_date or "", item.citation)
+        ):
+            lines.append(f"- {result.meeting_date} — {result.citation}")
+    else:
+        lines.append("- No dated evidence found.")
+    lines.append("")
+
+    lines.extend(["## Open Questions", ""])
+    lines.extend(
+        [
+            "- What additional source documents should be reviewed?",
+            "- Are there related agenda items, minutes, or staff reports that corroborate this evidence?",
+            "",
+        ]
+    )
+
+    lines.extend(["## Source List", ""])
+    if results:
+        for result in results:
+            lines.append(f"- {format_source_list_entry(result)}")
+    else:
+        lines.append("- No sources found.")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def write_source_packet(path: Path, content: str, *, overwrite: bool = False) -> None:
+    """Write a source packet to disk, refusing accidental overwrites by default."""
+
+    if path.exists() and not overwrite:
+        raise PacketError(f"Output file already exists: {path}. Use --overwrite to replace it.")
+    path.write_text(content, encoding="utf-8")
+
+
+def format_source_list_entry(result: SearchResult) -> str:
+    """Format one source-list entry with available metadata."""
+
+    details = [f"page {result.page_start}"]
+    for label, value in (
+        ("title", result.title),
+        ("body", result.body),
+        ("meeting date", result.meeting_date),
+        ("document type", result.document_type),
+        ("jurisdiction", result.jurisdiction),
+        ("source file", result.source_path),
+        ("source URL", result.source_url),
+    ):
+        if value is not None and value.strip():
+            details.append(f"{label}: {value.strip()}")
+    return f"{result.citation} ({'; '.join(details)})"
+
+
+def _normalize_text(value: str) -> str:
+    return " ".join(value.split())

--- a/newsrag/search.py
+++ b/newsrag/search.py
@@ -106,6 +106,7 @@ class SearchCandidate:
     document_type: str | None = None
     jurisdiction: str | None = None
     source_url: str | None = None
+    source_path: str | None = None
     keyword_score: float | None = None
     vector_score: float | None = None
 
@@ -123,10 +124,13 @@ class SearchResult:
     score: float
     keyword_score: float | None
     vector_score: float | None
+    title: str | None = None
+    meeting_date: str | None = None
     body: str | None = None
     document_type: str | None = None
     jurisdiction: str | None = None
     source_url: str | None = None
+    source_path: str | None = None
 
 
 class Reranker(Protocol):
@@ -340,6 +344,7 @@ def search_keyword_candidates(
                 passages.text AS passage_text,
                 documents.title AS title,
                 documents.source_url AS source_url,
+                documents.source_path AS source_path,
                 documents.metadata_json AS metadata_json,
                 bm25(passages_fts) AS keyword_score
             FROM passages_fts
@@ -369,6 +374,9 @@ def search_keyword_candidates(
                 jurisdiction=_optional_string(metadata.get("jurisdiction")),
                 source_url=_optional_string(row["source_url"])
                 or _optional_string(metadata.get("source_url")),
+                source_path=_optional_string(row["source_path"])
+                or _optional_string(metadata.get("stored_source_path"))
+                or _optional_string(metadata.get("source_filename")),
                 keyword_score=float(row["keyword_score"]),
             )
         )
@@ -428,10 +436,13 @@ def merge_search_candidates(
             score=score,
             keyword_score=context.keyword_score,
             vector_score=context.vector_score,
+            title=context.title,
+            meeting_date=context.meeting_date,
             body=context.body,
             document_type=context.document_type,
             jurisdiction=context.jurisdiction,
             source_url=context.source_url,
+            source_path=context.source_path,
         )
 
     return sorted(
@@ -644,6 +655,7 @@ def _expand_contextual_keyword_candidates(
                     document_type=neighbor.document_type,
                     jurisdiction=neighbor.jurisdiction,
                     source_url=neighbor.source_url,
+                    source_path=neighbor.source_path,
                     keyword_score=(candidate.keyword_score or 0.0) + 0.5,
                 )
             )
@@ -712,6 +724,7 @@ def _load_passage_context(
                     passages.text AS passage_text,
                     documents.title AS title,
                     documents.source_url AS source_url,
+                    documents.source_path AS source_path,
                     documents.metadata_json AS metadata_json
                 FROM passages
                 JOIN documents ON documents.id = passages.document_id
@@ -735,6 +748,9 @@ def _load_passage_context(
                 jurisdiction=_optional_string(metadata.get("jurisdiction")),
                 source_url=_optional_string(row["source_url"])
                 or _optional_string(metadata.get("source_url")),
+                source_path=_optional_string(row["source_path"])
+                or _optional_string(metadata.get("stored_source_path"))
+                or _optional_string(metadata.get("source_filename")),
             )
 
     for candidate in vector_candidates:
@@ -751,6 +767,7 @@ def _load_passage_context(
             document_type=existing.document_type,
             jurisdiction=existing.jurisdiction,
             source_url=existing.source_url,
+            source_path=existing.source_path,
             keyword_score=existing.keyword_score,
             vector_score=candidate.vector_score,
         )
@@ -809,6 +826,7 @@ def _load_adjacent_passages(
                 passages.text AS passage_text,
                 documents.title AS title,
                 documents.source_url AS source_url,
+                documents.source_path AS source_path,
                 documents.metadata_json AS metadata_json
             FROM passages
             JOIN origin
@@ -837,6 +855,9 @@ def _load_adjacent_passages(
                 jurisdiction=_optional_string(metadata.get("jurisdiction")),
                 source_url=_optional_string(row["source_url"])
                 or _optional_string(metadata.get("source_url")),
+                source_path=_optional_string(row["source_path"])
+                or _optional_string(metadata.get("stored_source_path"))
+                or _optional_string(metadata.get("source_filename")),
             )
         )
     return candidates

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import newsrag.cli as cli
+from newsrag.cli import app
+from newsrag.packets import PacketError, format_source_packet, write_source_packet
+from newsrag.search import SearchFilters, SearchResult
+
+runner = CliRunner()
+
+
+def test_source_packet_contains_required_sections_and_cited_evidence() -> None:
+    content = format_source_packet(query="stormwater", results=[_search_result()])
+
+    assert "# Source Packet: stormwater" in content
+    assert "## Key Evidence" in content
+    assert "## Timeline" in content
+    assert "## Open Questions" in content
+    assert "## Source List" in content
+    assert "**Stormwater Report — 2026-05-01 — p. 3**" in content
+    assert "> downtown stormwater improvements" in content
+
+
+def test_source_packet_source_list_includes_available_metadata() -> None:
+    content = format_source_packet(query="stormwater", results=[_search_result()])
+
+    assert "title: Stormwater Report" in content
+    assert "body: Planning Commission" in content
+    assert "meeting date: 2026-05-01" in content
+    assert "page 3" in content
+    assert "source file: /tmp/stormwater.pdf" in content
+
+
+def test_write_source_packet_refuses_existing_output_without_overwrite(tmp_path: Path) -> None:
+    output_path = tmp_path / "packet.md"
+    output_path.write_text("existing", encoding="utf-8")
+
+    with pytest.raises(PacketError, match="Use --overwrite"):
+        write_source_packet(output_path, "replacement")
+
+    assert output_path.read_text(encoding="utf-8") == "existing"
+
+
+def test_write_source_packet_allows_explicit_overwrite(tmp_path: Path) -> None:
+    output_path = tmp_path / "packet.md"
+    output_path.write_text("existing", encoding="utf-8")
+
+    write_source_packet(output_path, "replacement", overwrite=True)
+
+    assert output_path.read_text(encoding="utf-8") == "replacement"
+
+
+def test_packet_command_writes_markdown_from_mocked_retrieval(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_path = tmp_path / "packet.md"
+    captured_filters: list[SearchFilters] = []
+
+    class FakeSearchEngine:
+        def search(
+            self,
+            query: str,
+            *,
+            filters: SearchFilters | None = None,
+        ) -> list[SearchResult]:
+            assert query == "stormwater"
+            assert filters is not None
+            captured_filters.append(filters)
+            return [_search_result()]
+
+    monkeypatch.setattr(cli, "build_search_engine", lambda **_: FakeSearchEngine())
+
+    result = runner.invoke(
+        app,
+        [
+            "--data-dir",
+            str(tmp_path / ".newsrag"),
+            "packet",
+            "stormwater",
+            "--out",
+            str(output_path),
+            "--body",
+            "Planning Commission",
+            "--since",
+            "2025-01-01",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == f"Wrote source packet to {output_path}"
+    assert output_path.exists()
+    assert "# Source Packet: stormwater" in output_path.read_text(encoding="utf-8")
+    assert captured_filters == [SearchFilters(body="Planning Commission", since="2025-01-01")]
+
+
+def test_packet_command_requires_overwrite_for_existing_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_path = tmp_path / "packet.md"
+    output_path.write_text("existing", encoding="utf-8")
+
+    class FakeSearchEngine:
+        def search(
+            self,
+            query: str,
+            *,
+            filters: SearchFilters | None = None,
+        ) -> list[SearchResult]:
+            return [_search_result()]
+
+    monkeypatch.setattr(cli, "build_search_engine", lambda **_: FakeSearchEngine())
+
+    result = runner.invoke(
+        app,
+        [
+            "--data-dir",
+            str(tmp_path / ".newsrag"),
+            "packet",
+            "stormwater",
+            "--out",
+            str(output_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Use --overwrite to replace it" in result.stdout
+    assert output_path.read_text(encoding="utf-8") == "existing"
+
+    overwrite_result = runner.invoke(
+        app,
+        [
+            "--data-dir",
+            str(tmp_path / ".newsrag"),
+            "packet",
+            "stormwater",
+            "--out",
+            str(output_path),
+            "--overwrite",
+        ],
+    )
+
+    assert overwrite_result.exit_code == 0
+    assert "# Source Packet: stormwater" in output_path.read_text(encoding="utf-8")
+
+
+def _search_result() -> SearchResult:
+    return SearchResult(
+        passage_id="passage-a",
+        document_id="document-a",
+        page_start=3,
+        page_end=3,
+        text="downtown stormwater improvements",
+        citation="Stormwater Report — 2026-05-01 — p. 3",
+        score=1.0,
+        keyword_score=0.1,
+        vector_score=0.2,
+        title="Stormwater Report",
+        meeting_date="2026-05-01",
+        body="Planning Commission",
+        document_type="staff_report",
+        jurisdiction="Example City",
+        source_url="https://example.test/stormwater.pdf",
+        source_path="/tmp/stormwater.pdf",
+    )


### PR DESCRIPTION
## Summary
- add `newsrag packet <query> --out <path>` with the same metadata filters as search
- generate fixed extractive Markdown packets with Key Evidence, Timeline, Open Questions, and Source List sections
- include citation/source metadata in packet output and protect existing output files unless `--overwrite` is passed

## Verification
- `uv run pytest tests/test_packets.py tests/test_search.py`
- `make check`
- `./scripts/pre-pr.sh`
- manual packet generation against disposable `/tmp/newsrag-filter-manual.GQJDMr` corpus

Task: #task-f0a187f0
