### PR TITLE
Fix piped install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,8 +15,8 @@ require_command git
 require_command uv
 
 source_dir=""
-script_path="${BASH_SOURCE[0]}"
-if [[ -f "$script_path" ]]; then
+script_path="${BASH_SOURCE[0]-}"
+if [[ -n "$script_path" && -f "$script_path" ]]; then
     candidate_dir="$(cd "$(dirname "$script_path")/.." && pwd)"
     if [[ -f "$candidate_dir/pyproject.toml" && -d "$candidate_dir/newsrag" ]]; then
         source_dir="$candidate_dir"

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_install_script_runs_when_piped_to_bash(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    git = bin_dir / "git"
+    git.write_text(
+        """#!/usr/bin/env bash
+set -eu
+if [[ "${1:-}" == "clone" ]]; then
+    mkdir -p "$3/.git"
+    exit 0
+fi
+if [[ "${1:-}" == "-C" ]]; then
+    case "${3:-}" in
+        fetch|checkout|pull) exit 0 ;;
+    esac
+fi
+echo "unexpected git invocation: $*" >&2
+exit 1
+""",
+        encoding="utf-8",
+    )
+    git.chmod(0o755)
+
+    uv = bin_dir / "uv"
+    uv.write_text(
+        """#!/usr/bin/env bash
+set -eu
+if [[ "${1:-}" == "tool" && "${2:-}" == "install" ]]; then
+    exit 0
+fi
+echo "unexpected uv invocation: $*" >&2
+exit 1
+""",
+        encoding="utf-8",
+    )
+    uv.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path / "home"),
+            "NEWSRAG_INSTALL_DIR": str(tmp_path / "checkout"),
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+        }
+    )
+
+    script = Path("scripts/install.sh").read_text(encoding="utf-8")
+    result = subprocess.run(
+        ["bash"],
+        input=script,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Cloning NewsRAG into" in result.stdout
+    assert "Installing NewsRAG with uv" in result.stdout


### PR DESCRIPTION
## Summary
- fix `scripts/install.sh` when run via `curl ... | bash`
- guard `BASH_SOURCE[0]` so `set -u` does not fail when the script is provided on stdin
- add a regression test that pipes the install script into bash with fake `git` and `uv`

## Verification
- `bash -n scripts/install.sh`
- `uv run pytest tests/test_install_script.py -q`
- `make check`
- `./scripts/pre-pr.sh`
