### PR TITLE
Add branch CI for lint, build, and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches:
+    branches-ignore:
       - main
 
 jobs:
@@ -26,5 +26,17 @@ jobs:
       - name: Sync dependencies
         run: uv sync --dev
 
-      - name: Run checks
-        run: make check
+      - name: Check formatting
+        run: uv run ruff format --check .
+
+      - name: Lint
+        run: uv run ruff check .
+
+      - name: Type check
+        run: uv run mypy .
+
+      - name: Build package
+        run: uv build
+
+      - name: Run unit tests
+        run: uv run pytest -m "not integration"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 addopts = "-v"
+markers = [
+    "integration: tests that require external services or slow end-to-end setup",
+]
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
## Summary
- run CI on pull requests and non-main branch pushes only
- split CI into formatting, lint, type-check, build, and unit-test steps
- exclude integration tests from CI with pytest marker support

## Verification
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy .
- uv build
- uv run pytest -m "not integration" -q
- make check
- ./scripts/pre-pr.sh

Task: #task-7b5221fd