### PR TITLE
Add watcher debouncing and health checks

### DIFF
--- a/newsrag/daemon.py
+++ b/newsrag/daemon.py
@@ -11,7 +11,7 @@ from newsrag.config import EmbeddingConfig
 from newsrag.ingest import INGEST_JOB_KIND, build_ingest_handler
 from newsrag.jobs import Job, claim_next_job, mark_job_done, mark_job_failed
 from newsrag.storage import initialize_storage
-from newsrag.watches import enqueue_watch_changes, list_watches
+from newsrag.watches import DEFAULT_WATCH_STABILITY_SECONDS, WatchDebouncer, list_watches
 
 JobHandler = Callable[[Job], Awaitable[None]]
 
@@ -28,6 +28,7 @@ class DaemonConfig:
     embedding_config: EmbeddingConfig = EmbeddingConfig()
     poll_interval: float = 0.5
     max_loops: int | None = None
+    watch_stability_seconds: float = DEFAULT_WATCH_STABILITY_SECONDS
 
 
 class DaemonRunner:
@@ -109,6 +110,7 @@ async def run_daemon(
         watch_paths,
         watch_stream_factory=watch_stream_factory or _default_watch_stream,
         max_batches=config.max_loops,
+        stability_seconds=config.watch_stability_seconds,
     )
     await asyncio.gather(runner.run(max_loops=config.max_loops), watch_task)
 
@@ -119,10 +121,18 @@ async def _run_watch_loop(
     *,
     watch_stream_factory: WatchStreamFactory,
     max_batches: int | None,
+    stability_seconds: float,
 ) -> None:
     batches = 0
+    debouncer = WatchDebouncer(
+        database_path=database_path,
+        stability_seconds=stability_seconds,
+    )
     async for changes in watch_stream_factory(watch_paths):
-        await asyncio.to_thread(enqueue_watch_changes, database_path, changes)
+        await asyncio.to_thread(debouncer.consider_changes, changes)
+        if stability_seconds > 0:
+            await asyncio.sleep(stability_seconds)
+        await asyncio.to_thread(debouncer.flush_ready)
         batches += 1
         if max_batches is not None and batches >= max_batches:
             return

--- a/newsrag/doctor.py
+++ b/newsrag/doctor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import stat
 from dataclasses import dataclass
 from pathlib import Path
@@ -9,6 +10,7 @@ from typing import Any
 import httpx
 
 from newsrag.config import EmbeddingConfig, RuntimeSettings
+from newsrag.storage import build_storage_paths
 
 DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
@@ -64,6 +66,7 @@ def run_doctor(
     checks.append(_binary_check("qpdf", "qpdf"))
     checks.append(_embedding_check(settings.config.embedding, timeout_seconds=timeout_seconds))
     checks.append(_daemon_check(settings.config.daemon.socket_path))
+    checks.append(_watcher_check(settings.data_dir))
     return DoctorReport(checks=tuple(checks))
 
 
@@ -246,6 +249,37 @@ def _daemon_check(socket_path: Path | None) -> DoctorCheck:
     return DoctorCheck(
         "daemon", "warn", f"configured path {socket_path} exists but is not a socket"
     )
+
+
+def _watcher_check(data_dir: Path) -> DoctorCheck:
+    database_path = build_storage_paths(data_dir).database
+    if not database_path.exists():
+        return DoctorCheck("watcher", "info", "storage is not initialized; no watches to inspect")
+
+    try:
+        with sqlite3.connect(database_path) as connection:
+            rows = connection.execute("SELECT path FROM watches ORDER BY path ASC").fetchall()
+    except sqlite3.Error as exc:
+        return DoctorCheck("watcher", "warn", f"could not inspect watches: {exc}")
+
+    if not rows:
+        return DoctorCheck("watcher", "ok", "no watched folders configured")
+
+    problems: list[str] = []
+    for (raw_path,) in rows:
+        path = Path(str(raw_path))
+        if not path.exists():
+            problems.append(
+                f"missing watched folder {path}; recreate it or remove/re-add the watch"
+            )
+        elif not path.is_dir():
+            problems.append(f"watched path {path} is not a directory; remove/re-add the watch")
+        elif not os.access(path, os.R_OK | os.X_OK):
+            problems.append(f"watched folder {path} is not readable; fix permissions")
+
+    if problems:
+        return DoctorCheck("watcher", "warn", "; ".join(problems))
+    return DoctorCheck("watcher", "ok", f"{len(rows)} watched folder(s) ready")
 
 
 def _json_get(

--- a/newsrag/storage.py
+++ b/newsrag/storage.py
@@ -287,6 +287,7 @@ def get_storage_status(data_dir: Path) -> StorageStatusReport:
     else:
         checks.append(StorageCheck("database", "ok", f"schema ready at {paths.database}"))
         checks.append(_job_queue_check(paths.database))
+        checks.append(_watcher_health_check(paths.database))
 
     return StorageStatusReport(checks=tuple(checks))
 
@@ -312,6 +313,30 @@ def _job_status_counts(database_path: Path) -> dict[str, int]:
     for status, count in rows:
         counts[str(status)] = int(count)
     return counts
+
+
+def _watcher_health_check(database_path: Path) -> StorageCheck:
+    with sqlite3.connect(database_path) as connection:
+        rows = connection.execute("SELECT path FROM watches ORDER BY path ASC").fetchall()
+
+    if not rows:
+        return StorageCheck("watcher", "ok", "no watched folders configured")
+
+    problems: list[str] = []
+    for (raw_path,) in rows:
+        path = Path(str(raw_path))
+        if not path.exists():
+            problems.append(
+                f"missing watched folder {path}; recreate it or remove/re-add the watch"
+            )
+        elif not path.is_dir():
+            problems.append(f"watched path {path} is not a directory; remove/re-add the watch")
+        elif not os.access(path, os.R_OK | os.X_OK):
+            problems.append(f"watched folder {path} is not readable; fix permissions")
+
+    if problems:
+        return StorageCheck("watcher", "warn", "; ".join(problems))
+    return StorageCheck("watcher", "ok", f"{len(rows)} watched folder(s) ready")
 
 
 def format_status_report(report: StorageStatusReport, *, data_dir: Path) -> str:

--- a/newsrag/watches.py
+++ b/newsrag/watches.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import json
 import sqlite3
 import uuid
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,7 @@ from newsrag.ingest import INGEST_JOB_KIND
 from newsrag.jobs import Job, create_job
 
 WATCH_JOB_KIND = INGEST_JOB_KIND
+DEFAULT_WATCH_STABILITY_SECONDS = 1.0
 
 
 @dataclass(frozen=True)
@@ -84,44 +86,126 @@ def get_watch_by_path(database_path: Path, path: Path) -> Watch:
     return _row_to_watch(row)
 
 
+@dataclass(frozen=True)
+class WatchCandidate:
+    """One pending watch candidate waiting for file stabilization."""
+
+    path: Path
+    watch: Watch
+    signature: str
+    observed_at: float
+
+
+@dataclass
+class WatchDebouncer:
+    """Debounce watch events until candidate PDFs have stable signatures."""
+
+    database_path: Path
+    stability_seconds: float = DEFAULT_WATCH_STABILITY_SECONDS
+    monotonic: Callable[[], float] | None = None
+    candidates: dict[Path, WatchCandidate] = field(default_factory=dict)
+
+    def consider_changes(self, changes: set[tuple[object, str]]) -> None:
+        """Track changed PDF paths as stabilization candidates."""
+
+        watches = list_watches(self.database_path)
+        now = self._now()
+        for _, changed_path_text in sorted(changes, key=lambda item: item[1]):
+            changed_path = Path(changed_path_text).expanduser().resolve()
+            watch = _matching_watch(changed_path, watches)
+            if watch is None or not _is_existing_pdf(changed_path):
+                continue
+
+            signature = _file_signature(changed_path)
+            candidate = self.candidates.get(changed_path)
+            if candidate is None or candidate.signature != signature:
+                self.candidates[changed_path] = WatchCandidate(
+                    path=changed_path,
+                    watch=watch,
+                    signature=signature,
+                    observed_at=now,
+                )
+
+    def flush_ready(self) -> list[Job]:
+        """Enqueue candidates whose file signatures remained stable long enough."""
+
+        now = self._now()
+        enqueued: list[Job] = []
+        for path, candidate in sorted(self.candidates.items(), key=lambda item: str(item[0])):
+            if not _is_existing_pdf(path):
+                del self.candidates[path]
+                continue
+
+            current_signature = _file_signature(path)
+            if current_signature != candidate.signature:
+                self.candidates[path] = WatchCandidate(
+                    path=path,
+                    watch=candidate.watch,
+                    signature=current_signature,
+                    observed_at=now,
+                )
+                continue
+
+            if now - candidate.observed_at < self.stability_seconds:
+                continue
+
+            job = _enqueue_stable_watch_pdf(
+                self.database_path,
+                path,
+                candidate.watch,
+                current_signature,
+            )
+            del self.candidates[path]
+            if job is not None:
+                enqueued.append(job)
+
+        return enqueued
+
+    def _now(self) -> float:
+        if self.monotonic is None:
+            import time
+
+            return time.monotonic()
+        return self.monotonic()
+
+
 def enqueue_watch_changes(
     database_path: Path,
     changes: set[tuple[object, str]],
 ) -> list[Job]:
-    """Turn relevant watch-file changes into durable ingestion jobs."""
+    """Turn relevant stable watch-file changes into durable ingestion jobs."""
 
-    watches = list_watches(database_path)
-    enqueued: list[Job] = []
+    debouncer = WatchDebouncer(database_path=database_path, stability_seconds=0)
+    debouncer.consider_changes(changes)
+    return debouncer.flush_ready()
 
-    for _, changed_path_text in sorted(changes, key=lambda item: item[1]):
-        changed_path = Path(changed_path_text).expanduser().resolve()
-        watch = _matching_watch(changed_path, watches)
-        if watch is None:
-            continue
-        if changed_path.suffix.lower() != ".pdf":
-            continue
-        if not changed_path.exists() or not changed_path.is_file():
-            continue
 
-        signature = _file_signature(changed_path)
-        if _seen_signature(database_path, changed_path, signature):
-            continue
+def _enqueue_stable_watch_pdf(
+    database_path: Path,
+    changed_path: Path,
+    watch: Watch,
+    signature: str,
+) -> Job | None:
+    if _seen_signature(database_path, changed_path, signature):
+        return None
 
-        job = create_job(
-            database_path,
-            kind=INGEST_JOB_KIND,
-            payload={
-                "path": str(changed_path),
-                "watch_id": watch.id,
-                "metadata": watch.metadata,
-                "signature": signature,
-                "source": "watch",
-            },
-        )
-        _remember_signature(database_path, changed_path, watch.id, signature)
-        enqueued.append(job)
+    job = create_job(
+        database_path,
+        kind=INGEST_JOB_KIND,
+        payload={
+            "path": str(changed_path),
+            "watch_id": watch.id,
+            "metadata": watch.metadata,
+            "signature": signature,
+            "source": "watch",
+        },
+    )
+    _remember_signature(database_path, changed_path, watch.id, signature)
+    return job
 
-    return enqueued
+
+def _is_existing_pdf(path: Path) -> bool:
+    return path.suffix.lower() == ".pdf" and path.exists() and path.is_file()
 
 
 def _matching_watch(changed_path: Path, watches: list[Watch]) -> Watch | None:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -5,8 +5,10 @@ from pathlib import Path
 import httpx
 import pytest
 
-from newsrag.config import AppConfig, EmbeddingConfig, RuntimeSettings
+from newsrag.config import AppConfig, DaemonConfig, EmbeddingConfig, RuntimeSettings
 from newsrag.doctor import DoctorCheck, DoctorReport, format_report, run_doctor
+from newsrag.storage import initialize_storage
+from newsrag.watches import add_watch
 
 
 def test_format_report_uses_warn_summary_for_warnings(tmp_path: Path) -> None:
@@ -48,6 +50,44 @@ def test_run_doctor_warns_when_embedding_provider_is_unconfigured(tmp_path: Path
     assert embedding_check.status == "warn"
     assert "no embedding provider configured" in embedding_check.detail
     assert report.summary == "warn"
+
+
+def test_run_doctor_reports_daemon_connectivity_when_configured(tmp_path: Path) -> None:
+    socket_path = tmp_path / "missing.sock"
+    settings = RuntimeSettings(
+        config_path=tmp_path / "config.yaml",
+        data_dir=tmp_path / ".newsrag",
+        config=AppConfig(
+            source_path=tmp_path / "config.yaml",
+            daemon=DaemonConfig(socket_path=socket_path),
+        ),
+    )
+
+    report = run_doctor(settings)
+
+    daemon_check = next(check for check in report.checks if check.name == "daemon")
+    assert daemon_check.status == "warn"
+    assert str(socket_path) in daemon_check.detail
+    assert "not found" in daemon_check.detail
+
+
+def test_run_doctor_reports_actionable_watcher_health_failures(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    missing_watch_dir = tmp_path / "missing"
+    paths = initialize_storage(data_dir)
+    add_watch(paths.database, path=missing_watch_dir)
+    settings = RuntimeSettings(
+        config_path=tmp_path / "config.yaml",
+        data_dir=data_dir,
+        config=AppConfig(source_path=tmp_path / "config.yaml"),
+    )
+
+    report = run_doctor(settings)
+
+    watcher_check = next(check for check in report.checks if check.name == "watcher")
+    assert watcher_check.status == "warn"
+    assert "missing watched folder" in watcher_check.detail
+    assert "remove/re-add the watch" in watcher_check.detail
 
 
 def test_run_doctor_handles_malformed_ollama_response(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -8,6 +8,7 @@ from typer.testing import CliRunner
 
 from newsrag.cli import app
 from newsrag.storage import REQUIRED_TABLES, StorageError, _existing_tables, initialize_storage
+from newsrag.watches import add_watch
 
 runner = CliRunner()
 
@@ -133,4 +134,21 @@ def test_status_command_reports_storage_health(tmp_path: Path) -> None:
     assert third_result.exit_code == 0
     assert "database: ok" in third_result.stdout
     assert "source_pdfs: ok" in third_result.stdout
+    assert "jobs: ok" in third_result.stdout
+    assert "watcher: ok" in third_result.stdout
     assert "summary: ok" in third_result.stdout
+
+
+def test_status_reports_actionable_watcher_health_failures(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    missing_watch_dir = tmp_path / "missing"
+    paths = initialize_storage(data_dir)
+    add_watch(paths.database, path=missing_watch_dir)
+
+    result = runner.invoke(app, ["--data-dir", str(data_dir), "status"])
+
+    assert result.exit_code == 0
+    assert "watcher: warn" in result.stdout
+    assert "missing watched folder" in result.stdout
+    assert "remove/re-add the watch" in result.stdout
+    assert "summary: warn" in result.stdout

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -10,7 +10,7 @@ from newsrag.cli import app
 from newsrag.daemon import DaemonConfig, run_daemon
 from newsrag.jobs import Job, list_jobs
 from newsrag.storage import initialize_storage
-from newsrag.watches import WATCH_JOB_KIND, add_watch
+from newsrag.watches import WATCH_JOB_KIND, WatchDebouncer, add_watch
 
 runner = CliRunner()
 
@@ -63,7 +63,9 @@ def test_daemon_enqueues_job_for_pdf_watch_event(tmp_path: Path) -> None:
 
     asyncio.run(
         run_daemon(
-            DaemonConfig(data_dir=data_dir, poll_interval=0, max_loops=1),
+            DaemonConfig(
+                data_dir=data_dir, poll_interval=0, max_loops=1, watch_stability_seconds=0
+            ),
             handlers={WATCH_JOB_KIND: _noop_handler},
             watch_stream_factory=fake_watch_stream,
         )
@@ -91,7 +93,9 @@ def test_non_pdf_files_are_ignored(tmp_path: Path) -> None:
 
     asyncio.run(
         run_daemon(
-            DaemonConfig(data_dir=data_dir, poll_interval=0, max_loops=1),
+            DaemonConfig(
+                data_dir=data_dir, poll_interval=0, max_loops=1, watch_stability_seconds=0
+            ),
             handlers={WATCH_JOB_KIND: _noop_handler},
             watch_stream_factory=fake_watch_stream,
         )
@@ -117,7 +121,9 @@ def test_duplicate_unchanged_pdf_events_do_not_create_duplicate_jobs(tmp_path: P
 
     asyncio.run(
         run_daemon(
-            DaemonConfig(data_dir=data_dir, poll_interval=0, max_loops=2),
+            DaemonConfig(
+                data_dir=data_dir, poll_interval=0, max_loops=2, watch_stability_seconds=0
+            ),
             handlers={WATCH_JOB_KIND: _noop_handler},
             watch_stream_factory=fake_watch_stream,
         )
@@ -126,6 +132,79 @@ def test_duplicate_unchanged_pdf_events_do_not_create_duplicate_jobs(tmp_path: P
     jobs = list_jobs(paths.database)
     assert len(jobs) == 1
     assert jobs[0].payload["path"] == str(pdf_path.resolve())
+
+
+def test_burst_of_pdf_events_enqueues_once_after_stabilization(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    watch_dir = tmp_path / "incoming"
+    watch_dir.mkdir()
+    pdf_path = watch_dir / "packet.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+    clock = FakeClock()
+
+    paths = initialize_storage(data_dir)
+    add_watch(paths.database, path=watch_dir)
+    debouncer = WatchDebouncer(
+        database_path=paths.database,
+        stability_seconds=5,
+        monotonic=clock.now,
+    )
+
+    change = ("modified", str(pdf_path.resolve()))
+    debouncer.consider_changes({change})
+    debouncer.consider_changes({change})
+    assert debouncer.flush_ready() == []
+
+    clock.advance(5)
+    jobs = debouncer.flush_ready()
+
+    assert len(jobs) == 1
+    assert jobs[0].payload["path"] == str(pdf_path.resolve())
+    assert debouncer.flush_ready() == []
+    assert len(list_jobs(paths.database)) == 1
+
+
+def test_changing_pdf_waits_until_signature_is_stable(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    watch_dir = tmp_path / "incoming"
+    watch_dir.mkdir()
+    pdf_path = watch_dir / "packet.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\npartial")
+    clock = FakeClock()
+
+    paths = initialize_storage(data_dir)
+    add_watch(paths.database, path=watch_dir)
+    debouncer = WatchDebouncer(
+        database_path=paths.database,
+        stability_seconds=5,
+        monotonic=clock.now,
+    )
+
+    debouncer.consider_changes({("modified", str(pdf_path.resolve()))})
+    clock.advance(5)
+    pdf_path.write_bytes(b"%PDF-1.4\ncomplete")
+
+    assert debouncer.flush_ready() == []
+
+    clock.advance(4)
+    assert debouncer.flush_ready() == []
+
+    clock.advance(1)
+    jobs = debouncer.flush_ready()
+
+    assert len(jobs) == 1
+    assert jobs[0].payload["path"] == str(pdf_path.resolve())
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def now(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
 
 
 async def _noop_handler(_: Job) -> None:


### PR DESCRIPTION
## Summary
- add watch event debouncing with file signature stabilization before enqueueing PDFs
- keep duplicate suppression for unchanged stable files
- surface watcher health in status and doctor with actionable watch path warnings
- add mocked-clock tests for burst events and changing-file stabilization

## Verification
- make check
- ./scripts/pre-pr.sh

Task: #task-c98325bb