### PR TITLE
Add install script and release workflow

### DIFF
--- a/.pi/skills/release/SKILL.md
+++ b/.pi/skills/release/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: release
+description: Release newsrag. Use when user says "release newsrag", "create a release", "new version", "bump version", "ship it", "cut a release", or similar.
+---
+
+# Release newsrag
+
+Guide the release process through conversation. Draft a changelog collaboratively, bump the project version, tag, and push.
+
+## Quick Reference
+
+```bash
+.pi/skills/release/scripts/release.sh <version>  # e.g. 0.2.0
+```
+
+## Workflow
+
+### 1. Pre-flight
+
+Verify readiness — stop and report if any check fails.
+
+```bash
+git branch --show-current          # must be main
+git fetch origin main
+git log origin/main..HEAD --oneline  # must be empty
+gh pr list --state open --json number,title  # warn if any open
+make check
+uv build
+```
+
+### 2. Determine current version
+
+The source of truth is `project.version` in `pyproject.toml`.
+
+```bash
+python - <<'PY'
+import tomllib
+from pathlib import Path
+print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])
+PY
+```
+
+Also check the latest release tag:
+
+```bash
+git tag --list 'v*' --sort=-v:refname | head -1
+```
+
+### 3. Gather changes
+
+Collect changes since the last tag:
+
+```bash
+LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
+git log ${LATEST_TAG:-HEAD}..HEAD --oneline --no-merges
+```
+
+Cross-reference task IDs from commit messages where present.
+
+### 4. Recommend version bump
+
+Analyze commit prefixes:
+- `feat!:` or `BREAKING CHANGE:` → major
+- `feat:` → minor
+- `fix:` → patch
+
+Present recommendation with reasoning. User confirms or overrides.
+
+### 5. Draft changelog conversationally
+
+If `CHANGELOG.md` exists, update it. If it does not exist, create it with a Keep a Changelog style header. Do not run the release script until the user approves the changelog.
+
+### 6. Run release script
+
+Once the changelog is approved:
+
+```bash
+.pi/skills/release/scripts/release.sh <version>
+```
+
+The script handles:
+1. Validate on `main` with no unpushed commits.
+2. Update `project.version` in `pyproject.toml`.
+3. Refresh `uv.lock` metadata.
+4. Commit version/changelog artifacts.
+5. Create annotated tag `v<version>`.
+6. Push commit and tag.
+7. Verify tag exists on remote.
+
+## Important
+
+- Never force push or use force flags.
+- Never run the release script without user approval of the changelog.
+- If anything fails, stop and report; do not retry blindly.

--- a/.pi/skills/release/scripts/release.sh
+++ b/.pi/skills/release/scripts/release.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+die() { echo -e "${RED}Error: $1${NC}" >&2; exit 1; }
+info() { echo -e "${GREEN}$1${NC}"; }
+warn() { echo -e "${YELLOW}$1${NC}"; }
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <version>"
+  echo "Example: $0 0.2.0"
+  exit 1
+fi
+
+NEW_VERSION="$1"
+NEW_TAG="v${NEW_VERSION}"
+
+if ! echo "$NEW_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+  die "Invalid version format: $NEW_VERSION (expected X.Y.Z or X.Y.Z-suffix)"
+fi
+
+command -v python3 >/dev/null 2>&1 || die "Missing required command: python3"
+command -v uv >/dev/null 2>&1 || die "Missing required command: uv"
+
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  die "Must be on main branch (currently on '$CURRENT_BRANCH')"
+fi
+
+git fetch origin main --quiet
+UNPUSHED=$(git log origin/main..HEAD --oneline)
+if [[ -n "$UNPUSHED" ]]; then
+  die "Unpushed commits on main:\n$UNPUSHED\n\nPush these first."
+fi
+
+if git tag --list | grep -q "^${NEW_TAG}$"; then
+  die "Tag $NEW_TAG already exists locally"
+fi
+if git ls-remote --tags origin | grep -q "refs/tags/${NEW_TAG}$"; then
+  die "Tag $NEW_TAG already exists on remote"
+fi
+
+if [[ ! -f CHANGELOG.md ]]; then
+  die "CHANGELOG.md is required and must be updated before release"
+fi
+
+info "Releasing: $NEW_TAG"
+
+python3 - "$NEW_VERSION" <<'PY'
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+version = sys.argv[1]
+path = Path("pyproject.toml")
+text = path.read_text(encoding="utf-8")
+updated = re.sub(
+    r'(?m)^(version\s*=\s*)"[^"]+"',
+    rf'\1"{version}"',
+    text,
+    count=1,
+)
+if updated == text:
+    raise SystemExit("project.version not found in pyproject.toml")
+path.write_text(updated, encoding="utf-8")
+PY
+
+uv lock
+
+git add pyproject.toml uv.lock CHANGELOG.md
+
+if git diff --cached --quiet; then
+  warn "No version or changelog changes to commit"
+else
+  git commit -m "chore: release v${NEW_VERSION}"
+  info "Committed release v${NEW_VERSION}"
+fi
+
+git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+info "Created tag: $NEW_TAG"
+
+info "Pushing to origin..."
+git push origin main --follow-tags
+
+info "Verifying tag on remote..."
+sleep 2
+if ! git ls-remote --tags origin | grep -q "refs/tags/${NEW_TAG}$"; then
+  die "Tag $NEW_TAG was NOT pushed to remote. Manually push with: git push origin $NEW_TAG"
+fi
+
+info ""
+info "✅ Released $NEW_TAG"
+info "✅ Tag verified on remote"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ For the full macOS setup, installation commands, and validation steps, see [docs
 
 ## Installation
 
+Install the latest version from GitHub:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/evcraddock/newsrag/main/scripts/install.sh | bash
+```
+
+For development from a checkout:
+
 ```bash
 uv sync --dev
 ```

--- a/newsrag/__init__.py
+++ b/newsrag/__init__.py
@@ -1,1 +1,8 @@
 """NewsRAG package."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("newsrag")
+except PackageNotFoundError:  # pragma: no cover - source tree without installed metadata
+    __version__ = "0.0.0"

--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import typer
 
+from newsrag import __version__
 from newsrag.config import (
     DEFAULT_CONFIG_PATH,
     AppConfig,
@@ -62,7 +63,11 @@ PDF_EXTRACTOR_OPTION = typer.Option(
     help="PDF text extractor mode: auto, pymupdf, pdfplumber, or table.",
 )
 
-app = typer.Typer(help="Local-first evidence retrieval for city hall PDFs.")
+app = typer.Typer(
+    help="Local-first evidence retrieval for city hall PDFs.",
+    invoke_without_command=True,
+    no_args_is_help=True,
+)
 daemon_app = typer.Typer(help="Run the NewsRAG background daemon.")
 jobs_app = typer.Typer(help="Inspect durable NewsRAG jobs.")
 watch_app = typer.Typer(help="Manage watched folders for automatic ingestion.")
@@ -84,8 +89,13 @@ def main(
     ctx: typer.Context,
     config_path: Path | None = CONFIG_PATH_OPTION,
     data_dir: Path | None = DATA_DIR_OPTION,
+    version: bool = typer.Option(False, "--version", help="Show the NewsRAG version and exit."),
 ) -> None:
     """Run NewsRAG commands."""
+
+    if version:
+        typer.echo(f"newsrag {__version__}")
+        raise typer.Exit
 
     ctx.obj = CliState(
         config_path=(config_path or DEFAULT_CONFIG_PATH).expanduser(),

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="${NEWSRAG_REPO_URL:-https://github.com/evcraddock/newsrag.git}"
+INSTALL_DIR="${NEWSRAG_INSTALL_DIR:-$HOME/.local/share/newsrag}"
+REF="${NEWSRAG_REF:-main}"
+
+log() { printf '%s\n' "$*"; }
+die() { printf 'Error: %s\n' "$*" >&2; exit 1; }
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+require_command git
+require_command uv
+
+source_dir=""
+script_path="${BASH_SOURCE[0]}"
+if [[ -f "$script_path" ]]; then
+    candidate_dir="$(cd "$(dirname "$script_path")/.." && pwd)"
+    if [[ -f "$candidate_dir/pyproject.toml" && -d "$candidate_dir/newsrag" ]]; then
+        source_dir="$candidate_dir"
+    fi
+fi
+
+if [[ -n "$source_dir" ]]; then
+    log "Installing NewsRAG from source at $source_dir"
+else
+    if [[ -d "$INSTALL_DIR/.git" ]]; then
+        log "Updating NewsRAG checkout at $INSTALL_DIR"
+        git -C "$INSTALL_DIR" fetch --tags origin
+    else
+        log "Cloning NewsRAG into $INSTALL_DIR"
+        mkdir -p "$(dirname "$INSTALL_DIR")"
+        rm -rf "$INSTALL_DIR"
+        git clone "$REPO_URL" "$INSTALL_DIR"
+    fi
+
+    git -C "$INSTALL_DIR" checkout "$REF"
+    git -C "$INSTALL_DIR" pull --ff-only origin "$REF" 2>/dev/null || true
+    source_dir="$INSTALL_DIR"
+fi
+
+log "Installing NewsRAG with uv"
+uv tool install --force "$source_dir"
+
+if command -v newsrag >/dev/null 2>&1; then
+    log "Installed $(newsrag --version 2>/dev/null || printf 'newsrag')"
+else
+    log "Installed newsrag. Ensure uv's tool bin directory is on PATH."
+fi
+
+log "Done. Try: newsrag --help"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 from typer.testing import CliRunner
 
+from newsrag import __version__
 from newsrag.cli import app
 from newsrag.config import EmbeddingConfig
 from newsrag.doctor import DoctorCheck, DoctorReport
@@ -26,6 +27,13 @@ def test_help_shows_cli_commands() -> None:
     assert "search" in result.stdout
     assert "jobs" in result.stdout
     assert "watch" in result.stdout
+
+
+def test_version_option_shows_project_version() -> None:
+    result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert f"newsrag {__version__}" in result.stdout
 
 
 def test_doctor_runs_without_crashing(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- expose project version through package metadata and a `newsrag --version` CLI option
- add curl-friendly `scripts/install.sh` that installs from a checkout/source tree or clones from GitHub
- add a project release skill and release script for updating `pyproject.toml`, refreshing `uv.lock`, committing, tagging, and pushing
- document curl-based installation in README

## Verification
- `bash -n scripts/install.sh .pi/skills/release/scripts/release.sh`
- `uv build`
- `uv run pytest tests/test_cli.py -q`
- `make check`
- `./scripts/pre-pr.sh`

Task: #task-c22cca03
