### PR TITLE
feat: add discovery storage

### DIFF
--- a/newsrag/discovery.py
+++ b/newsrag/discovery.py
@@ -1,0 +1,634 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class DiscoveryError(Exception):
+    """Raised when discovery records cannot be persisted or loaded."""
+
+
+@dataclass(frozen=True)
+class DocumentProfileRecord:
+    """Durable extraction profile for one document."""
+
+    id: str
+    document_id: str
+    page_count: int
+    text_length: int
+    extraction_quality: dict[str, Any]
+    extractor: str
+    provider: str | None
+    model: str | None
+    created_at: str
+    updated_at: str
+
+
+@dataclass(frozen=True)
+class DocumentBriefRecord:
+    """Durable evidence-oriented brief for one document."""
+
+    id: str
+    document_id: str
+    summary: str
+    significance: str
+    open_questions: tuple[str, ...]
+    extractor: str
+    provider: str | None
+    model: str | None
+    status: str
+    created_at: str
+    updated_at: str
+
+
+@dataclass(frozen=True)
+class DiscoveryEvidenceDraft:
+    """Evidence reference to persist for one discovery item."""
+
+    document_id: str
+    page_start: int
+    page_end: int
+    quote: str
+    validation_status: str
+    page_id: str | None = None
+    passage_id: str | None = None
+
+
+@dataclass(frozen=True)
+class DiscoveryEvidenceRecord:
+    """Durable provenance reference for one discovery item."""
+
+    id: str
+    item_id: str
+    document_id: str
+    page_id: str | None
+    passage_id: str | None
+    page_start: int
+    page_end: int
+    quote: str
+    validation_status: str
+    created_at: str
+
+
+@dataclass(frozen=True)
+class DiscoveryItemRecord:
+    """Durable evidence-backed discovery item."""
+
+    id: str
+    document_id: str
+    item_type: str
+    label: str
+    value: dict[str, Any]
+    summary: str
+    confidence: float | None
+    extractor: str
+    provider: str | None
+    model: str | None
+    created_at: str
+    evidence: tuple[DiscoveryEvidenceRecord, ...]
+
+
+def create_document_profile(
+    database_path: Path,
+    *,
+    document_id: str,
+    page_count: int,
+    text_length: int,
+    extraction_quality: dict[str, Any] | None = None,
+    extractor: str,
+    provider: str | None = None,
+    model: str | None = None,
+    profile_id: str | None = None,
+) -> DocumentProfileRecord:
+    """Create or replace a document extraction profile."""
+
+    _validate_non_empty(document_id, field_name="document_id")
+    _validate_non_empty(extractor, field_name="extractor")
+    if page_count < 0:
+        raise DiscoveryError("page_count must be zero or greater")
+    if text_length < 0:
+        raise DiscoveryError("text_length must be zero or greater")
+
+    resolved_profile_id = profile_id or f"profile-{uuid.uuid4().hex[:8]}"
+    quality_json = _dump_json_object(extraction_quality or {}, field_name="extraction_quality")
+
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO document_profiles(
+                id,
+                document_id,
+                page_count,
+                text_length,
+                extraction_quality_json,
+                extractor,
+                provider,
+                model
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(document_id) DO UPDATE SET
+                page_count = excluded.page_count,
+                text_length = excluded.text_length,
+                extraction_quality_json = excluded.extraction_quality_json,
+                extractor = excluded.extractor,
+                provider = excluded.provider,
+                model = excluded.model,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (
+                resolved_profile_id,
+                document_id,
+                page_count,
+                text_length,
+                quality_json,
+                extractor.strip(),
+                _optional_string(provider),
+                _optional_string(model),
+            ),
+        )
+        connection.commit()
+
+    return get_document_profile(database_path, document_id)
+
+
+def get_document_profile(database_path: Path, document_id: str) -> DocumentProfileRecord:
+    """Load one document profile by document ID."""
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        row = connection.execute(
+            """
+            SELECT
+                id,
+                document_id,
+                page_count,
+                text_length,
+                extraction_quality_json,
+                extractor,
+                provider,
+                model,
+                created_at,
+                updated_at
+            FROM document_profiles
+            WHERE document_id = ?
+            """,
+            (document_id,),
+        ).fetchone()
+
+    if row is None:
+        raise DiscoveryError(f"Unknown document profile: {document_id}")
+    return _row_to_document_profile(row)
+
+
+def create_document_brief(
+    database_path: Path,
+    *,
+    document_id: str,
+    summary: str,
+    extractor: str,
+    significance: str = "",
+    open_questions: Sequence[str] = (),
+    provider: str | None = None,
+    model: str | None = None,
+    status: str = "draft",
+    brief_id: str | None = None,
+) -> DocumentBriefRecord:
+    """Persist a document brief and index its searchable text."""
+
+    _validate_non_empty(document_id, field_name="document_id")
+    _validate_non_empty(extractor, field_name="extractor")
+    _validate_non_empty(status, field_name="status")
+    resolved_brief_id = brief_id or f"brief-{uuid.uuid4().hex[:8]}"
+    open_questions_json = json.dumps(list(open_questions), sort_keys=True)
+
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO document_briefs(
+                id,
+                document_id,
+                summary,
+                significance,
+                open_questions_json,
+                extractor,
+                provider,
+                model,
+                status
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                resolved_brief_id,
+                document_id,
+                summary,
+                significance,
+                open_questions_json,
+                extractor.strip(),
+                _optional_string(provider),
+                _optional_string(model),
+                status.strip(),
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO document_briefs_fts(brief_id, summary, significance)
+            VALUES(?, ?, ?)
+            """,
+            (resolved_brief_id, summary, significance),
+        )
+        connection.commit()
+
+    return get_document_brief(database_path, resolved_brief_id)
+
+
+def get_document_brief(database_path: Path, brief_id: str) -> DocumentBriefRecord:
+    """Load one document brief by ID."""
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        row = connection.execute(
+            """
+            SELECT
+                id,
+                document_id,
+                summary,
+                significance,
+                open_questions_json,
+                extractor,
+                provider,
+                model,
+                status,
+                created_at,
+                updated_at
+            FROM document_briefs
+            WHERE id = ?
+            """,
+            (brief_id,),
+        ).fetchone()
+
+    if row is None:
+        raise DiscoveryError(f"Unknown document brief: {brief_id}")
+    return _row_to_document_brief(row)
+
+
+def list_document_briefs(
+    database_path: Path,
+    *,
+    document_id: str | None = None,
+) -> list[DocumentBriefRecord]:
+    """List document briefs, optionally scoped to one document."""
+
+    clause = ""
+    parameters: tuple[object, ...] = ()
+    if document_id is not None:
+        clause = "WHERE document_id = ?"
+        parameters = (document_id,)
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(
+            f"""
+            SELECT
+                id,
+                document_id,
+                summary,
+                significance,
+                open_questions_json,
+                extractor,
+                provider,
+                model,
+                status,
+                created_at,
+                updated_at
+            FROM document_briefs
+            {clause}
+            ORDER BY created_at ASC, id ASC
+            """,
+            parameters,
+        ).fetchall()
+
+    return [_row_to_document_brief(row) for row in rows]
+
+
+def create_discovery_item(
+    database_path: Path,
+    *,
+    document_id: str,
+    item_type: str,
+    label: str,
+    extractor: str,
+    value: dict[str, Any] | None = None,
+    summary: str = "",
+    confidence: float | None = None,
+    provider: str | None = None,
+    model: str | None = None,
+    evidence: Sequence[DiscoveryEvidenceDraft] = (),
+    item_id: str | None = None,
+) -> DiscoveryItemRecord:
+    """Persist one discovery item and its evidence references."""
+
+    _validate_non_empty(document_id, field_name="document_id")
+    _validate_non_empty(item_type, field_name="item_type")
+    _validate_non_empty(label, field_name="label")
+    _validate_non_empty(extractor, field_name="extractor")
+    _validate_confidence(confidence)
+    for draft in evidence:
+        _validate_evidence_draft(draft, item_document_id=document_id)
+
+    resolved_item_id = item_id or f"discovery-{uuid.uuid4().hex[:8]}"
+    value_json = _dump_json_object(value or {}, field_name="value")
+
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO discovery_items(
+                id,
+                document_id,
+                item_type,
+                label,
+                value_json,
+                summary,
+                confidence,
+                extractor,
+                provider,
+                model
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                resolved_item_id,
+                document_id,
+                item_type.strip(),
+                label.strip(),
+                value_json,
+                summary,
+                confidence,
+                extractor.strip(),
+                _optional_string(provider),
+                _optional_string(model),
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO discovery_items_fts(item_id, label, summary)
+            VALUES(?, ?, ?)
+            """,
+            (resolved_item_id, label, summary),
+        )
+        connection.executemany(
+            """
+            INSERT INTO discovery_evidence(
+                id,
+                item_id,
+                document_id,
+                page_id,
+                passage_id,
+                page_start,
+                page_end,
+                quote,
+                validation_status
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    f"evidence-{uuid.uuid4().hex[:8]}",
+                    resolved_item_id,
+                    draft.document_id,
+                    draft.page_id,
+                    draft.passage_id,
+                    draft.page_start,
+                    draft.page_end,
+                    draft.quote,
+                    draft.validation_status.strip(),
+                )
+                for draft in evidence
+            ],
+        )
+        connection.commit()
+
+    return get_discovery_item(database_path, resolved_item_id)
+
+
+def get_discovery_item(database_path: Path, item_id: str) -> DiscoveryItemRecord:
+    """Load one discovery item with evidence references."""
+
+    items = list_discovery_items(database_path, item_id=item_id)
+    if not items:
+        raise DiscoveryError(f"Unknown discovery item: {item_id}")
+    return items[0]
+
+
+def list_discovery_items(
+    database_path: Path,
+    *,
+    document_id: str | None = None,
+    item_type: str | None = None,
+    item_id: str | None = None,
+) -> list[DiscoveryItemRecord]:
+    """List discovery items with evidence references."""
+
+    clauses: list[str] = []
+    parameters: list[object] = []
+    if document_id is not None:
+        clauses.append("document_id = ?")
+        parameters.append(document_id)
+    if item_type is not None:
+        clauses.append("item_type = ?")
+        parameters.append(item_type)
+    if item_id is not None:
+        clauses.append("id = ?")
+        parameters.append(item_id)
+
+    where_sql = ""
+    if clauses:
+        where_sql = "WHERE " + " AND ".join(clauses)
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        item_rows = connection.execute(
+            f"""
+            SELECT
+                id,
+                document_id,
+                item_type,
+                label,
+                value_json,
+                summary,
+                confidence,
+                extractor,
+                provider,
+                model,
+                created_at
+            FROM discovery_items
+            {where_sql}
+            ORDER BY created_at ASC, id ASC
+            """,
+            tuple(parameters),
+        ).fetchall()
+        item_ids = tuple(str(row["id"]) for row in item_rows)
+        if item_ids:
+            placeholders = ", ".join("?" for _ in item_ids)
+            evidence_rows = connection.execute(
+                f"""
+                SELECT
+                    id,
+                    item_id,
+                    document_id,
+                    page_id,
+                    passage_id,
+                    page_start,
+                    page_end,
+                    quote,
+                    validation_status,
+                    created_at
+                FROM discovery_evidence
+                WHERE item_id IN ({placeholders})
+                ORDER BY created_at ASC, id ASC
+                """,
+                item_ids,
+            ).fetchall()
+        else:
+            evidence_rows = []
+
+    evidence_by_item_id: dict[str, list[DiscoveryEvidenceRecord]] = {}
+    for row in evidence_rows:
+        evidence = _row_to_discovery_evidence(row)
+        evidence_by_item_id.setdefault(evidence.item_id, []).append(evidence)
+
+    return [
+        _row_to_discovery_item(row, evidence_by_item_id.get(str(row["id"]), []))
+        for row in item_rows
+    ]
+
+
+def _validate_non_empty(value: str, *, field_name: str) -> None:
+    if not value.strip():
+        raise DiscoveryError(f"{field_name} must be non-empty")
+
+
+def _validate_confidence(confidence: float | None) -> None:
+    if confidence is None:
+        return
+    if confidence < 0 or confidence > 1:
+        raise DiscoveryError("confidence must be between 0 and 1")
+
+
+def _validate_evidence_draft(
+    draft: DiscoveryEvidenceDraft,
+    *,
+    item_document_id: str,
+) -> None:
+    _validate_non_empty(draft.document_id, field_name="evidence.document_id")
+    _validate_non_empty(draft.quote, field_name="evidence.quote")
+    _validate_non_empty(draft.validation_status, field_name="evidence.validation_status")
+    if draft.document_id != item_document_id:
+        raise DiscoveryError("evidence.document_id must match discovery item document_id")
+    if draft.page_start < 1:
+        raise DiscoveryError("evidence.page_start must be 1 or greater")
+    if draft.page_end < draft.page_start:
+        raise DiscoveryError("evidence.page_end must be greater than or equal to page_start")
+
+
+def _dump_json_object(value: dict[str, Any], *, field_name: str) -> str:
+    if not isinstance(value, dict):
+        raise DiscoveryError(f"{field_name} must be a JSON object")
+    return json.dumps(value, sort_keys=True)
+
+
+def _optional_string(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _load_json_object(value: object) -> dict[str, Any]:
+    try:
+        loaded = json.loads(str(value))
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    return loaded
+
+
+def _load_string_tuple(value: object) -> tuple[str, ...]:
+    try:
+        loaded = json.loads(str(value))
+    except json.JSONDecodeError:
+        return ()
+    if not isinstance(loaded, list):
+        return ()
+    return tuple(item for item in loaded if isinstance(item, str))
+
+
+def _row_to_document_profile(row: sqlite3.Row) -> DocumentProfileRecord:
+    return DocumentProfileRecord(
+        id=str(row["id"]),
+        document_id=str(row["document_id"]),
+        page_count=int(row["page_count"]),
+        text_length=int(row["text_length"]),
+        extraction_quality=_load_json_object(row["extraction_quality_json"]),
+        extractor=str(row["extractor"]),
+        provider=str(row["provider"]) if row["provider"] is not None else None,
+        model=str(row["model"]) if row["model"] is not None else None,
+        created_at=str(row["created_at"]),
+        updated_at=str(row["updated_at"]),
+    )
+
+
+def _row_to_document_brief(row: sqlite3.Row) -> DocumentBriefRecord:
+    return DocumentBriefRecord(
+        id=str(row["id"]),
+        document_id=str(row["document_id"]),
+        summary=str(row["summary"]),
+        significance=str(row["significance"]),
+        open_questions=_load_string_tuple(row["open_questions_json"]),
+        extractor=str(row["extractor"]),
+        provider=str(row["provider"]) if row["provider"] is not None else None,
+        model=str(row["model"]) if row["model"] is not None else None,
+        status=str(row["status"]),
+        created_at=str(row["created_at"]),
+        updated_at=str(row["updated_at"]),
+    )
+
+
+def _row_to_discovery_evidence(row: sqlite3.Row) -> DiscoveryEvidenceRecord:
+    return DiscoveryEvidenceRecord(
+        id=str(row["id"]),
+        item_id=str(row["item_id"]),
+        document_id=str(row["document_id"]),
+        page_id=str(row["page_id"]) if row["page_id"] is not None else None,
+        passage_id=str(row["passage_id"]) if row["passage_id"] is not None else None,
+        page_start=int(row["page_start"]),
+        page_end=int(row["page_end"]),
+        quote=str(row["quote"]),
+        validation_status=str(row["validation_status"]),
+        created_at=str(row["created_at"]),
+    )
+
+
+def _row_to_discovery_item(
+    row: sqlite3.Row,
+    evidence: Sequence[DiscoveryEvidenceRecord],
+) -> DiscoveryItemRecord:
+    return DiscoveryItemRecord(
+        id=str(row["id"]),
+        document_id=str(row["document_id"]),
+        item_type=str(row["item_type"]),
+        label=str(row["label"]),
+        value=_load_json_object(row["value_json"]),
+        summary=str(row["summary"]),
+        confidence=float(row["confidence"]) if row["confidence"] is not None else None,
+        extractor=str(row["extractor"]),
+        provider=str(row["provider"]) if row["provider"] is not None else None,
+        model=str(row["model"]) if row["model"] is not None else None,
+        created_at=str(row["created_at"]),
+        evidence=tuple(evidence),
+    )

--- a/newsrag/storage.py
+++ b/newsrag/storage.py
@@ -80,6 +80,12 @@ REQUIRED_TABLES = {
     "watches",
     "watch_files",
     "embedding_records",
+    "document_profiles",
+    "document_briefs",
+    "document_briefs_fts",
+    "discovery_items",
+    "discovery_items_fts",
+    "discovery_evidence",
     "metadata",
 }
 SCHEMA_STATEMENTS = (
@@ -188,6 +194,85 @@ SCHEMA_STATEMENTS = (
         version TEXT NOT NULL,
         dimensions INTEGER NOT NULL,
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS document_profiles (
+        id TEXT PRIMARY KEY,
+        document_id TEXT NOT NULL UNIQUE,
+        page_count INTEGER NOT NULL,
+        text_length INTEGER NOT NULL,
+        extraction_quality_json TEXT NOT NULL DEFAULT '{}',
+        extractor TEXT NOT NULL,
+        provider TEXT,
+        model TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(document_id) REFERENCES documents(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS document_briefs (
+        id TEXT PRIMARY KEY,
+        document_id TEXT NOT NULL,
+        summary TEXT NOT NULL DEFAULT '',
+        significance TEXT NOT NULL DEFAULT '',
+        open_questions_json TEXT NOT NULL DEFAULT '[]',
+        extractor TEXT NOT NULL,
+        provider TEXT,
+        model TEXT,
+        status TEXT NOT NULL DEFAULT 'draft',
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(document_id) REFERENCES documents(id)
+    )
+    """,
+    """
+    CREATE VIRTUAL TABLE IF NOT EXISTS document_briefs_fts USING fts5(
+        brief_id UNINDEXED,
+        summary,
+        significance
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS discovery_items (
+        id TEXT PRIMARY KEY,
+        document_id TEXT NOT NULL,
+        item_type TEXT NOT NULL,
+        label TEXT NOT NULL,
+        value_json TEXT NOT NULL DEFAULT '{}',
+        summary TEXT NOT NULL DEFAULT '',
+        confidence REAL,
+        extractor TEXT NOT NULL,
+        provider TEXT,
+        model TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(document_id) REFERENCES documents(id)
+    )
+    """,
+    """
+    CREATE VIRTUAL TABLE IF NOT EXISTS discovery_items_fts USING fts5(
+        item_id UNINDEXED,
+        label,
+        summary
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS discovery_evidence (
+        id TEXT PRIMARY KEY,
+        item_id TEXT NOT NULL,
+        document_id TEXT NOT NULL,
+        page_id TEXT,
+        passage_id TEXT,
+        page_start INTEGER NOT NULL,
+        page_end INTEGER NOT NULL,
+        quote TEXT NOT NULL DEFAULT '',
+        validation_status TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(item_id) REFERENCES discovery_items(id),
+        FOREIGN KEY(document_id) REFERENCES documents(id),
+        FOREIGN KEY(page_id) REFERENCES pages(id),
+        FOREIGN KEY(passage_id) REFERENCES passages(id)
     )
     """,
 )
@@ -378,6 +463,9 @@ def _initialize_database(database_path: Path) -> None:
         _ensure_column(connection, "documents", "normalized_path", "TEXT")
         _ensure_column(connection, "documents", "metadata_json", "TEXT NOT NULL DEFAULT '{}'")
         _ensure_column(connection, "pages", "extractor", "TEXT NOT NULL DEFAULT 'unknown'")
+        _ensure_column(connection, "document_profiles", "provider", "TEXT")
+        _ensure_column(connection, "document_briefs", "provider", "TEXT")
+        _ensure_column(connection, "discovery_items", "provider", "TEXT")
         connection.execute(
             "CREATE INDEX IF NOT EXISTS idx_documents_source_hash ON documents(source_hash)"
         )

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from newsrag.discovery import (
+    DiscoveryError,
+    DiscoveryEvidenceDraft,
+    create_discovery_item,
+    create_document_brief,
+    create_document_profile,
+    get_document_profile,
+    list_discovery_items,
+    list_document_briefs,
+)
+from newsrag.storage import REQUIRED_TABLES, _existing_tables, initialize_storage
+
+
+def test_initialize_storage_creates_discovery_tables_idempotently(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+
+    first_paths = initialize_storage(data_dir)
+    second_paths = initialize_storage(data_dir)
+
+    expected_tables = {
+        "document_profiles",
+        "document_briefs",
+        "document_briefs_fts",
+        "discovery_items",
+        "discovery_items_fts",
+        "discovery_evidence",
+    }
+    existing_tables = _existing_tables(second_paths.database)
+
+    assert first_paths == second_paths
+    assert expected_tables.issubset(existing_tables)
+    assert expected_tables.issubset(REQUIRED_TABLES)
+
+
+def test_document_profile_can_be_created_and_replaced(tmp_path: Path) -> None:
+    database_path = _seed_discovery_document(tmp_path)
+
+    first_profile = create_document_profile(
+        database_path,
+        document_id="document-a",
+        page_count=2,
+        text_length=42,
+        extraction_quality={"empty_pages": 0},
+        extractor="deterministic",
+        provider="rules",
+        model="rules-v1",
+        profile_id="profile-a",
+    )
+    second_profile = create_document_profile(
+        database_path,
+        document_id="document-a",
+        page_count=3,
+        text_length=84,
+        extraction_quality={"empty_pages": 1},
+        extractor="deterministic",
+        provider="rules",
+        model="rules-v2",
+        profile_id="profile-b",
+    )
+    loaded_profile = get_document_profile(database_path, "document-a")
+
+    assert first_profile.id == "profile-a"
+    assert second_profile.id == "profile-a"
+    assert loaded_profile.page_count == 3
+    assert loaded_profile.text_length == 84
+    assert loaded_profile.extraction_quality == {"empty_pages": 1}
+    assert loaded_profile.extractor == "deterministic"
+    assert loaded_profile.provider == "rules"
+    assert loaded_profile.model == "rules-v2"
+
+
+def test_document_brief_persists_provider_identity_and_fts(tmp_path: Path) -> None:
+    database_path = _seed_discovery_document(tmp_path)
+
+    brief = create_document_brief(
+        database_path,
+        document_id="document-a",
+        summary="Stormwater funding moved forward.",
+        significance="Potential infrastructure story.",
+        open_questions=("What contract funds the project?",),
+        extractor="local-llm",
+        provider="ollama",
+        model="llama3.1",
+        status="validated",
+        brief_id="brief-a",
+    )
+    briefs = list_document_briefs(database_path, document_id="document-a")
+
+    with sqlite3.connect(database_path) as connection:
+        fts_rows = connection.execute(
+            "SELECT brief_id, summary, significance FROM document_briefs_fts"
+        ).fetchall()
+
+    assert brief.id == "brief-a"
+    assert brief.extractor == "local-llm"
+    assert brief.provider == "ollama"
+    assert brief.model == "llama3.1"
+    assert brief.status == "validated"
+    assert brief.open_questions == ("What contract funds the project?",)
+    assert briefs == [brief]
+    assert fts_rows == [
+        ("brief-a", "Stormwater funding moved forward.", "Potential infrastructure story.")
+    ]
+
+
+def test_discovery_item_persists_evidence_references_and_identity(
+    tmp_path: Path,
+) -> None:
+    database_path = _seed_discovery_document(tmp_path)
+
+    item = create_discovery_item(
+        database_path,
+        document_id="document-a",
+        item_type="money",
+        label="$250,000 stormwater contract",
+        value={"amount": 250000, "currency": "USD"},
+        summary="The packet references a stormwater contract amount.",
+        confidence=0.92,
+        extractor="deterministic-money",
+        provider="rules",
+        model="rules-v1",
+        evidence=(
+            DiscoveryEvidenceDraft(
+                document_id="document-a",
+                page_id="page-a-1",
+                passage_id="passage-a-1",
+                page_start=1,
+                page_end=1,
+                quote="Approve a $250,000 stormwater contract.",
+                validation_status="validated",
+            ),
+        ),
+        item_id="discovery-a",
+    )
+    listed_items = list_discovery_items(database_path, document_id="document-a", item_type="money")
+
+    with sqlite3.connect(database_path) as connection:
+        fts_rows = connection.execute(
+            "SELECT item_id, label, summary FROM discovery_items_fts"
+        ).fetchall()
+
+    assert item.id == "discovery-a"
+    assert item.item_type == "money"
+    assert item.value == {"amount": 250000, "currency": "USD"}
+    assert item.confidence == 0.92
+    assert item.extractor == "deterministic-money"
+    assert item.provider == "rules"
+    assert item.model == "rules-v1"
+    assert len(item.evidence) == 1
+    assert item.evidence[0].document_id == "document-a"
+    assert item.evidence[0].page_id == "page-a-1"
+    assert item.evidence[0].passage_id == "passage-a-1"
+    assert item.evidence[0].page_start == 1
+    assert item.evidence[0].page_end == 1
+    assert item.evidence[0].quote == "Approve a $250,000 stormwater contract."
+    assert item.evidence[0].validation_status == "validated"
+    assert listed_items == [item]
+    assert fts_rows == [
+        (
+            "discovery-a",
+            "$250,000 stormwater contract",
+            "The packet references a stormwater contract amount.",
+        )
+    ]
+
+
+def test_discovery_item_validates_confidence_and_evidence_pages(tmp_path: Path) -> None:
+    database_path = _seed_discovery_document(tmp_path)
+
+    with pytest.raises(DiscoveryError, match="confidence must be between 0 and 1"):
+        create_discovery_item(
+            database_path,
+            document_id="document-a",
+            item_type="topic",
+            label="Stormwater",
+            confidence=1.5,
+            extractor="deterministic",
+        )
+
+    with pytest.raises(DiscoveryError, match="evidence.page_end"):
+        create_discovery_item(
+            database_path,
+            document_id="document-a",
+            item_type="topic",
+            label="Stormwater",
+            extractor="deterministic",
+            evidence=(
+                DiscoveryEvidenceDraft(
+                    document_id="document-a",
+                    page_start=2,
+                    page_end=1,
+                    quote="Stormwater",
+                    validation_status="validated",
+                ),
+            ),
+        )
+
+    with pytest.raises(DiscoveryError, match="evidence.document_id must match"):
+        create_discovery_item(
+            database_path,
+            document_id="document-a",
+            item_type="topic",
+            label="Stormwater",
+            extractor="deterministic",
+            evidence=(
+                DiscoveryEvidenceDraft(
+                    document_id="document-other",
+                    page_start=1,
+                    page_end=1,
+                    quote="Stormwater",
+                    validation_status="validated",
+                ),
+            ),
+        )
+
+    with pytest.raises(DiscoveryError, match="evidence.quote must be non-empty"):
+        create_discovery_item(
+            database_path,
+            document_id="document-a",
+            item_type="topic",
+            label="Stormwater",
+            extractor="deterministic",
+            evidence=(
+                DiscoveryEvidenceDraft(
+                    document_id="document-a",
+                    page_start=1,
+                    page_end=1,
+                    quote="",
+                    validation_status="validated",
+                ),
+            ),
+        )
+
+
+def _seed_discovery_document(tmp_path: Path) -> Path:
+    database_path = initialize_storage(tmp_path / ".newsrag").database
+    with sqlite3.connect(database_path) as connection:
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute(
+            """
+            INSERT INTO documents(id, source_path, source_url, title, source_hash, normalized_path, metadata_json)
+            VALUES(?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "document-a",
+                "/tmp/stormwater.pdf",
+                "https://example.test/stormwater.pdf",
+                "Stormwater Packet",
+                "hash-a",
+                "/tmp/stormwater-ocr.pdf",
+                '{"body": "Planning Commission", "meeting_date": "2026-05-01"}',
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO pages(id, document_id, page_number, text, extractor)
+            VALUES(?, ?, ?, ?, ?)
+            """,
+            (
+                "page-a-1",
+                "document-a",
+                1,
+                "Approve a $250,000 stormwater contract.",
+                "pymupdf",
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO chunks(id, document_id, page_start, page_end, text)
+            VALUES(?, ?, ?, ?, ?)
+            """,
+            (
+                "chunk-a-1",
+                "document-a",
+                1,
+                1,
+                "Approve a $250,000 stormwater contract.",
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO passages(id, chunk_id, document_id, page_start, page_end, ordinal, text)
+            VALUES(?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "passage-a-1",
+                "chunk-a-1",
+                "document-a",
+                1,
+                1,
+                1,
+                "Approve a $250,000 stormwater contract.",
+            ),
+        )
+        connection.commit()
+    return database_path


### PR DESCRIPTION
## Summary

Adds durable storage and helper APIs for evidence-backed discovery records.

## Task

#task-2cba53c1

## Changes

- Added discovery schema tables for document profiles, document briefs, discovery items, discovery evidence, and FTS indexes.
- Added `newsrag.discovery` dataclasses and helper functions for creating/listing profiles, briefs, items, and evidence references.
- Stores extractor/provider/model identity, confidence, validation status, type-specific JSON values, and page/passage provenance.
- Added tests for idempotent schema initialization and helper persistence/listing behavior.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed: `./scripts/pre-pr.sh`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included