### PR TITLE
Add tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,171 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.2.0)"
+        required: true
+
+concurrency:
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+      version: ${{ steps.version.outputs.version }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Check out release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Extract and validate version
+        id: version
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'; then
+            echo "::error::Invalid release tag: $TAG"
+            exit 1
+          fi
+
+          VERSION="${TAG#v}"
+          PYPROJECT_VERSION=$(python -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])")
+
+          if [ "$PYPROJECT_VERSION" != "$VERSION" ]; then
+            echo "::error::Version mismatch: tag $TAG expects $VERSION but pyproject.toml has $PYPROJECT_VERSION"
+            exit 1
+          fi
+
+          echo "✅ pyproject.toml version matches $TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          if echo "$VERSION" | grep -qE '(alpha|beta|rc|dev)'; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build and test package
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Sync dependencies
+        run: uv sync --dev
+
+      - name: Check formatting
+        run: uv run ruff format --check .
+
+      - name: Lint
+        run: uv run ruff check .
+
+      - name: Type check
+        run: uv run mypy .
+
+      - name: Run unit tests
+        run: uv run pytest -m "not integration"
+
+      - name: Build package
+        run: uv build
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/*
+
+  release:
+    name: Create GitHub Release
+    needs: [validate, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.tag }}
+
+      - name: Download package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist
+
+      - name: Extract changelog
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          BODY=""
+          if [ -f CHANGELOG.md ]; then
+            BODY=$(awk "/^## .*${VERSION//./\\.}/ {found=1; next} /^## / {if(found) exit} found {print}" CHANGELOG.md)
+          fi
+
+          if [ -z "$BODY" ]; then
+            BODY="Release v${VERSION}"
+          fi
+
+          printf '%s\n' "$BODY" > release-notes.md
+          cat release-notes.md
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.validate.outputs.tag }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          PRERELEASE: ${{ needs.validate.outputs.prerelease }}
+        run: |
+          prerelease_flag=()
+          if [ "$PRERELEASE" = "true" ]; then
+            prerelease_flag=(--prerelease)
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --title "newsrag $TAG" \
+              --notes-file release-notes.md \
+              "${prerelease_flag[@]}"
+            gh release upload "$TAG" dist/* --clobber
+          else
+            gh release create "$TAG" dist/* \
+              --title "newsrag $TAG" \
+              --notes-file release-notes.md \
+              "${prerelease_flag[@]}"
+          fi

--- a/.pi/skills/release/SKILL.md
+++ b/.pi/skills/release/SKILL.md
@@ -5,7 +5,7 @@ description: Release newsrag. Use when user says "release newsrag", "create a re
 
 # Release newsrag
 
-Guide the release process through conversation. Draft a changelog collaboratively, bump the project version, tag, and push.
+Guide the release process through conversation. Draft a changelog collaboratively, bump the project version, tag, and push. GitHub Actions creates or updates the GitHub Release from the pushed tag.
 
 ## Quick Reference
 
@@ -86,6 +86,18 @@ The script handles:
 5. Create annotated tag `v<version>`.
 6. Push commit and tag.
 7. Verify tag exists on remote.
+
+The tag push triggers `.github/workflows/release.yml`, which validates the tag, runs checks, builds the Python distribution artifacts, extracts the matching `CHANGELOG.md` section, and creates or updates the GitHub Release with the built artifacts.
+
+### 7. Post-release
+
+After the script succeeds, verify the release workflow:
+
+```bash
+gh run list --workflow Release --limit 1 --json databaseId,status,conclusion,event,headBranch
+```
+
+If needed for an existing tag, manually dispatch the release workflow with the tag name.
 
 ## Important
 

--- a/.pi/skills/release/scripts/release.sh
+++ b/.pi/skills/release/scripts/release.sh
@@ -60,14 +60,10 @@ from pathlib import Path
 version = sys.argv[1]
 path = Path("pyproject.toml")
 text = path.read_text(encoding="utf-8")
-updated = re.sub(
-    r'(?m)^(version\s*=\s*)"[^"]+"',
-    rf'\1"{version}"',
-    text,
-    count=1,
-)
-if updated == text:
+pattern = r'(?m)^(version\s*=\s*)"[^"]+"'
+if re.search(pattern, text) is None:
     raise SystemExit("project.version not found in pyproject.toml")
+updated = re.sub(pattern, rf'\1"{version}"', text, count=1)
 path.write_text(updated, encoding="utf-8")
 PY
 
@@ -97,3 +93,6 @@ fi
 info ""
 info "✅ Released $NEW_TAG"
 info "✅ Tag verified on remote"
+info ""
+info "GitHub Actions will create or update the GitHub Release from the tag."
+info "Monitor with: gh run list --workflow Release --limit 1"


### PR DESCRIPTION
## Summary
- add a tag-triggered and manually dispatchable GitHub Release workflow
- validate release tags against `pyproject.toml`, run checks, build `dist/*`, extract changelog notes, and create/update the GitHub Release with artifacts
- update the release skill and script messaging so the script pushes the tag and GitHub Actions creates the release
- fix the release script so releasing an already-current version can still proceed when changelog changes exist

## Verification
- `bash -n .pi/skills/release/scripts/release.sh`
- parsed `.github/workflows/release.yml` and `.github/workflows/ci.yml` with PyYAML
- `make check`
- `./scripts/pre-pr.sh`

Task: #task-c22cca03
