### PR TITLE
feat: add document inventory commands

### DIFF
--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -56,9 +56,11 @@ app = typer.Typer(
 daemon_app = typer.Typer(help="Run the NewsRAG background daemon.")
 jobs_app = typer.Typer(help="Inspect durable NewsRAG jobs.")
 watch_app = typer.Typer(help="Manage watched folders for automatic ingestion.")
+documents_app = typer.Typer(help="Browse ingested document inventory.")
 app.add_typer(daemon_app, name="daemon")
 app.add_typer(jobs_app, name="jobs")
 app.add_typer(watch_app, name="watch")
+app.add_typer(documents_app, name="documents")
 
 
 @dataclass(frozen=True)
@@ -469,6 +471,96 @@ def packet_command(
         raise typer.Exit(code=1) from exc
 
     typer.echo(f"Wrote source packet to {out}")
+
+
+@documents_app.command("list")
+def documents_list_command(
+    ctx: typer.Context,
+    body: str | None = typer.Option(None, help="Only list documents from this civic body."),
+    document_type: str | None = typer.Option(
+        None,
+        "--document-type",
+        help="Only list documents with this document type metadata.",
+    ),
+    jurisdiction: str | None = typer.Option(
+        None,
+        help="Only list documents from this jurisdiction.",
+    ),
+    source_url: str | None = typer.Option(
+        None,
+        "--source-url",
+        help="Only list documents with this source URL.",
+    ),
+    since: str | None = typer.Option(
+        None,
+        "--since",
+        help="Only list documents with meeting dates on or after YYYY-MM-DD.",
+    ),
+    until: str | None = typer.Option(
+        None,
+        "--until",
+        help="Only list documents with meeting dates on or before YYYY-MM-DD.",
+    ),
+    query: str | None = typer.Option(
+        None,
+        "--query",
+        "-q",
+        help="Search document IDs, titles, source paths, source URLs, and filenames.",
+    ),
+    limit: int = typer.Option(50, "--limit", help="Maximum documents to show, up to 500."),
+    offset: int = typer.Option(0, "--offset", help="Number of matching documents to skip."),
+) -> None:
+    """List ingested documents with bounded, filterable output."""
+
+    from newsrag.documents import (
+        DocumentError,
+        DocumentFilters,
+        format_document_list,
+        list_document_summaries,
+    )
+    from newsrag.storage import initialize_storage
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    database_path = initialize_storage(settings.data_dir).database
+    filters = DocumentFilters(
+        body=body,
+        document_type=document_type,
+        jurisdiction=jurisdiction,
+        source_url=source_url,
+        since=since,
+        until=until,
+        query=query,
+    )
+    try:
+        page = list_document_summaries(
+            database_path,
+            filters=filters,
+            limit=limit,
+            offset=offset,
+        )
+    except DocumentError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(format_document_list(page))
+
+
+@documents_app.command("show")
+def documents_show_command(ctx: typer.Context, document_id: str) -> None:
+    """Show details for one ingested document."""
+
+    from newsrag.documents import DocumentError, format_document_detail, get_document_detail
+    from newsrag.storage import initialize_storage
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    database_path = initialize_storage(settings.data_dir).database
+    try:
+        document = get_document_detail(database_path, document_id)
+    except DocumentError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(format_document_detail(document))
 
 
 @jobs_app.command("list")

--- a/newsrag/documents.py
+++ b/newsrag/documents.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DOCUMENT_LIST_LIMIT = 50
+MAX_DOCUMENT_LIST_LIMIT = 500
+
+
+class DocumentError(Exception):
+    """Raised when document inventory commands cannot complete."""
+
+
+class DocumentNotFoundError(DocumentError):
+    """Raised when a requested document does not exist."""
+
+
+@dataclass(frozen=True)
+class DocumentFilters:
+    """Filters for document inventory listings."""
+
+    body: str | None = None
+    document_type: str | None = None
+    jurisdiction: str | None = None
+    source_url: str | None = None
+    since: str | None = None
+    until: str | None = None
+    query: str | None = None
+
+
+@dataclass(frozen=True)
+class DocumentSummary:
+    """One row in the document inventory."""
+
+    id: str
+    title: str | None
+    source_path: str | None
+    source_url: str | None
+    metadata: dict[str, Any]
+    page_count: int
+    created_at: str
+
+
+@dataclass(frozen=True)
+class DocumentDetail:
+    """Detailed read-only document metadata."""
+
+    id: str
+    title: str | None
+    source_path: str | None
+    source_url: str | None
+    source_hash: str | None
+    normalized_path: str | None
+    metadata: dict[str, Any]
+    page_count: int
+    created_at: str
+
+
+@dataclass(frozen=True)
+class DocumentListPage:
+    """One bounded page of document inventory results."""
+
+    documents: tuple[DocumentSummary, ...]
+    total: int
+    limit: int
+    offset: int
+    filters: DocumentFilters
+
+
+@dataclass(frozen=True)
+class _QueryParts:
+    where_sql: str
+    parameters: tuple[object, ...]
+
+
+def list_document_summaries(
+    database_path: Path,
+    *,
+    filters: DocumentFilters | None = None,
+    limit: int = DEFAULT_DOCUMENT_LIST_LIMIT,
+    offset: int = 0,
+) -> DocumentListPage:
+    """List a bounded page of document summaries from durable storage."""
+
+    _validate_pagination(limit=limit, offset=offset)
+    resolved_filters = filters or DocumentFilters()
+    _validate_filters(resolved_filters)
+    query = _build_filter_query(resolved_filters)
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        total_row = connection.execute(
+            f"""
+            SELECT COUNT(*) AS total
+            FROM documents
+            {query.where_sql}
+            """,
+            query.parameters,
+        ).fetchone()
+        rows = connection.execute(
+            f"""
+            SELECT
+                documents.id,
+                documents.source_path,
+                documents.source_url,
+                documents.title,
+                documents.metadata_json,
+                documents.created_at,
+                COUNT(pages.id) AS page_count
+            FROM documents
+            LEFT JOIN pages ON pages.document_id = documents.id
+            {query.where_sql}
+            GROUP BY documents.id
+            ORDER BY documents.created_at DESC, documents.id ASC
+            LIMIT ? OFFSET ?
+            """,
+            (*query.parameters, limit, offset),
+        ).fetchall()
+
+    total = int(total_row["total"]) if total_row is not None else 0
+    return DocumentListPage(
+        documents=tuple(_row_to_summary(row) for row in rows),
+        total=total,
+        limit=limit,
+        offset=offset,
+        filters=resolved_filters,
+    )
+
+
+def get_document_detail(database_path: Path, document_id: str) -> DocumentDetail:
+    """Return detailed metadata for one document."""
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        row = connection.execute(
+            """
+            SELECT
+                documents.id,
+                documents.source_path,
+                documents.source_url,
+                documents.title,
+                documents.source_hash,
+                documents.normalized_path,
+                documents.metadata_json,
+                documents.created_at,
+                COUNT(pages.id) AS page_count
+            FROM documents
+            LEFT JOIN pages ON pages.document_id = documents.id
+            WHERE documents.id = ?
+            GROUP BY documents.id
+            """,
+            (document_id,),
+        ).fetchone()
+
+    if row is None:
+        raise DocumentNotFoundError(f"Unknown document: {document_id}")
+
+    return DocumentDetail(
+        id=str(row["id"]),
+        title=_optional_string(row["title"]),
+        source_path=_optional_string(row["source_path"]),
+        source_url=_optional_string(row["source_url"]),
+        source_hash=_optional_string(row["source_hash"]),
+        normalized_path=_optional_string(row["normalized_path"]),
+        metadata=_load_metadata(row["metadata_json"]),
+        page_count=int(row["page_count"]),
+        created_at=str(row["created_at"]),
+    )
+
+
+def format_document_list(page: DocumentListPage) -> str:
+    """Format a document inventory page for terminal output."""
+
+    lines = ["NewsRAG Documents"]
+    if not page.documents:
+        if page.total == 0:
+            lines.append("documents: none")
+        else:
+            lines.append(
+                f"documents: none at offset {page.offset}; total={page.total} limit={page.limit}"
+            )
+        return "\n".join(lines)
+
+    shown = len(page.documents)
+    lines.append(
+        f"showing {shown} of {page.total} document(s); limit={page.limit} offset={page.offset}"
+    )
+    if page.offset + shown < page.total:
+        lines.append("more: use --limit/--offset or filters to narrow results")
+
+    for document in page.documents:
+        metadata = document.metadata
+        parts = [
+            document.id,
+            _display_value(document.title),
+            f"meeting_date={_display_value(_metadata_string(metadata, 'meeting_date'))}",
+            f"body={_display_value(_metadata_string(metadata, 'body'))}",
+            f"document_type={_display_value(_metadata_string(metadata, 'document_type'))}",
+            f"pages={document.page_count}",
+            f"source={_display_value(_best_source(document.source_url, document.source_path, metadata))}",
+            f"created_at={document.created_at}",
+        ]
+        lines.append(" | ".join(parts))
+
+    return "\n".join(lines)
+
+
+def format_document_detail(document: DocumentDetail) -> str:
+    """Format detailed document metadata for terminal output."""
+
+    lines = [
+        "NewsRAG Document",
+        f"id: {document.id}",
+        f"title: {_display_value(document.title)}",
+        f"created_at: {document.created_at}",
+        f"pages: {document.page_count}",
+        f"source_url: {_display_value(document.source_url)}",
+        f"source_path: {_display_value(document.source_path)}",
+        f"source_hash: {_display_value(document.source_hash)}",
+        f"normalized_path: {_display_value(document.normalized_path)}",
+        "metadata:",
+    ]
+
+    if not document.metadata:
+        lines.append("  none")
+        return "\n".join(lines)
+
+    for key in sorted(document.metadata):
+        value = document.metadata[key]
+        lines.append(f"  {key}: {_format_metadata_value(value)}")
+
+    return "\n".join(lines)
+
+
+def _build_filter_query(filters: DocumentFilters) -> _QueryParts:
+    clauses: list[str] = []
+    parameters: list[object] = []
+
+    for key, value in (
+        ("body", filters.body),
+        ("document_type", filters.document_type),
+        ("jurisdiction", filters.jurisdiction),
+    ):
+        resolved_value = _normalized_optional_string(value)
+        if resolved_value is None:
+            continue
+        clauses.append(f"json_extract(documents.metadata_json, '$.{key}') = ?")
+        parameters.append(resolved_value)
+
+    source_url = _normalized_optional_string(filters.source_url)
+    if source_url is not None:
+        clauses.append(
+            "(documents.source_url = ? OR json_extract(documents.metadata_json, '$.source_url') = ?)"
+        )
+        parameters.extend((source_url, source_url))
+
+    since = _normalized_optional_string(filters.since)
+    if since is not None:
+        clauses.append("json_extract(documents.metadata_json, '$.meeting_date') >= ?")
+        parameters.append(since)
+
+    until = _normalized_optional_string(filters.until)
+    if until is not None:
+        clauses.append("json_extract(documents.metadata_json, '$.meeting_date') <= ?")
+        parameters.append(until)
+
+    query = _normalized_optional_string(filters.query)
+    if query is not None:
+        like_query = f"%{query.lower()}%"
+        clauses.append(
+            "("
+            "lower(coalesce(documents.id, '')) LIKE ? OR "
+            "lower(coalesce(documents.title, '')) LIKE ? OR "
+            "lower(coalesce(documents.source_path, '')) LIKE ? OR "
+            "lower(coalesce(documents.source_url, '')) LIKE ? OR "
+            "lower(coalesce(json_extract(documents.metadata_json, '$.source_filename'), '')) LIKE ?"
+            ")"
+        )
+        parameters.extend((like_query, like_query, like_query, like_query, like_query))
+
+    where_sql = ""
+    if clauses:
+        where_sql = "WHERE " + " AND ".join(clauses)
+    return _QueryParts(where_sql=where_sql, parameters=tuple(parameters))
+
+
+def _validate_pagination(*, limit: int, offset: int) -> None:
+    if limit < 1 or limit > MAX_DOCUMENT_LIST_LIMIT:
+        raise DocumentError(f"--limit must be between 1 and {MAX_DOCUMENT_LIST_LIMIT}")
+    if offset < 0:
+        raise DocumentError("--offset must be zero or greater")
+
+
+def _validate_filters(filters: DocumentFilters) -> None:
+    since_date = _parse_filter_date(filters.since, option_name="--since")
+    until_date = _parse_filter_date(filters.until, option_name="--until")
+    if since_date is not None and until_date is not None and since_date > until_date:
+        raise DocumentError("Invalid date range: --since must be on or before --until")
+
+
+def _parse_filter_date(value: str | None, *, option_name: str) -> date | None:
+    resolved_value = _normalized_optional_string(value)
+    if resolved_value is None:
+        return None
+    try:
+        return date.fromisoformat(resolved_value)
+    except ValueError as exc:
+        raise DocumentError(f"Invalid {option_name} date: expected YYYY-MM-DD") from exc
+
+
+def _row_to_summary(row: sqlite3.Row) -> DocumentSummary:
+    return DocumentSummary(
+        id=str(row["id"]),
+        title=_optional_string(row["title"]),
+        source_path=_optional_string(row["source_path"]),
+        source_url=_optional_string(row["source_url"]),
+        metadata=_load_metadata(row["metadata_json"]),
+        page_count=int(row["page_count"]),
+        created_at=str(row["created_at"]),
+    )
+
+
+def _load_metadata(raw_metadata: object) -> dict[str, Any]:
+    try:
+        metadata = json.loads(str(raw_metadata))
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(metadata, dict):
+        return {}
+    return metadata
+
+
+def _metadata_string(metadata: dict[str, Any], key: str) -> str | None:
+    return _optional_string(metadata.get(key))
+
+
+def _best_source(
+    source_url: str | None,
+    source_path: str | None,
+    metadata: dict[str, Any],
+) -> str | None:
+    return (
+        source_url
+        or source_path
+        or _metadata_string(metadata, "stored_source_path")
+        or _metadata_string(metadata, "source_filename")
+    )
+
+
+def _optional_string(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _normalized_optional_string(value: str | None) -> str | None:
+    if value is None:
+        return None
+    resolved_value = value.strip()
+    if not resolved_value:
+        return None
+    return resolved_value
+
+
+def _display_value(value: str | None) -> str:
+    if value is None:
+        return "-"
+    return value
+
+
+def _format_metadata_value(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, sort_keys=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,7 @@ def test_help_shows_cli_commands() -> None:
     assert "search" in result.stdout
     assert "jobs" in result.stdout
     assert "watch" in result.stdout
+    assert "documents" in result.stdout
 
 
 def test_version_option_shows_project_version() -> None:

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from newsrag.cli import app
+from newsrag.documents import (
+    DocumentFilters,
+    get_document_detail,
+    list_document_summaries,
+)
+from newsrag.storage import initialize_storage
+
+runner = CliRunner()
+
+
+def test_documents_list_empty_corpus(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    initialize_storage(data_dir)
+
+    result = runner.invoke(app, ["--data-dir", str(data_dir), "documents", "list"])
+
+    assert result.exit_code == 0
+    assert "NewsRAG Documents" in result.stdout
+    assert "documents: none" in result.stdout
+
+
+def test_documents_list_shows_bounded_recent_documents(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    database_path = _seed_document_inventory(data_dir)
+
+    result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "documents", "list", "--limit", "2"],
+    )
+    page = list_document_summaries(database_path, limit=2)
+
+    assert result.exit_code == 0, result.stdout
+    assert "showing 2 of 3 document(s); limit=2 offset=0" in result.stdout
+    assert "more: use --limit/--offset or filters to narrow results" in result.stdout
+    assert "document-c | Zoning Packet" in result.stdout
+    assert "document-b | Budget Packet" in result.stdout
+    assert "document-a | Stormwater Report" not in result.stdout
+    assert [document.id for document in page.documents] == ["document-c", "document-b"]
+    assert page.total == 3
+
+
+def test_documents_list_supports_metadata_date_query_and_pagination_filters(
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / ".newsrag"
+    database_path = _seed_document_inventory(data_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            "--data-dir",
+            str(data_dir),
+            "documents",
+            "list",
+            "--body",
+            "City Council",
+            "--document-type",
+            "agenda_packet",
+            "--jurisdiction",
+            "Example City",
+            "--since",
+            "2026-04-01",
+            "--until",
+            "2026-04-30",
+            "--query",
+            "budget",
+            "--limit",
+            "1",
+            "--offset",
+            "0",
+        ],
+    )
+    page = list_document_summaries(
+        database_path,
+        filters=DocumentFilters(
+            body="City Council",
+            document_type="agenda_packet",
+            jurisdiction="Example City",
+            since="2026-04-01",
+            until="2026-04-30",
+            query="budget",
+        ),
+        limit=1,
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "document-b | Budget Packet" in result.stdout
+    assert "document-a | Stormwater Report" not in result.stdout
+    assert [document.id for document in page.documents] == ["document-b"]
+    assert page.total == 1
+
+
+def test_documents_list_rejects_invalid_limit_and_date(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    initialize_storage(data_dir)
+
+    limit_result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "documents", "list", "--limit", "501"],
+    )
+    date_result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "documents", "list", "--since", "04-01-2026"],
+    )
+
+    assert limit_result.exit_code == 1
+    assert "--limit must be between 1 and 500" in limit_result.stdout
+    assert date_result.exit_code == 1
+    assert "Invalid --since date" in date_result.stdout
+
+
+def test_documents_show_outputs_detail_and_page_count(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    database_path = _seed_document_inventory(data_dir)
+
+    result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "documents", "show", "document-a"],
+    )
+    detail = get_document_detail(database_path, "document-a")
+
+    assert result.exit_code == 0, result.stdout
+    assert "NewsRAG Document" in result.stdout
+    assert "id: document-a" in result.stdout
+    assert "title: Stormwater Report" in result.stdout
+    assert "pages: 2" in result.stdout
+    assert "source_url: https://example.test/stormwater.pdf" in result.stdout
+    assert "source_path: /tmp/stormwater.pdf" in result.stdout
+    assert "source_hash: hash-a" in result.stdout
+    assert "normalized_path: /tmp/stormwater-ocr.pdf" in result.stdout
+    assert "body: Planning Commission" in result.stdout
+    assert "document_type: staff_report" in result.stdout
+    assert detail.page_count == 2
+
+
+def test_documents_show_missing_id_fails_clearly(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    initialize_storage(data_dir)
+
+    result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "documents", "show", "document-missing"],
+    )
+
+    assert result.exit_code == 1
+    assert "Unknown document: document-missing" in result.stdout
+
+
+def _seed_document_inventory(data_dir: Path) -> Path:
+    database_path = initialize_storage(data_dir).database
+    with sqlite3.connect(database_path) as connection:
+        connection.executemany(
+            """
+            INSERT INTO documents(
+                id,
+                source_path,
+                source_url,
+                title,
+                source_hash,
+                normalized_path,
+                metadata_json,
+                created_at
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    "document-a",
+                    "/tmp/stormwater.pdf",
+                    "https://example.test/stormwater.pdf",
+                    "Stormwater Report",
+                    "hash-a",
+                    "/tmp/stormwater-ocr.pdf",
+                    '{"body": "Planning Commission", "document_type": "staff_report", "jurisdiction": "Example City", "meeting_date": "2026-03-15", "source_filename": "stormwater.pdf"}',
+                    "2026-04-01T00:00:00+00:00",
+                ),
+                (
+                    "document-b",
+                    "/tmp/budget.pdf",
+                    "https://example.test/budget.pdf",
+                    "Budget Packet",
+                    "hash-b",
+                    "/tmp/budget-ocr.pdf",
+                    '{"body": "City Council", "document_type": "agenda_packet", "jurisdiction": "Example City", "meeting_date": "2026-04-20", "source_filename": "budget.pdf"}',
+                    "2026-04-02T00:00:00+00:00",
+                ),
+                (
+                    "document-c",
+                    "/tmp/zoning.pdf",
+                    None,
+                    "Zoning Packet",
+                    "hash-c",
+                    "/tmp/zoning-ocr.pdf",
+                    '{"body": "Planning Commission", "document_type": "agenda_packet", "jurisdiction": "Example City", "meeting_date": "2026-05-01", "source_filename": "zoning.pdf"}',
+                    "2026-04-03T00:00:00+00:00",
+                ),
+            ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO pages(id, document_id, page_number, text, extractor)
+            VALUES(?, ?, ?, ?, ?)
+            """,
+            [
+                ("page-a-1", "document-a", 1, "Stormwater page one", "pymupdf"),
+                ("page-a-2", "document-a", 2, "Stormwater page two", "pymupdf"),
+                ("page-b-1", "document-b", 1, "Budget page", "pymupdf"),
+            ],
+        )
+        connection.commit()
+    return database_path


### PR DESCRIPTION
## Summary

Adds read-only document inventory browsing commands so users can inspect ingested documents before knowing exact search terms.

## Task

#task-fe65ea9a

## Changes

- Added `newsrag documents list` with bounded default output, pagination, metadata filters, date filters, source URL filtering, and text query filtering.
- Added `newsrag documents show <document-id>` with page count, source details, hash, normalized path, creation time, and metadata.
- Added document inventory service/formatting helpers.
- Added CLI and inventory tests for empty output, filtered list output, detail output, validation errors, and missing IDs.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed: `./scripts/pre-pr.sh`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included