### PR TITLE
feat: add discovery browsing commands

### DIFF
--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -18,6 +18,7 @@ from newsrag.config import (
 )
 
 if TYPE_CHECKING:
+    from newsrag.discovery_browse import DiscoveryBrowseFilters
     from newsrag.jobs import Job
     from newsrag.search import SearchFilters
 
@@ -54,6 +55,43 @@ ENRICH_RESPONSE_JSON_OPTION = typer.Option(
     dir_okay=False,
     resolve_path=False,
 )
+DISCOVERY_BODY_OPTION = typer.Option(None, help="Only browse items from this civic body.")
+DISCOVERY_DOCUMENT_TYPE_OPTION = typer.Option(
+    None,
+    "--document-type",
+    help="Only browse items from documents with this document type metadata.",
+)
+DISCOVERY_JURISDICTION_OPTION = typer.Option(
+    None,
+    help="Only browse items from this jurisdiction.",
+)
+DISCOVERY_SOURCE_URL_OPTION = typer.Option(
+    None,
+    "--source-url",
+    help="Only browse items from documents with this source URL.",
+)
+DISCOVERY_SINCE_OPTION = typer.Option(
+    None,
+    "--since",
+    help="Only browse items from documents with meeting dates on or after YYYY-MM-DD.",
+)
+DISCOVERY_UNTIL_OPTION = typer.Option(
+    None,
+    "--until",
+    help="Only browse items from documents with meeting dates on or before YYYY-MM-DD.",
+)
+DISCOVERY_ITEM_TYPE_OPTION = typer.Option(
+    None,
+    "--item-type",
+    help="Only browse timeline items with this discovery item type.",
+)
+DISCOVERY_MIN_CONFIDENCE_OPTION = typer.Option(
+    None,
+    "--min-confidence",
+    help="Only browse items at or above this confidence threshold.",
+)
+DISCOVERY_LIMIT_OPTION = typer.Option(50, "--limit", help="Maximum items to show, up to 500.")
+DISCOVERY_OFFSET_OPTION = typer.Option(0, "--offset", help="Number of matching items to skip.")
 
 app = typer.Typer(
     help="Local-first evidence retrieval for city hall PDFs.",
@@ -66,12 +104,18 @@ watch_app = typer.Typer(help="Manage watched folders for automatic ingestion.")
 documents_app = typer.Typer(help="Browse ingested document inventory.")
 discover_app = typer.Typer(help="Extract and inspect discovery signals.")
 enrich_app = typer.Typer(help="Run optional structured discovery enrichment.")
+topics_app = typer.Typer(help="Browse corpus topics from discovery records.")
+entities_app = typer.Typer(help="Browse corpus entities from discovery records.")
+leads_app = typer.Typer(help="Browse story leads from discovery records.")
 app.add_typer(daemon_app, name="daemon")
 app.add_typer(jobs_app, name="jobs")
 app.add_typer(watch_app, name="watch")
 app.add_typer(documents_app, name="documents")
 app.add_typer(discover_app, name="discover")
 app.add_typer(enrich_app, name="enrich")
+app.add_typer(topics_app, name="topics")
+app.add_typer(entities_app, name="entities")
+app.add_typer(leads_app, name="leads")
 
 
 @dataclass(frozen=True)
@@ -653,6 +697,260 @@ def enrich_document_command(
     typer.echo(format_enrichment_result(result))
 
 
+@topics_app.command("list")
+def topics_list_command(
+    ctx: typer.Context,
+    body: str | None = DISCOVERY_BODY_OPTION,
+    document_type: str | None = DISCOVERY_DOCUMENT_TYPE_OPTION,
+    jurisdiction: str | None = DISCOVERY_JURISDICTION_OPTION,
+    source_url: str | None = DISCOVERY_SOURCE_URL_OPTION,
+    since: str | None = DISCOVERY_SINCE_OPTION,
+    until: str | None = DISCOVERY_UNTIL_OPTION,
+    min_confidence: float | None = DISCOVERY_MIN_CONFIDENCE_OPTION,
+    limit: int = DISCOVERY_LIMIT_OPTION,
+    offset: int = DISCOVERY_OFFSET_OPTION,
+) -> None:
+    """List corpus topics from discovery records."""
+
+    from newsrag.discovery_browse import (
+        TOPIC_ITEM_TYPES,
+        DiscoveryBrowseError,
+        format_topics_list,
+        list_browse_items,
+    )
+    from newsrag.storage import initialize_storage
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    database_path = initialize_storage(settings.data_dir).database
+    filters = _build_discovery_browse_filters(
+        body=body,
+        document_type=document_type,
+        jurisdiction=jurisdiction,
+        source_url=source_url,
+        since=since,
+        until=until,
+        min_confidence=min_confidence,
+    )
+    try:
+        page = list_browse_items(
+            database_path,
+            item_types=TOPIC_ITEM_TYPES,
+            filters=filters,
+            limit=limit,
+            offset=offset,
+        )
+    except DiscoveryBrowseError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(format_topics_list(page))
+
+
+@topics_app.command("show")
+def topics_show_command(ctx: typer.Context, item_id: str) -> None:
+    """Show one topic discovery record with citations."""
+
+    from newsrag.discovery_browse import DiscoveryBrowseError, format_browse_detail, get_browse_item
+    from newsrag.storage import initialize_storage
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    database_path = initialize_storage(settings.data_dir).database
+    try:
+        item = get_browse_item(database_path, item_id)
+    except DiscoveryBrowseError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(format_browse_detail(item, title="NewsRAG Topic"))
+
+
+@entities_app.command("list")
+def entities_list_command(
+    ctx: typer.Context,
+    body: str | None = DISCOVERY_BODY_OPTION,
+    document_type: str | None = DISCOVERY_DOCUMENT_TYPE_OPTION,
+    jurisdiction: str | None = DISCOVERY_JURISDICTION_OPTION,
+    source_url: str | None = DISCOVERY_SOURCE_URL_OPTION,
+    since: str | None = DISCOVERY_SINCE_OPTION,
+    until: str | None = DISCOVERY_UNTIL_OPTION,
+    min_confidence: float | None = DISCOVERY_MIN_CONFIDENCE_OPTION,
+    limit: int = DISCOVERY_LIMIT_OPTION,
+    offset: int = DISCOVERY_OFFSET_OPTION,
+) -> None:
+    """List corpus entities from discovery records."""
+
+    from newsrag.discovery_browse import (
+        ENTITY_ITEM_TYPES,
+        DiscoveryBrowseError,
+        format_entities_list,
+        list_browse_items,
+    )
+    from newsrag.storage import initialize_storage
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    database_path = initialize_storage(settings.data_dir).database
+    filters = _build_discovery_browse_filters(
+        body=body,
+        document_type=document_type,
+        jurisdiction=jurisdiction,
+        source_url=source_url,
+        since=since,
+        until=until,
+        min_confidence=min_confidence,
+    )
+    try:
+        page = list_browse_items(
+            database_path,
+            item_types=ENTITY_ITEM_TYPES,
+            filters=filters,
+            limit=limit,
+            offset=offset,
+        )
+    except DiscoveryBrowseError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(format_entities_list(page))
+
+
+@entities_app.command("show")
+def entities_show_command(ctx: typer.Context, item_id: str) -> None:
+    """Show one entity discovery record with citations."""
+
+    from newsrag.discovery_browse import DiscoveryBrowseError, format_browse_detail, get_browse_item
+    from newsrag.storage import initialize_storage
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    database_path = initialize_storage(settings.data_dir).database
+    try:
+        item = get_browse_item(database_path, item_id)
+    except DiscoveryBrowseError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(format_browse_detail(item, title="NewsRAG Entity"))
+
+
+@app.command("timeline")
+def timeline_command(
+    ctx: typer.Context,
+    body: str | None = DISCOVERY_BODY_OPTION,
+    document_type: str | None = DISCOVERY_DOCUMENT_TYPE_OPTION,
+    jurisdiction: str | None = DISCOVERY_JURISDICTION_OPTION,
+    source_url: str | None = DISCOVERY_SOURCE_URL_OPTION,
+    since: str | None = DISCOVERY_SINCE_OPTION,
+    until: str | None = DISCOVERY_UNTIL_OPTION,
+    item_type: str | None = DISCOVERY_ITEM_TYPE_OPTION,
+    min_confidence: float | None = DISCOVERY_MIN_CONFIDENCE_OPTION,
+    limit: int = DISCOVERY_LIMIT_OPTION,
+    offset: int = DISCOVERY_OFFSET_OPTION,
+) -> None:
+    """Show dated evidence-backed discovery items across the corpus."""
+
+    from newsrag.discovery_browse import (
+        TIMELINE_ITEM_TYPES,
+        DiscoveryBrowseError,
+        format_timeline,
+        list_browse_items,
+    )
+    from newsrag.storage import initialize_storage
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    database_path = initialize_storage(settings.data_dir).database
+    filters = _build_discovery_browse_filters(
+        body=body,
+        document_type=document_type,
+        jurisdiction=jurisdiction,
+        source_url=source_url,
+        since=since,
+        until=until,
+        item_type=item_type,
+        min_confidence=min_confidence,
+    )
+    try:
+        page = list_browse_items(
+            database_path,
+            item_types=TIMELINE_ITEM_TYPES,
+            filters=filters,
+            limit=limit,
+            offset=offset,
+            order_by="timeline",
+        )
+    except DiscoveryBrowseError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(format_timeline(page))
+
+
+@leads_app.command("list")
+def leads_list_command(
+    ctx: typer.Context,
+    body: str | None = DISCOVERY_BODY_OPTION,
+    document_type: str | None = DISCOVERY_DOCUMENT_TYPE_OPTION,
+    jurisdiction: str | None = DISCOVERY_JURISDICTION_OPTION,
+    source_url: str | None = DISCOVERY_SOURCE_URL_OPTION,
+    since: str | None = DISCOVERY_SINCE_OPTION,
+    until: str | None = DISCOVERY_UNTIL_OPTION,
+    min_confidence: float | None = DISCOVERY_MIN_CONFIDENCE_OPTION,
+    limit: int = DISCOVERY_LIMIT_OPTION,
+    offset: int = DISCOVERY_OFFSET_OPTION,
+) -> None:
+    """List possible story leads from discovery records."""
+
+    from newsrag.discovery_browse import (
+        LEAD_ITEM_TYPES,
+        DiscoveryBrowseError,
+        format_leads_list,
+        list_browse_items,
+    )
+    from newsrag.storage import initialize_storage
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    database_path = initialize_storage(settings.data_dir).database
+    filters = _build_discovery_browse_filters(
+        body=body,
+        document_type=document_type,
+        jurisdiction=jurisdiction,
+        source_url=source_url,
+        since=since,
+        until=until,
+        min_confidence=min_confidence,
+    )
+    try:
+        page = list_browse_items(
+            database_path,
+            item_types=LEAD_ITEM_TYPES,
+            filters=filters,
+            limit=limit,
+            offset=offset,
+            order_by="created",
+        )
+    except DiscoveryBrowseError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(format_leads_list(page))
+
+
+@leads_app.command("show")
+def leads_show_command(ctx: typer.Context, item_id: str) -> None:
+    """Show one story lead with supporting evidence."""
+
+    from newsrag.discovery_browse import DiscoveryBrowseError, format_browse_detail, get_browse_item
+    from newsrag.storage import initialize_storage
+
+    settings, _ = _resolve_runtime_settings(ctx)
+    database_path = initialize_storage(settings.data_dir).database
+    try:
+        item = get_browse_item(database_path, item_id)
+    except DiscoveryBrowseError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(format_browse_detail(item, title="NewsRAG Story Lead"))
+
+
 @jobs_app.command("list")
 def jobs_list_command(ctx: typer.Context) -> None:
     """List durable NewsRAG jobs."""
@@ -796,6 +1094,31 @@ def _build_search_filters(
         source_url=source_url,
         since=since,
         until=until,
+    )
+
+
+def _build_discovery_browse_filters(
+    *,
+    body: str | None,
+    document_type: str | None,
+    jurisdiction: str | None,
+    source_url: str | None,
+    since: str | None,
+    until: str | None,
+    item_type: str | None = None,
+    min_confidence: float | None = None,
+) -> DiscoveryBrowseFilters:
+    from newsrag.discovery_browse import DiscoveryBrowseFilters
+
+    return DiscoveryBrowseFilters(
+        body=body,
+        document_type=document_type,
+        jurisdiction=jurisdiction,
+        source_url=source_url,
+        since=since,
+        until=until,
+        item_type=item_type,
+        min_confidence=min_confidence,
     )
 
 

--- a/newsrag/discovery_browse.py
+++ b/newsrag/discovery_browse.py
@@ -1,0 +1,552 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from newsrag.discovery import DiscoveryEvidenceRecord, DiscoveryItemRecord
+
+DEFAULT_DISCOVERY_LIST_LIMIT = 50
+MAX_DISCOVERY_LIST_LIMIT = 500
+TOPIC_ITEM_TYPES = ("topic",)
+ENTITY_ITEM_TYPES = ("entity",)
+LEAD_ITEM_TYPES = ("story_lead",)
+TIMELINE_ITEM_TYPES = ("date", "deadline", "action")
+
+
+class DiscoveryBrowseError(Exception):
+    """Raised when discovery browsing commands cannot complete."""
+
+
+@dataclass(frozen=True)
+class DiscoveryBrowseFilters:
+    """Filters for corpus discovery browsing."""
+
+    body: str | None = None
+    document_type: str | None = None
+    jurisdiction: str | None = None
+    source_url: str | None = None
+    since: str | None = None
+    until: str | None = None
+    item_type: str | None = None
+    min_confidence: float | None = None
+
+
+@dataclass(frozen=True)
+class DiscoveryBrowseItem:
+    """One discovery record with document metadata for browsing."""
+
+    item: DiscoveryItemRecord
+    document_title: str | None
+    source_path: str | None
+    source_url: str | None
+    metadata: dict[str, Any]
+
+    @property
+    def meeting_date(self) -> str | None:
+        """Return the document meeting date when present."""
+
+        return _metadata_string(self.metadata, "meeting_date")
+
+    @property
+    def display_date(self) -> str | None:
+        """Return the best date-like value for timeline display."""
+
+        for key in ("date", "date_text", "deadline", "meeting_date"):
+            value = _metadata_string(self.item.value, key)
+            if value is not None:
+                return value
+        if self.item.item_type in {"date", "deadline"}:
+            return self.item.label
+        return self.meeting_date
+
+
+@dataclass(frozen=True)
+class DiscoveryBrowsePage:
+    """A bounded page of discovery browsing results."""
+
+    items: tuple[DiscoveryBrowseItem, ...]
+    total: int
+    limit: int
+    offset: int
+    filters: DiscoveryBrowseFilters
+
+
+@dataclass(frozen=True)
+class _QueryParts:
+    where_sql: str
+    parameters: tuple[object, ...]
+
+
+@dataclass(frozen=True)
+class _SelectParts:
+    sql: str
+    parameters: tuple[object, ...]
+
+
+def list_browse_items(
+    database_path: Path,
+    *,
+    item_types: tuple[str, ...],
+    filters: DiscoveryBrowseFilters | None = None,
+    limit: int = DEFAULT_DISCOVERY_LIST_LIMIT,
+    offset: int = 0,
+    order_by: str = "label",
+) -> DiscoveryBrowsePage:
+    """List a bounded page of discovery records with document metadata."""
+
+    _validate_item_types(item_types)
+    _validate_pagination(limit=limit, offset=offset)
+    resolved_filters = filters or DiscoveryBrowseFilters()
+    _validate_filters(resolved_filters)
+    query = _build_filter_query(item_types=item_types, filters=resolved_filters)
+    order_sql = _order_sql(order_by)
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        total_row = connection.execute(
+            f"""
+            SELECT COUNT(*) AS total
+            FROM discovery_items
+            JOIN documents ON documents.id = discovery_items.document_id
+            {query.where_sql}
+            """,
+            query.parameters,
+        ).fetchone()
+        item_rows = connection.execute(
+            f"""
+            {_select_browse_columns()}
+            FROM discovery_items
+            JOIN documents ON documents.id = discovery_items.document_id
+            {query.where_sql}
+            {order_sql}
+            LIMIT ? OFFSET ?
+            """,
+            (*query.parameters, limit, offset),
+        ).fetchall()
+
+        evidence_by_item_id = _load_evidence_for_rows(connection, item_rows)
+
+    total = int(total_row["total"]) if total_row is not None else 0
+    return DiscoveryBrowsePage(
+        items=tuple(_row_to_browse_item(row, evidence_by_item_id) for row in item_rows),
+        total=total,
+        limit=limit,
+        offset=offset,
+        filters=resolved_filters,
+    )
+
+
+def get_browse_item(database_path: Path, item_id: str) -> DiscoveryBrowseItem:
+    """Load one discovery record with evidence and document metadata."""
+
+    resolved_item_id = _normalized_optional_string(item_id)
+    if resolved_item_id is None:
+        raise DiscoveryBrowseError("item_id must be non-empty")
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(
+            f"""
+            {_select_browse_columns()}
+            FROM discovery_items
+            JOIN documents ON documents.id = discovery_items.document_id
+            WHERE discovery_items.id = ?
+            """,
+            (resolved_item_id,),
+        ).fetchall()
+        evidence_by_item_id = _load_evidence_for_rows(connection, rows)
+
+    if not rows:
+        raise DiscoveryBrowseError(f"Unknown discovery item: {resolved_item_id}")
+    return _row_to_browse_item(rows[0], evidence_by_item_id)
+
+
+def format_topics_list(page: DiscoveryBrowsePage) -> str:
+    """Format corpus topics for terminal output."""
+
+    return _format_browse_list(page, title="NewsRAG Topics", empty_label="topics")
+
+
+def format_entities_list(page: DiscoveryBrowsePage) -> str:
+    """Format corpus entities for terminal output."""
+
+    return _format_browse_list(page, title="NewsRAG Entities", empty_label="entities")
+
+
+def format_leads_list(page: DiscoveryBrowsePage) -> str:
+    """Format story leads for terminal output."""
+
+    return _format_browse_list(page, title="NewsRAG Story Leads", empty_label="leads")
+
+
+def format_timeline(page: DiscoveryBrowsePage) -> str:
+    """Format timeline-oriented discovery items for terminal output."""
+
+    return _format_browse_list(
+        page,
+        title="NewsRAG Timeline",
+        empty_label="timeline items",
+        include_display_date=True,
+    )
+
+
+def format_browse_detail(
+    item: DiscoveryBrowseItem, *, title: str = "NewsRAG Discovery Item"
+) -> str:
+    """Format one discovery item with supporting evidence for terminal output."""
+
+    record = item.item
+    lines = [
+        title,
+        f"id: {record.id}",
+        f"type: {record.item_type}",
+        f"label: {record.label}",
+        f"document_id: {record.document_id}",
+        f"document_title: {_display_value(item.document_title)}",
+        f"meeting_date: {_display_value(item.meeting_date)}",
+        f"source: {_display_value(_best_source(item))}",
+        f"confidence: {_format_confidence(record.confidence)}",
+        f"summary: {_display_value(record.summary or None)}",
+        "value:",
+    ]
+    if record.value:
+        for key in sorted(record.value):
+            lines.append(f"  {key}: {_format_json_value(record.value[key])}")
+    else:
+        lines.append("  none")
+
+    lines.append("evidence:")
+    if not record.evidence:
+        lines.append("  none")
+        return "\n".join(lines)
+
+    for evidence in record.evidence:
+        lines.append(f"  - {_format_evidence_reference(evidence)}")
+        lines.append(f'    quote: "{evidence.quote}"')
+    return "\n".join(lines)
+
+
+def _format_browse_list(
+    page: DiscoveryBrowsePage,
+    *,
+    title: str,
+    empty_label: str,
+    include_display_date: bool = False,
+) -> str:
+    lines = [title]
+    if not page.items:
+        if page.total == 0:
+            lines.append(f"{empty_label}: none")
+        else:
+            lines.append(
+                f"{empty_label}: none at offset {page.offset}; total={page.total} limit={page.limit}"
+            )
+        return "\n".join(lines)
+
+    shown = len(page.items)
+    lines.append(
+        f"showing {shown} of {page.total} item(s); limit={page.limit} offset={page.offset}"
+    )
+    if page.offset + shown < page.total:
+        lines.append("more: use --limit/--offset or filters to narrow results")
+
+    for browse_item in page.items:
+        record = browse_item.item
+        parts = [
+            record.id,
+            record.item_type,
+            record.label,
+            f"confidence={_format_confidence(record.confidence)}",
+            f"document={record.document_id}",
+            f"title={_display_value(browse_item.document_title)}",
+            f"meeting_date={_display_value(browse_item.meeting_date)}",
+        ]
+        if include_display_date:
+            parts.insert(2, f"date={_display_value(browse_item.display_date)}")
+        citation = _first_citation(record)
+        if citation is not None:
+            parts.append(f"citation={citation}")
+        lines.append(" | ".join(parts))
+
+    return "\n".join(lines)
+
+
+def _build_filter_query(
+    *,
+    item_types: tuple[str, ...],
+    filters: DiscoveryBrowseFilters,
+) -> _QueryParts:
+    clauses: list[str] = []
+    parameters: list[object] = []
+
+    placeholders = ", ".join("?" for _ in item_types)
+    clauses.append(f"discovery_items.item_type IN ({placeholders})")
+    parameters.extend(item_types)
+
+    requested_item_type = _normalized_optional_string(filters.item_type)
+    if requested_item_type is not None:
+        if requested_item_type not in item_types:
+            raise DiscoveryBrowseError(
+                f"--item-type must be one of: {', '.join(sorted(item_types))}"
+            )
+        clauses.append("discovery_items.item_type = ?")
+        parameters.append(requested_item_type)
+
+    for key, value in (
+        ("body", filters.body),
+        ("document_type", filters.document_type),
+        ("jurisdiction", filters.jurisdiction),
+    ):
+        resolved_value = _normalized_optional_string(value)
+        if resolved_value is None:
+            continue
+        clauses.append(f"json_extract(documents.metadata_json, '$.{key}') = ?")
+        parameters.append(resolved_value)
+
+    source_url = _normalized_optional_string(filters.source_url)
+    if source_url is not None:
+        clauses.append(
+            "(documents.source_url = ? OR json_extract(documents.metadata_json, '$.source_url') = ?)"
+        )
+        parameters.extend((source_url, source_url))
+
+    since = _normalized_optional_string(filters.since)
+    if since is not None:
+        clauses.append("json_extract(documents.metadata_json, '$.meeting_date') >= ?")
+        parameters.append(since)
+
+    until = _normalized_optional_string(filters.until)
+    if until is not None:
+        clauses.append("json_extract(documents.metadata_json, '$.meeting_date') <= ?")
+        parameters.append(until)
+
+    if filters.min_confidence is not None:
+        clauses.append("discovery_items.confidence IS NOT NULL")
+        clauses.append("discovery_items.confidence >= ?")
+        parameters.append(filters.min_confidence)
+
+    return _QueryParts(where_sql="WHERE " + " AND ".join(clauses), parameters=tuple(parameters))
+
+
+def _select_browse_columns() -> str:
+    return """
+        SELECT
+            discovery_items.id,
+            discovery_items.document_id,
+            discovery_items.item_type,
+            discovery_items.label,
+            discovery_items.value_json,
+            discovery_items.summary,
+            discovery_items.confidence,
+            discovery_items.extractor,
+            discovery_items.provider,
+            discovery_items.model,
+            discovery_items.created_at,
+            documents.title AS document_title,
+            documents.source_path,
+            documents.source_url,
+            documents.metadata_json
+        """
+
+
+def _load_evidence_for_rows(
+    connection: sqlite3.Connection,
+    rows: list[sqlite3.Row],
+) -> dict[str, list[DiscoveryEvidenceRecord]]:
+    item_ids = tuple(str(row["id"]) for row in rows)
+    if not item_ids:
+        return {}
+
+    placeholders = ", ".join("?" for _ in item_ids)
+    evidence_rows = connection.execute(
+        f"""
+        SELECT
+            id,
+            item_id,
+            document_id,
+            page_id,
+            passage_id,
+            page_start,
+            page_end,
+            quote,
+            validation_status,
+            created_at
+        FROM discovery_evidence
+        WHERE item_id IN ({placeholders})
+        ORDER BY created_at ASC, id ASC
+        """,
+        item_ids,
+    ).fetchall()
+
+    evidence_by_item_id: dict[str, list[DiscoveryEvidenceRecord]] = {}
+    for row in evidence_rows:
+        evidence = _row_to_evidence(row)
+        evidence_by_item_id.setdefault(evidence.item_id, []).append(evidence)
+    return evidence_by_item_id
+
+
+def _row_to_browse_item(
+    row: sqlite3.Row,
+    evidence_by_item_id: dict[str, list[DiscoveryEvidenceRecord]],
+) -> DiscoveryBrowseItem:
+    item_id = str(row["id"])
+    item = DiscoveryItemRecord(
+        id=item_id,
+        document_id=str(row["document_id"]),
+        item_type=str(row["item_type"]),
+        label=str(row["label"]),
+        value=_load_json_object(row["value_json"]),
+        summary=str(row["summary"]),
+        confidence=float(row["confidence"]) if row["confidence"] is not None else None,
+        extractor=str(row["extractor"]),
+        provider=str(row["provider"]) if row["provider"] is not None else None,
+        model=str(row["model"]) if row["model"] is not None else None,
+        created_at=str(row["created_at"]),
+        evidence=tuple(evidence_by_item_id.get(item_id, [])),
+    )
+    return DiscoveryBrowseItem(
+        item=item,
+        document_title=_optional_string(row["document_title"]),
+        source_path=_optional_string(row["source_path"]),
+        source_url=_optional_string(row["source_url"]),
+        metadata=_load_json_object(row["metadata_json"]),
+    )
+
+
+def _row_to_evidence(row: sqlite3.Row) -> DiscoveryEvidenceRecord:
+    return DiscoveryEvidenceRecord(
+        id=str(row["id"]),
+        item_id=str(row["item_id"]),
+        document_id=str(row["document_id"]),
+        page_id=str(row["page_id"]) if row["page_id"] is not None else None,
+        passage_id=str(row["passage_id"]) if row["passage_id"] is not None else None,
+        page_start=int(row["page_start"]),
+        page_end=int(row["page_end"]),
+        quote=str(row["quote"]),
+        validation_status=str(row["validation_status"]),
+        created_at=str(row["created_at"]),
+    )
+
+
+def _order_sql(order_by: str) -> str:
+    if order_by == "timeline":
+        return (
+            "ORDER BY "
+            "coalesce(json_extract(discovery_items.value_json, '$.date_text'), "
+            "json_extract(discovery_items.value_json, '$.date'), "
+            "json_extract(discovery_items.value_json, '$.deadline'), "
+            "json_extract(documents.metadata_json, '$.meeting_date'), "
+            "discovery_items.created_at) ASC, "
+            "discovery_items.label ASC, discovery_items.id ASC"
+        )
+    if order_by == "created":
+        return "ORDER BY discovery_items.created_at DESC, discovery_items.id ASC"
+    return "ORDER BY lower(discovery_items.label) ASC, discovery_items.created_at DESC, discovery_items.id ASC"
+
+
+def _validate_item_types(item_types: tuple[str, ...]) -> None:
+    if not item_types:
+        raise DiscoveryBrowseError("At least one item type is required")
+    for item_type in item_types:
+        if _normalized_optional_string(item_type) is None:
+            raise DiscoveryBrowseError("Item types must be non-empty")
+
+
+def _validate_pagination(*, limit: int, offset: int) -> None:
+    if limit < 1 or limit > MAX_DISCOVERY_LIST_LIMIT:
+        raise DiscoveryBrowseError(f"--limit must be between 1 and {MAX_DISCOVERY_LIST_LIMIT}")
+    if offset < 0:
+        raise DiscoveryBrowseError("--offset must be zero or greater")
+
+
+def _validate_filters(filters: DiscoveryBrowseFilters) -> None:
+    since_date = _parse_filter_date(filters.since, option_name="--since")
+    until_date = _parse_filter_date(filters.until, option_name="--until")
+    if since_date is not None and until_date is not None and since_date > until_date:
+        raise DiscoveryBrowseError("Invalid date range: --since must be on or before --until")
+    if filters.min_confidence is not None and not 0 <= filters.min_confidence <= 1:
+        raise DiscoveryBrowseError("--min-confidence must be between 0 and 1")
+
+
+def _parse_filter_date(value: str | None, *, option_name: str) -> date | None:
+    resolved_value = _normalized_optional_string(value)
+    if resolved_value is None:
+        return None
+    try:
+        return date.fromisoformat(resolved_value)
+    except ValueError as exc:
+        raise DiscoveryBrowseError(f"Invalid {option_name} date: expected YYYY-MM-DD") from exc
+
+
+def _first_citation(item: DiscoveryItemRecord) -> str | None:
+    if not item.evidence:
+        return None
+    return _format_evidence_reference(item.evidence[0])
+
+
+def _format_evidence_reference(evidence: DiscoveryEvidenceRecord) -> str:
+    if evidence.page_start == evidence.page_end:
+        page_label = f"p.{evidence.page_start}"
+    else:
+        page_label = f"pp.{evidence.page_start}-{evidence.page_end}"
+    return f"{evidence.document_id} {page_label}"
+
+
+def _best_source(item: DiscoveryBrowseItem) -> str | None:
+    return (
+        item.source_url
+        or item.source_path
+        or _metadata_string(item.metadata, "stored_source_path")
+        or _metadata_string(item.metadata, "source_filename")
+    )
+
+
+def _metadata_string(metadata: dict[str, Any], key: str) -> str | None:
+    return _optional_string(metadata.get(key))
+
+
+def _load_json_object(value: object) -> dict[str, Any]:
+    try:
+        loaded = json.loads(str(value))
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    return loaded
+
+
+def _optional_string(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _normalized_optional_string(value: str | None) -> str | None:
+    if value is None:
+        return None
+    resolved_value = value.strip()
+    if not resolved_value:
+        return None
+    return resolved_value
+
+
+def _display_value(value: str | None) -> str:
+    if value is None:
+        return "-"
+    return value
+
+
+def _format_confidence(value: float | None) -> str:
+    if value is None:
+        return "-"
+    return f"{value:.2f}"
+
+
+def _format_json_value(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, sort_keys=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,6 +32,10 @@ def test_help_shows_cli_commands() -> None:
     assert "documents" in result.stdout
     assert "discover" in result.stdout
     assert "enrich" in result.stdout
+    assert "topics" in result.stdout
+    assert "entities" in result.stdout
+    assert "timeline" in result.stdout
+    assert "leads" in result.stdout
 
 
 def test_version_option_shows_project_version() -> None:

--- a/tests/test_discovery_browse.py
+++ b/tests/test_discovery_browse.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from newsrag.cli import app
+from newsrag.discovery import DiscoveryEvidenceDraft, create_discovery_item
+from newsrag.storage import initialize_storage
+
+runner = CliRunner()
+
+
+def test_topics_list_empty_corpus(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    initialize_storage(data_dir)
+
+    result = runner.invoke(app, ["--data-dir", str(data_dir), "topics", "list"])
+
+    assert result.exit_code == 0
+    assert "NewsRAG Topics" in result.stdout
+    assert "topics: none" in result.stdout
+
+
+def test_topics_list_supports_metadata_date_and_confidence_filters(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    _seed_discovery_browse_data(data_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            "--data-dir",
+            str(data_dir),
+            "topics",
+            "list",
+            "--body",
+            "City Council",
+            "--document-type",
+            "agenda_packet",
+            "--jurisdiction",
+            "Example City",
+            "--source-url",
+            "https://example.test/council.pdf",
+            "--since",
+            "2026-05-01",
+            "--until",
+            "2026-05-31",
+            "--min-confidence",
+            "0.55",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "NewsRAG Topics" in result.stdout
+    assert "topic-council-contract | topic | contract" in result.stdout
+    assert "meeting_date=2026-05-12" in result.stdout
+    assert "citation=document-council p.2" in result.stdout
+    assert "topic-planning-zoning" not in result.stdout
+
+
+def test_entities_list_shows_extracted_entities(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    _seed_discovery_browse_data(data_dir)
+
+    result = runner.invoke(app, ["--data-dir", str(data_dir), "entities", "list"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "NewsRAG Entities" in result.stdout
+    assert "entity-planning-board | entity | Planning Board" in result.stdout
+    assert "entity-council-vendor | entity | Acme Construction LLC" in result.stdout
+
+
+def test_timeline_supports_item_type_filter_and_citation_output(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    _seed_discovery_browse_data(data_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            "--data-dir",
+            str(data_dir),
+            "timeline",
+            "--item-type",
+            "deadline",
+            "--min-confidence",
+            "0.80",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "NewsRAG Timeline" in result.stdout
+    assert "deadline-council | deadline | date=June 1, 2026 | June 1, 2026" in result.stdout
+    assert "citation=document-council p.2" in result.stdout
+    assert "action-council" not in result.stdout
+
+
+def test_timeline_rejects_invalid_filters(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    initialize_storage(data_dir)
+
+    invalid_date_result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "timeline", "--since", "05-01-2026"],
+    )
+    invalid_confidence_result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "timeline", "--min-confidence", "1.5"],
+    )
+    invalid_item_type_result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "timeline", "--item-type", "topic"],
+    )
+
+    assert invalid_date_result.exit_code == 1
+    assert "Invalid --since date" in invalid_date_result.stdout
+    assert invalid_confidence_result.exit_code == 1
+    assert "--min-confidence must be between 0 and 1" in invalid_confidence_result.stdout
+    assert invalid_item_type_result.exit_code == 1
+    assert "--item-type must be one of" in invalid_item_type_result.stdout
+
+
+def test_leads_list_and_show_include_supporting_evidence(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    _seed_discovery_browse_data(data_dir)
+
+    list_result = runner.invoke(app, ["--data-dir", str(data_dir), "leads", "list"])
+    show_result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "leads", "show", "lead-council-contract"],
+    )
+
+    assert list_result.exit_code == 0, list_result.stdout
+    assert "NewsRAG Story Leads" in list_result.stdout
+    assert "lead-council-contract | story_lead | Follow stormwater contract" in list_result.stdout
+    assert "citation=document-council p.2" in list_result.stdout
+
+    assert show_result.exit_code == 0, show_result.stdout
+    assert "NewsRAG Story Lead" in show_result.stdout
+    assert "id: lead-council-contract" in show_result.stdout
+    assert "label: Follow stormwater contract" in show_result.stdout
+    assert "source: https://example.test/council.pdf" in show_result.stdout
+    assert "evidence:" in show_result.stdout
+    assert "document-council p.2" in show_result.stdout
+    assert 'quote: "Council awarded a $250,000 stormwater contract."' in show_result.stdout
+
+
+def test_leads_show_missing_id_fails_clearly(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    initialize_storage(data_dir)
+
+    result = runner.invoke(app, ["--data-dir", str(data_dir), "leads", "show", "missing"])
+
+    assert result.exit_code == 1
+    assert "Unknown discovery item: missing" in result.stdout
+
+
+def _seed_discovery_browse_data(data_dir: Path) -> Path:
+    database_path = initialize_storage(data_dir).database
+    with sqlite3.connect(database_path) as connection:
+        connection.executemany(
+            """
+            INSERT INTO documents(
+                id,
+                source_path,
+                source_url,
+                title,
+                source_hash,
+                normalized_path,
+                metadata_json,
+                created_at
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    "document-council",
+                    "/tmp/council.pdf",
+                    "https://example.test/council.pdf",
+                    "Council Packet",
+                    "hash-council",
+                    "/tmp/council-ocr.pdf",
+                    '{"body": "City Council", "document_type": "agenda_packet", "jurisdiction": "Example City", "meeting_date": "2026-05-12"}',
+                    "2026-05-12T00:00:00+00:00",
+                ),
+                (
+                    "document-planning",
+                    "/tmp/planning.pdf",
+                    "https://example.test/planning.pdf",
+                    "Planning Packet",
+                    "hash-planning",
+                    "/tmp/planning-ocr.pdf",
+                    '{"body": "Planning Board", "document_type": "staff_report", "jurisdiction": "Example City", "meeting_date": "2026-04-10"}',
+                    "2026-04-10T00:00:00+00:00",
+                ),
+            ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO pages(id, document_id, page_number, text, extractor)
+            VALUES(?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    "page-council-2",
+                    "document-council",
+                    2,
+                    "Council awarded a $250,000 stormwater contract. Work must begin by June 1, 2026.",
+                    "pymupdf",
+                ),
+                (
+                    "page-planning-1",
+                    "document-planning",
+                    1,
+                    "Planning Board reviewed the zoning request.",
+                    "pymupdf",
+                ),
+            ],
+        )
+        connection.commit()
+
+    _create_item(
+        database_path,
+        document_id="document-council",
+        item_id="topic-council-contract",
+        item_type="topic",
+        label="contract",
+        summary="Topic candidate from keyword 'contract'.",
+        confidence=0.60,
+        page_id="page-council-2",
+        page=2,
+        quote="Council awarded a $250,000 stormwater contract.",
+    )
+    _create_item(
+        database_path,
+        document_id="document-planning",
+        item_id="topic-planning-zoning",
+        item_type="topic",
+        label="zoning",
+        summary="Topic candidate from keyword 'zoning'.",
+        confidence=0.60,
+        page_id="page-planning-1",
+        page=1,
+        quote="Planning Board reviewed the zoning request.",
+    )
+    _create_item(
+        database_path,
+        document_id="document-council",
+        item_id="entity-council-vendor",
+        item_type="entity",
+        label="Acme Construction LLC",
+        summary="Entity candidate from capitalized phrase.",
+        confidence=0.55,
+        page_id="page-council-2",
+        page=2,
+        quote="Council awarded a $250,000 stormwater contract.",
+    )
+    _create_item(
+        database_path,
+        document_id="document-planning",
+        item_id="entity-planning-board",
+        item_type="entity",
+        label="Planning Board",
+        summary="Entity candidate from capitalized phrase.",
+        confidence=0.55,
+        page_id="page-planning-1",
+        page=1,
+        quote="Planning Board reviewed the zoning request.",
+    )
+    _create_item(
+        database_path,
+        document_id="document-council",
+        item_id="deadline-council",
+        item_type="deadline",
+        label="June 1, 2026",
+        summary="Deadline-related language appears in document text.",
+        confidence=0.82,
+        page_id="page-council-2",
+        page=2,
+        quote="Work must begin by June 1, 2026.",
+        value={"deadline": "June 1, 2026"},
+    )
+    _create_item(
+        database_path,
+        document_id="document-council",
+        item_id="action-council",
+        item_type="action",
+        label="awarded",
+        summary="Action or vote language appears in document text.",
+        confidence=0.75,
+        page_id="page-council-2",
+        page=2,
+        quote="Council awarded a $250,000 stormwater contract.",
+    )
+    _create_item(
+        database_path,
+        document_id="document-council",
+        item_id="lead-council-contract",
+        item_type="story_lead",
+        label="Follow stormwater contract",
+        summary="The vendor and funding source may merit follow-up reporting.",
+        confidence=0.70,
+        page_id="page-council-2",
+        page=2,
+        quote="Council awarded a $250,000 stormwater contract.",
+    )
+    return database_path
+
+
+def _create_item(
+    database_path: Path,
+    *,
+    document_id: str,
+    item_id: str,
+    item_type: str,
+    label: str,
+    summary: str,
+    confidence: float,
+    page_id: str,
+    page: int,
+    quote: str,
+    value: dict[str, object] | None = None,
+) -> None:
+    create_discovery_item(
+        database_path,
+        document_id=document_id,
+        item_id=item_id,
+        item_type=item_type,
+        label=label,
+        value=value or {},
+        summary=summary,
+        confidence=confidence,
+        extractor="test-extractor",
+        provider="rules",
+        model="rules-v1",
+        evidence=(
+            DiscoveryEvidenceDraft(
+                document_id=document_id,
+                page_id=page_id,
+                page_start=page,
+                page_end=page,
+                quote=quote,
+                validation_status="validated",
+            ),
+        ),
+    )


### PR DESCRIPTION
## Summary

Adds corpus-level browsing commands for discovery records so users can inspect topics, entities, timelines, and story leads without knowing exact search terms.

## Task

#task-36887b88

## Changes

- Added `newsrag.discovery_browse` query/formatting helpers for discovery items joined with document metadata and evidence.
- Added `newsrag topics list/show`, `newsrag entities list/show`, `newsrag timeline`, and `newsrag leads list/show`.
- Supports body, document type, jurisdiction, source URL, since/until, confidence, item type where applicable, limit, and offset filters.
- Shows citations in list output and full evidence quotes in detail output.
- Added tests for commands, filters, empty states, invalid filters, and citation output.

## Testing

- [x] Unit tests added/updated
- [x] Manual smoke testing with `.newsrag` corpus
- [x] `make check`
- [x] `./scripts/pre-pr.sh`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included