### PR TITLE
Avoid installer data dir collision

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 REPO_URL="${NEWSRAG_REPO_URL:-https://github.com/evcraddock/newsrag.git}"
-INSTALL_DIR="${NEWSRAG_INSTALL_DIR:-$HOME/.local/share/newsrag}"
+CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+INSTALL_DIR="${NEWSRAG_INSTALL_DIR:-$CACHE_HOME/newsrag/source}"
 REF="${NEWSRAG_REF:-main}"
 
 log() { printf '%s\n' "$*"; }
@@ -30,9 +31,11 @@ else
         log "Updating NewsRAG checkout at $INSTALL_DIR"
         git -C "$INSTALL_DIR" fetch --tags origin
     else
+        if [[ -e "$INSTALL_DIR" ]]; then
+            die "$INSTALL_DIR exists but is not a git checkout. Move it aside or set NEWSRAG_INSTALL_DIR."
+        fi
         log "Cloning NewsRAG into $INSTALL_DIR"
         mkdir -p "$(dirname "$INSTALL_DIR")"
-        rm -rf "$INSTALL_DIR"
         git clone "$REPO_URL" "$INSTALL_DIR"
     fi
 

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -44,10 +44,12 @@ exit 1
     uv.chmod(0o755)
 
     env = os.environ.copy()
+    cache_home = tmp_path / "cache"
+    checkout = cache_home / "newsrag" / "source"
     env.update(
         {
             "HOME": str(tmp_path / "home"),
-            "NEWSRAG_INSTALL_DIR": str(tmp_path / "checkout"),
+            "XDG_CACHE_HOME": str(cache_home),
             "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
         }
     )
@@ -63,5 +65,6 @@ exit 1
     )
 
     assert result.returncode == 0, result.stderr
-    assert "Cloning NewsRAG into" in result.stdout
+    assert f"Cloning NewsRAG into {checkout}" in result.stdout
     assert "Installing NewsRAG with uv" in result.stdout
+    assert (checkout / ".git").is_dir()


### PR DESCRIPTION
## Summary
- change the curl installer's default clone/update checkout from `~/.local/share/newsrag` to `${XDG_CACHE_HOME:-~/.cache}/newsrag/source`
- prevent the installer from deleting an existing non-git directory at the checkout target
- update the piped installer regression test to verify the cache checkout path

## Verification
- `bash -n scripts/install.sh`
- `uv run pytest tests/test_install_script.py -q`
- `make check`
- `./scripts/pre-pr.sh`

## Notes
This prevents the installer source checkout from colliding with NewsRAG's default data directory at `~/.local/share/newsrag`.
