### PR TITLE
Default data dir to user storage

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ newsrag jobs retry <job-id>
 
 ## Storage and configuration
 
-NewsRAG uses configurable local storage with a per-corpus data directory defaulting to `./.newsrag/`. A user can override the active data directory with a CLI flag or configured default. The data directory contains the corpus-local SQLite database, LanceDB vector index directory, downloaded source PDFs, OCR-normalized PDFs, processing artifacts, and local logs relevant to that corpus.
+NewsRAG uses configurable local storage with a data directory defaulting to the user data directory (`$XDG_DATA_HOME/newsrag`, or `~/.local/share/newsrag` when `XDG_DATA_HOME` is unset). A user can override the active data directory with a CLI flag or configured default for a separate corpus. The data directory contains the corpus-local SQLite database, LanceDB vector index directory, downloaded source PDFs, OCR-normalized PDFs, processing artifacts, and local logs relevant to that corpus.
 
 Configuration is user-global, for example `~/.config/newsrag/config.yaml`. The global config stores daemon settings, embedding provider/model defaults, watched folder registrations, and user-level defaults. CLI flags can override config values for a specific command.
 
@@ -38,7 +38,7 @@ The daemon is global and may manage many data directories over time. Search beha
 
 NewsRAG is organized around a small set of durable entities rather than a server-side application model.
 
-- **Corpus/data directory**: a local collection of documents, metadata, artifacts, and indexes stored under a `.newsrag/` directory or configured equivalent.
+- **Corpus/data directory**: a local collection of documents, metadata, artifacts, and indexes stored under the default user data directory or configured equivalent.
 - **Document**: a source PDF and its user-supplied civic metadata, such as title, source URL, meeting date, body or committee, document type, and jurisdiction.
 - **Normalized PDF artifact**: the OCR-normalized/searchable PDF produced from the source document and used for text extraction.
 - **Page**: canonical extracted page text with page number and extraction quality information. Pages are the source of citation truth.

--- a/docs/plans/01-cli-config-doctor.md
+++ b/docs/plans/01-cli-config-doctor.md
@@ -8,7 +8,7 @@ Create the initial Typer CLI foundation, global config loading, selected data-di
 
 - Add a Typer-based `newsrag` CLI entrypoint runnable through `uv run newsrag`.
 - Load user-global configuration from a conventional config path such as `~/.config/newsrag/config.yaml`.
-- Resolve the active corpus data directory from CLI flag, config, or default `./.newsrag/`.
+- Resolve the active corpus data directory from CLI flag, config, or the default user data directory.
 - Implement `newsrag doctor` with checks for config validity, data-dir writability, OCR tooling presence, embedding provider availability, and daemon connectivity when applicable.
 - Keep output readable for humans and stable enough for agents to inspect.
 

--- a/docs/plans/02-corpus-storage-lifecycle.md
+++ b/docs/plans/02-corpus-storage-lifecycle.md
@@ -6,7 +6,7 @@ Make a selected corpus data directory usable by the CLI and daemon by creating, 
 
 ## Requirements
 
-- Initialize a `.newsrag/` data directory when needed.
+- Initialize the configured NewsRAG data directory when needed.
 - Create stable subdirectories for source PDFs, downloaded PDFs, OCR-normalized PDFs, LanceDB data, logs, and transient processing artifacts.
 - Create or migrate the SQLite database enough to track high-level entities: documents, pages, chunks, jobs, watches, and metadata.
 - Ensure storage initialization is idempotent.

--- a/newsrag/config.py
+++ b/newsrag/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -7,7 +8,7 @@ from pathlib import Path
 import yaml
 
 DEFAULT_CONFIG_PATH = Path("~/.config/newsrag/config.yaml").expanduser()
-DEFAULT_DATA_DIR_NAME = ".newsrag"
+DEFAULT_DATA_DIR_NAME = "newsrag"
 
 
 class ConfigError(Exception):
@@ -110,7 +111,7 @@ def resolve_data_dir(
     """
 
     base_dir = cwd or Path.cwd()
-    selected = cli_data_dir or config.data_dir or Path(DEFAULT_DATA_DIR_NAME)
+    selected = cli_data_dir or config.data_dir or _default_data_dir()
     return _normalize_path(selected, cwd=base_dir)
 
 
@@ -196,6 +197,13 @@ def _optional_path(value: object, *, field_name: str) -> Path | None:
     if string_value is None:
         return None
     return Path(string_value).expanduser()
+
+
+def _default_data_dir() -> Path:
+    data_home = os.environ.get("XDG_DATA_HOME")
+    if data_home:
+        return Path(data_home).expanduser() / DEFAULT_DATA_DIR_NAME
+    return Path("~/.local/share").expanduser() / DEFAULT_DATA_DIR_NAME
 
 
 def _normalize_path(path: Path, *, cwd: Path) -> Path:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from pytest import MonkeyPatch
 
 from newsrag.config import (
     DEFAULT_CONFIG_PATH,
@@ -88,12 +89,16 @@ def test_resolve_data_dir_uses_config_value(tmp_path: Path) -> None:
     assert data_dir == (tmp_path / "configured-dir").resolve()
 
 
-def test_resolve_data_dir_defaults_to_local_newsrag(tmp_path: Path) -> None:
+def test_resolve_data_dir_defaults_to_user_data_home(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    data_home = tmp_path / "data-home"
+    monkeypatch.setenv("XDG_DATA_HOME", str(data_home))
     config = AppConfig(source_path=DEFAULT_CONFIG_PATH)
 
     data_dir = resolve_data_dir(None, config, cwd=tmp_path)
 
-    assert data_dir == (tmp_path / ".newsrag").resolve()
+    assert data_dir == data_home / "newsrag"
 
 
 def test_apply_embedding_overrides_replaces_selected_fields() -> None:


### PR DESCRIPTION
## Summary
- change the default NewsRAG data directory from cwd-relative `./.newsrag` to user data storage
- use `$XDG_DATA_HOME/newsrag` when set, otherwise `~/.local/share/newsrag`
- keep `--data-dir` and configured `data_dir` overrides working as before
- update tests and docs for the new default

## Verification
- `uv run pytest tests/test_config.py -q`
- `make check`
- `./scripts/pre-pr.sh`
- `XDG_DATA_HOME=$(mktemp -d)/data uv run newsrag status` shows the data dir under the configured user data home, not the project directory
