### PR TITLE
Add job failure visibility and retry UX

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,7 +9,7 @@ This document defines how to work in this project.
 3. Make the smallest change that satisfies the task.
 4. Follow [CODE_STANDARDS.md](CODE_STANDARDS.md).
 5. Do not add manual line breaks in markdown paragraphs.
-6. Before asking the user to approve planned work, show a concise summary of task readiness, current repo state, and the planned steps.
+6. Before starting implementation work, show the user a concise plan to approve, including task readiness, current repo state, and the planned steps.
 7. If blocked or requirements are ambiguous, stop and report `BLOCKED` with reason.
 8. Summarize changed files and verification results.
 

--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -23,7 +23,7 @@ from newsrag.ingest import (
     enqueue_ingest_url_job,
     normalize_pdf_extractor_mode,
 )
-from newsrag.jobs import list_jobs
+from newsrag.jobs import FAILED, Job, JobRetryError, list_jobs, retry_failed_job
 from newsrag.manifests import ManifestError, load_manifest
 from newsrag.packets import PacketError, format_source_packet, write_source_packet
 from newsrag.search import SearchError, SearchFilters, build_search_engine, format_search_results
@@ -461,10 +461,22 @@ def jobs_list_command(ctx: typer.Context) -> None:
         return
 
     for job in jobs:
-        line = f"{job.id} {job.status} {job.kind}"
-        if job.error is not None:
-            line = f"{line} error={job.error}"
-        typer.echo(line)
+        typer.echo(_format_job_line(job))
+
+
+@jobs_app.command("retry")
+def jobs_retry_command(ctx: typer.Context, job_id: str) -> None:
+    """Retry one failed durable NewsRAG job."""
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    database_path = initialize_storage(settings.data_dir).database
+    try:
+        job = retry_failed_job(database_path, job_id)
+    except JobRetryError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(f"Retried {job.id}; status={job.status}")
 
 
 @watch_app.command("add")
@@ -530,6 +542,19 @@ def run() -> None:
     """Run the Typer application."""
 
     app()
+
+
+def _format_job_line(job: Job) -> str:
+    parts = [job.id, job.status, job.kind, f"updated_at={job.updated_at}"]
+    source_path = job.payload.get("path")
+    if isinstance(source_path, str) and source_path.strip():
+        parts.append(f"path={source_path}")
+    if job.status == FAILED and job.error is not None:
+        parts.append(f"failed_at={job.updated_at}")
+        parts.append(f"error={job.error}")
+    elif job.error is not None:
+        parts.append(f"error={job.error}")
+    return " ".join(parts)
 
 
 def _build_search_filters(

--- a/newsrag/jobs.py
+++ b/newsrag/jobs.py
@@ -14,6 +14,10 @@ DONE: JobStatus = "done"
 FAILED: JobStatus = "failed"
 
 
+class JobRetryError(Exception):
+    """Raised when a durable job cannot be retried."""
+
+
 @dataclass(frozen=True)
 class Job:
     """One durable NewsRAG job."""
@@ -132,6 +136,20 @@ def mark_job_failed(database_path: Path, job_id: str, *, error: str) -> Job:
     """Mark a running job failed with context."""
 
     return _set_job_status(database_path, job_id, status=FAILED, error=error)
+
+
+def retry_failed_job(database_path: Path, job_id: str) -> Job:
+    """Move one failed job back to pending for daemon reprocessing."""
+
+    try:
+        job = get_job(database_path, job_id)
+    except KeyError as exc:
+        raise JobRetryError(f"Unknown job: {job_id}") from exc
+
+    if job.status != FAILED:
+        raise JobRetryError(f"Job {job_id} is {job.status}; only failed jobs can be retried")
+
+    return _set_job_status(database_path, job_id, status=PENDING, error=None)
 
 
 def set_job_status(

--- a/newsrag/storage.py
+++ b/newsrag/storage.py
@@ -5,6 +5,7 @@ import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 
+from newsrag.jobs import DONE, FAILED, PENDING, RUNNING
 from newsrag.passages import build_passage_rows
 
 
@@ -285,8 +286,32 @@ def get_storage_status(data_dir: Path) -> StorageStatusReport:
         checks.append(StorageCheck("database", "warn", f"missing tables: {table_list}"))
     else:
         checks.append(StorageCheck("database", "ok", f"schema ready at {paths.database}"))
+        checks.append(_job_queue_check(paths.database))
 
     return StorageStatusReport(checks=tuple(checks))
+
+
+def _job_queue_check(database_path: Path) -> StorageCheck:
+    counts = _job_status_counts(database_path)
+    detail = (
+        f"pending={counts[PENDING]} running={counts[RUNNING]} "
+        f"failed={counts[FAILED]} done={counts[DONE]}"
+    )
+    if counts[FAILED] > 0:
+        return StorageCheck("jobs", "warn", detail)
+    return StorageCheck("jobs", "ok", detail)
+
+
+def _job_status_counts(database_path: Path) -> dict[str, int]:
+    counts = {PENDING: 0, RUNNING: 0, FAILED: 0, DONE: 0}
+    with sqlite3.connect(database_path) as connection:
+        rows = connection.execute(
+            "SELECT status, COUNT(*) FROM jobs GROUP BY status ORDER BY status ASC"
+        ).fetchall()
+
+    for status, count in rows:
+        counts[str(status)] = int(count)
+    return counts
 
 
 def format_status_report(report: StorageStatusReport, *, data_dir: Path) -> str:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 
 from newsrag.cli import app
 from newsrag.daemon import DaemonRunner
-from newsrag.jobs import DONE, FAILED, RUNNING, Job, create_job, get_job, set_job_status
+from newsrag.jobs import DONE, FAILED, PENDING, RUNNING, Job, create_job, get_job, set_job_status
 from newsrag.storage import initialize_storage
 
 runner = CliRunner()
@@ -106,4 +106,77 @@ def test_jobs_list_shows_all_job_statuses(tmp_path: Path) -> None:
     assert "done" in result.stdout
     assert failed_job.id in result.stdout
     assert "failed" in result.stdout
-    assert "boom" in result.stdout
+    assert "failed_at=" in result.stdout
+    assert "error=boom" in result.stdout
+
+
+def test_failed_job_appears_in_status_with_error_count(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    paths = initialize_storage(data_dir)
+    failed_job = create_job(
+        paths.database,
+        kind="mock",
+        payload={"path": str(tmp_path / "packet.pdf")},
+        job_id="job-failed",
+    )
+    set_job_status(paths.database, failed_job.id, status=FAILED, error="ocr boom")
+
+    status_result = runner.invoke(app, ["--data-dir", str(data_dir), "status"])
+    jobs_result = runner.invoke(app, ["--data-dir", str(data_dir), "jobs", "list"])
+
+    assert status_result.exit_code == 0
+    assert "jobs: warn" in status_result.stdout
+    assert "failed=1" in status_result.stdout
+    assert "summary: warn" in status_result.stdout
+    assert jobs_result.exit_code == 0
+    assert "job-failed" in jobs_result.stdout
+    assert "path=" in jobs_result.stdout
+    assert "error=ocr boom" in jobs_result.stdout
+
+
+def test_jobs_retry_moves_failed_job_back_to_pending_and_daemon_reprocesses(
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / ".newsrag"
+    paths = initialize_storage(data_dir)
+    job = create_job(paths.database, kind="mock", job_id="job-retry")
+    set_job_status(paths.database, job.id, status=FAILED, error="boom")
+    seen_statuses: list[str] = []
+
+    result = runner.invoke(app, ["--data-dir", str(data_dir), "jobs", "retry", job.id])
+
+    async def handler(_: Job) -> None:
+        seen_statuses.append(get_job(paths.database, job.id).status)
+
+    processed = asyncio.run(
+        DaemonRunner(
+            database_path=paths.database,
+            handlers={"mock": handler},
+            poll_interval=0,
+        ).run_cycle()
+    )
+
+    assert result.exit_code == 0
+    assert "Retried job-retry; status=pending" in result.stdout
+    assert seen_statuses == [RUNNING]
+    assert processed is True
+    assert get_job(paths.database, job.id).status == DONE
+    assert get_job(paths.database, job.id).error is None
+
+
+def test_jobs_retry_reports_clear_errors_for_unknown_or_non_failed_jobs(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    paths = initialize_storage(data_dir)
+    pending_job = create_job(paths.database, kind="mock", job_id="job-pending")
+
+    unknown_result = runner.invoke(app, ["--data-dir", str(data_dir), "jobs", "retry", "missing"])
+    non_failed_result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "jobs", "retry", pending_job.id],
+    )
+
+    assert unknown_result.exit_code == 1
+    assert "Unknown job: missing" in unknown_result.stdout
+    assert non_failed_result.exit_code == 1
+    assert "Job job-pending is pending; only failed jobs can be retried" in non_failed_result.stdout
+    assert get_job(paths.database, pending_job.id).status == PENDING

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -38,7 +38,7 @@ from newsrag.ingest import (
     list_documents,
     list_pages,
 )
-from newsrag.jobs import FAILED, create_job, get_job, list_jobs
+from newsrag.jobs import FAILED, create_job, get_job, list_jobs, set_job_status
 from newsrag.manifests import ManifestError, load_manifest
 from newsrag.storage import initialize_storage
 
@@ -609,6 +609,58 @@ def test_reingesting_unchanged_pdf_does_not_duplicate_records(tmp_path: Path) ->
     asyncio.run(runner_instance.run_cycle())
     asyncio.run(runner_instance.run_cycle())
 
+    assert len(list_documents(paths.database)) == 1
+    assert len(list_pages(paths.database)) == 1
+    assert len(list_chunks(paths.database)) == 1
+    assert len(list_chunk_vectors(paths.lancedb)) == 1
+    assert len(list_embedding_records(paths.database)) == 2
+
+
+def test_retried_ingest_job_keeps_duplicate_detection_idempotent(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    source_pdf = tmp_path / "packet.pdf"
+    source_pdf.write_bytes(b"%PDF-1.4\nmock")
+    paths = initialize_storage(data_dir)
+
+    first_job = create_job(
+        paths.database,
+        kind=INGEST_JOB_KIND,
+        payload={"path": str(source_pdf.resolve()), "metadata": {"body": "City Council"}},
+        job_id="job-a-first",
+    )
+    failed_duplicate_job = create_job(
+        paths.database,
+        kind=INGEST_JOB_KIND,
+        payload={"path": str(source_pdf.resolve()), "metadata": {"body": "City Council"}},
+        job_id="job-z-duplicate",
+    )
+
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        ocr_runner=FakeOcrRunner(),
+        text_extractor=FakeTextExtractor(pages=[ExtractedPage(page_number=1, text="Agenda")]),
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+    runner_instance = DaemonRunner(
+        database_path=paths.database,
+        handlers={INGEST_JOB_KIND: handler},
+        poll_interval=0,
+    )
+
+    asyncio.run(runner_instance.run_cycle())
+    set_job_status(paths.database, failed_duplicate_job.id, status=FAILED, error="transient boom")
+
+    retry_result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "jobs", "retry", failed_duplicate_job.id],
+    )
+    asyncio.run(runner_instance.run_cycle())
+
+    assert retry_result.exit_code == 0
+    assert get_job(paths.database, first_job.id).status == "done"
+    assert get_job(paths.database, failed_duplicate_job.id).status == "done"
     assert len(list_documents(paths.database)) == 1
     assert len(list_pages(paths.database)) == 1
     assert len(list_chunks(paths.database)) == 1


### PR DESCRIPTION
## Summary
- show job update timestamps, failed timestamps, errors, and source paths in jobs list
- add jobs retry command for failed jobs with clear errors for unknown or non-failed jobs
- summarize queue health and failed job counts in status
- document the required user-approved implementation plan in CONTRIBUTING

## Verification
- make check
- ./scripts/pre-pr.sh

Task: #task-393a0a9c