### PR TITLE
feat: add Homebrew installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,26 @@ jobs:
 
       - name: Run unit tests
         run: uv run pytest -m "not integration"
+
+  macos-package:
+    name: macOS package
+    runs-on: macos-15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Sync locked dependencies
+        run: uv sync --locked --dev
+
+      - name: Build and smoke test Apple Silicon artifact
+        run: ./scripts/build-macos-artifact.sh
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: newsrag-macos-arm64
+          path: dist/newsrag-*-macos-arm64.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,9 +112,34 @@ jobs:
           name: python-dist
           path: dist/*
 
+  build-macos:
+    name: Build macOS application artifact
+    needs: validate
+    runs-on: macos-15
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.tag }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Sync locked dependencies
+        run: uv sync --locked --dev
+
+      - name: Build and smoke test Apple Silicon artifact
+        run: ./scripts/build-macos-artifact.sh
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-dist
+          path: dist/newsrag-*-macos-arm64.tar.gz
+
   release:
     name: Create GitHub Release
-    needs: [validate, build]
+    needs: [validate, build, build-macos]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -124,10 +149,16 @@ jobs:
         with:
           ref: ${{ needs.validate.outputs.tag }}
 
-      - name: Download package artifacts
+      - name: Download Python package artifacts
         uses: actions/download-artifact@v4
         with:
           name: python-dist
+          path: dist
+
+      - name: Download macOS application artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-dist
           path: dist
 
       - name: Extract changelog

--- a/README.md
+++ b/README.md
@@ -2,44 +2,89 @@
 
 Local-first CLI evidence retrieval tool for city hall PDFs with OCR, hybrid search, and cited Markdown source packets.
 
-## Development prerequisites
-
-NewsRAG uses a local-first stack:
-- SQLite with FTS5 for metadata and keyword search
-- LanceDB for vector search
-- OCRmyPDF, Tesseract, Ghostscript, and qpdf for OCR normalization
-- Ollama with `nomic-embed-text` for local embeddings
-- Overmind for `make dev`
-
-The default development path does not require Docker or `compose.yaml` because SQLite and LanceDB are embedded/local.
-
-For the full macOS setup, installation commands, and validation steps, see [docs/development.md](docs/development.md).
-
 ## Installation
 
-Install the latest version from GitHub:
+NewsRAG's supported macOS installation uses Homebrew on Apple Silicon. The formula installs NewsRAG together with SQLite, OCRmyPDF, Tesseract, Ghostscript, and qpdf:
+
+```bash
+brew install evcraddock/tap/newsrag
+```
+
+The curl installer is a convenience wrapper around the same Homebrew formula:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/evcraddock/newsrag/main/scripts/install.sh | bash
 ```
 
-For development from a checkout:
+NewsRAG installs as a standalone `newsrag` command. Installed usage does not require `uv` or a repository checkout.
+
+### Configure embeddings
+
+Ollama is optional and is not installed with NewsRAG. To use the default local embedding model:
 
 ```bash
-uv sync --dev
+brew install ollama
+brew services start ollama
+ollama pull nomic-embed-text
+mkdir -p ~/.config/newsrag
+cat > ~/.config/newsrag/config.yaml <<'YAML'
+embedding:
+  provider: ollama
+  base_url: http://127.0.0.1:11434
+  model: nomic-embed-text
+YAML
+```
+
+A hosted OpenAI-compatible embedding provider can be configured instead through `~/.config/newsrag/config.yaml`.
+
+### Verify and initialize
+
+```bash
+newsrag --version
+newsrag doctor
+newsrag status --initialize
+```
+
+### Update or uninstall
+
+```bash
+brew update
+brew upgrade newsrag
+
+# Remove NewsRAG while retaining corpus data under ~/.local/share/newsrag
+brew uninstall newsrag
 ```
 
 ## CLI quick start
 
 ```bash
-uv run newsrag --help
-uv run newsrag doctor
-uv run newsrag status --initialize
+newsrag --help
+newsrag doctor
+newsrag status --initialize
 ```
 
-## How to work on this project
+## Development prerequisites
 
-### Start the dev environment
+NewsRAG uses a local-first stack:
+
+- SQLite with FTS5 for metadata and keyword search
+- LanceDB for vector search
+- OCRmyPDF, Tesseract, Ghostscript, and qpdf for OCR normalization
+- Ollama with `nomic-embed-text` for optional local embeddings
+- Overmind for `make dev`
+
+The default development path does not require Docker because SQLite and LanceDB are embedded. For the full macOS development setup and validation steps, see [docs/development.md](docs/development.md).
+
+## Development from a checkout
+
+Development commands use the repository's uv environment and are intentionally different from installed CLI commands:
+
+```bash
+uv sync --dev
+uv run newsrag --help
+```
+
+### Start the development environment
 
 ```bash
 make dev
@@ -47,28 +92,13 @@ make dev
 
 This starts all processes defined in `Procfile.dev`, including the foreground `newsrag daemon run` process managed by Overmind.
 
-### View logs
+### View and manage the development environment
 
 ```bash
-# Stream all logs (Ctrl+C to stop)
 make dev-logs
-
-# Quick peek at recent logs
 make dev-tail
-
-# Attach to one service terminal (default: SERVICE=newsrag)
 make dev-connect
-```
-
-### Check status
-
-```bash
 make dev-status
-```
-
-### Stop the dev environment
-
-```bash
 make dev-stop
 ```
 
@@ -90,9 +120,11 @@ make pre-pr
 make help
 ```
 
-## Environment configuration
+## Configuration
 
-Copy `.env.example` to `.env` and adjust values as needed for your local corpus path, config path, and embedding provider settings.
+Installed NewsRAG reads user configuration from `~/.config/newsrag/config.yaml` by default and stores corpus data under `${XDG_DATA_HOME:-~/.local/share}/newsrag`. Use `--config-path` or `--data-dir` for command-specific overrides.
+
+The repository's `.env.example` is only for development process configuration; it is not the installed CLI configuration file.
 
 ## License
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,8 +7,7 @@ NewsRAG uses a local-first development stack. SQLite and LanceDB are embedded de
 Install the local tools NewsRAG expects on a fresh machine:
 
 ```bash
-brew install uv python@3.11 overmind tmux sqlite ocrmypdf tesseract ghostscript qpdf
-brew install --cask ollama
+brew install uv python@3.11 overmind tmux sqlite ocrmypdf tesseract ghostscript qpdf ollama
 ```
 
 Notes:
@@ -68,6 +67,8 @@ cp .env.example .env
 make check
 ```
 
+Development commands run through `uv run`. An end-user Homebrew installation instead exposes `newsrag` directly and does not require a repository checkout; see the installation section in the [README](../README.md).
+
 ## Development workflow
 
 Start the development environment:
@@ -113,4 +114,4 @@ make check
 
 ## Environment variables
 
-See `.env.example` for the local defaults and optional overrides used by the planned local stack.
+See `.env.example` for development process variables. Installed CLI configuration is YAML at `~/.config/newsrag/config.yaml`; `.env` is not the installed application's configuration file.

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -1,0 +1,64 @@
+# Homebrew packaging
+
+NewsRAG is distributed on Apple Silicon macOS through the `evcraddock/homebrew-tap` repository. The formula installs a self-contained NewsRAG application artifact because LanceDB does not publish a source distribution compatible with Homebrew's standard Python virtual environment helper.
+
+## Packaging model
+
+The upstream release workflow builds `newsrag-<version>-macos-arm64.tar.gz` on GitHub's Apple Silicon macOS runner. The archive contains the NewsRAG executable, Python runtime, and Python dependencies. The Homebrew formula installs that archive under the formula's `libexec` directory and links the `newsrag` executable into Homebrew's `bin` directory.
+
+Native commands invoked by NewsRAG remain formula dependencies:
+
+- SQLite
+- OCRmyPDF
+- Tesseract
+- Ghostscript
+- qpdf
+
+Ollama is optional. The formula must not install Ollama or download an embedding model during installation.
+
+## Build and validate an artifact
+
+Run the packaging script on Apple Silicon macOS:
+
+```bash
+uv sync --locked --dev
+./scripts/build-macos-artifact.sh
+```
+
+The script creates and smoke-tests `dist/newsrag-<version>-macos-arm64.tar.gz`. It verifies both `newsrag --version` and storage initialization before creating the archive.
+
+## Update the formula for a release
+
+After the NewsRAG GitHub release workflow publishes the macOS archive:
+
+1. Download the release artifact and calculate its checksum:
+
+   ```bash
+   curl -LO https://github.com/evcraddock/newsrag/releases/download/v<VERSION>/newsrag-<VERSION>-macos-arm64.tar.gz
+   shasum -a 256 newsrag-<VERSION>-macos-arm64.tar.gz
+   ```
+
+2. In `evcraddock/homebrew-tap`, create a branch and update `Formula/newsrag.rb` with the new immutable release URL and SHA-256 checksum.
+3. Run the local formula checks:
+
+   ```bash
+   brew style --formula evcraddock/tap/newsrag
+   brew audit --strict --online evcraddock/tap/newsrag
+   brew install --build-from-source evcraddock/tap/newsrag
+   brew test evcraddock/tap/newsrag
+   ```
+
+4. Open a pull request in the tap. The tap's formula checks workflow runs style, strict audit, installation, and functional tests on supported macOS runners.
+5. Merge the formula only after both macOS checks pass.
+
+Never point the formula at `main`, a branch archive, or another mutable URL. Formula updates must follow a completed stable NewsRAG release.
+
+## User commands
+
+```bash
+brew install evcraddock/tap/newsrag
+brew upgrade newsrag
+brew uninstall newsrag
+```
+
+Uninstalling the formula does not remove the user's corpus under `~/.local/share/newsrag`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ newsrag = "newsrag.cli:run"
 [dependency-groups]
 dev = [
     "mypy>=1.18.0",
+    "pyinstaller==6.22.2",
     "pytest>=9.0.0",
     "ruff>=0.14.0",
     "types-pyyaml>=6.0.12.20250915",

--- a/scripts/build-macos-artifact.sh
+++ b/scripts/build-macos-artifact.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" || "$(uname -m)" != "arm64" ]]; then
+    echo "The NewsRAG macOS artifact must be built on Apple Silicon." >&2
+    exit 1
+fi
+
+command -v uv >/dev/null 2>&1 || {
+    echo "Missing required command: uv" >&2
+    exit 1
+}
+
+version="$(uv run python -c 'from newsrag import __version__; print(__version__)')"
+build_root="build/pyinstaller-macos-arm64"
+bundle_root="dist/macos-arm64"
+bundle_dir="$bundle_root/newsrag"
+artifact="dist/newsrag-${version}-macos-arm64.tar.gz"
+
+rm -rf "$build_root" "$bundle_root" "$artifact"
+
+uv run pyinstaller \
+    --noconfirm \
+    --clean \
+    --onedir \
+    --name newsrag \
+    --distpath "$bundle_root" \
+    --workpath "$build_root" \
+    --specpath "$build_root" \
+    --collect-binaries lancedb \
+    --collect-data lancedb \
+    scripts/newsrag_pyinstaller_entrypoint.py
+
+"$bundle_dir/newsrag" --version
+smoke_root="$(mktemp -d)"
+trap 'rm -rf "$smoke_root"' EXIT
+smoke_data_dir="$smoke_root/data"
+"$bundle_dir/newsrag" --data-dir "$smoke_data_dir" status --initialize >/dev/null
+test -f "$smoke_data_dir/newsrag.sqlite3"
+
+/usr/bin/tar -czf "$artifact" -C "$bundle_dir" .
+shasum -a 256 "$artifact"
+echo "Built $artifact"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,56 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_URL="${NEWSRAG_REPO_URL:-https://github.com/evcraddock/newsrag.git}"
-CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
-INSTALL_DIR="${NEWSRAG_INSTALL_DIR:-$CACHE_HOME/newsrag/source}"
-REF="${NEWSRAG_REF:-main}"
+FORMULA="${NEWSRAG_HOMEBREW_FORMULA:-evcraddock/tap/newsrag}"
 
-log() { printf '%s\n' "$*"; }
-die() { printf 'Error: %s\n' "$*" >&2; exit 1; }
-require_command() {
-    command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
-}
-
-require_command git
-require_command uv
-
-source_dir=""
-script_path="${BASH_SOURCE[0]-}"
-if [[ -n "$script_path" && -f "$script_path" ]]; then
-    candidate_dir="$(cd "$(dirname "$script_path")/.." && pwd)"
-    if [[ -f "$candidate_dir/pyproject.toml" && -d "$candidate_dir/newsrag" ]]; then
-        source_dir="$candidate_dir"
-    fi
+if ! command -v brew >/dev/null 2>&1; then
+    printf '%s\n' "Error: Homebrew is required to install NewsRAG on macOS." >&2
+    printf '%s\n' "Install Homebrew from https://brew.sh and rerun this command." >&2
+    exit 1
 fi
 
-if [[ -n "$source_dir" ]]; then
-    log "Installing NewsRAG from source at $source_dir"
-else
-    if [[ -d "$INSTALL_DIR/.git" ]]; then
-        log "Updating NewsRAG checkout at $INSTALL_DIR"
-        git -C "$INSTALL_DIR" fetch --tags origin
-    else
-        if [[ -e "$INSTALL_DIR" ]]; then
-            die "$INSTALL_DIR exists but is not a git checkout. Move it aside or set NEWSRAG_INSTALL_DIR."
-        fi
-        log "Cloning NewsRAG into $INSTALL_DIR"
-        mkdir -p "$(dirname "$INSTALL_DIR")"
-        git clone "$REPO_URL" "$INSTALL_DIR"
-    fi
-
-    git -C "$INSTALL_DIR" checkout "$REF"
-    git -C "$INSTALL_DIR" pull --ff-only origin "$REF" 2>/dev/null || true
-    source_dir="$INSTALL_DIR"
-fi
-
-log "Installing NewsRAG with uv"
-uv tool install --force "$source_dir"
-
-if command -v newsrag >/dev/null 2>&1; then
-    log "Installed $(newsrag --version 2>/dev/null || printf 'newsrag')"
-else
-    log "Installed newsrag. Ensure uv's tool bin directory is on PATH."
-fi
-
-log "Done. Try: newsrag --help"
+printf '%s\n' "Installing NewsRAG with Homebrew"
+brew install "$FORMULA"
+printf '%s\n' "Installed NewsRAG. Run: newsrag doctor"

--- a/scripts/newsrag_pyinstaller_entrypoint.py
+++ b/scripts/newsrag_pyinstaller_entrypoint.py
@@ -1,0 +1,4 @@
+from newsrag.cli import run
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -5,52 +5,26 @@ import subprocess
 from pathlib import Path
 
 
-def test_install_script_runs_when_piped_to_bash(tmp_path: Path) -> None:
+def test_install_script_uses_homebrew_formula_when_piped_to_bash(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
+    invocation_path = tmp_path / "brew-invocation"
 
-    git = bin_dir / "git"
-    git.write_text(
+    brew = bin_dir / "brew"
+    brew.write_text(
         """#!/usr/bin/env bash
 set -eu
-if [[ "${1:-}" == "clone" ]]; then
-    mkdir -p "$3/.git"
-    exit 0
-fi
-if [[ "${1:-}" == "-C" ]]; then
-    case "${3:-}" in
-        fetch|checkout|pull) exit 0 ;;
-    esac
-fi
-echo "unexpected git invocation: $*" >&2
-exit 1
+printf '%s\n' "$*" > "$BREW_INVOCATION_PATH"
 """,
         encoding="utf-8",
     )
-    git.chmod(0o755)
-
-    uv = bin_dir / "uv"
-    uv.write_text(
-        """#!/usr/bin/env bash
-set -eu
-if [[ "${1:-}" == "tool" && "${2:-}" == "install" ]]; then
-    exit 0
-fi
-echo "unexpected uv invocation: $*" >&2
-exit 1
-""",
-        encoding="utf-8",
-    )
-    uv.chmod(0o755)
+    brew.chmod(0o755)
 
     env = os.environ.copy()
-    cache_home = tmp_path / "cache"
-    checkout = cache_home / "newsrag" / "source"
     env.update(
         {
-            "HOME": str(tmp_path / "home"),
-            "XDG_CACHE_HOME": str(cache_home),
-            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "BREW_INVOCATION_PATH": str(invocation_path),
+            "PATH": f"{bin_dir}{os.pathsep}/usr/bin{os.pathsep}/bin",
         }
     )
 
@@ -65,6 +39,23 @@ exit 1
     )
 
     assert result.returncode == 0, result.stderr
-    assert f"Cloning NewsRAG into {checkout}" in result.stdout
-    assert "Installing NewsRAG with uv" in result.stdout
-    assert (checkout / ".git").is_dir()
+    assert "Installing NewsRAG with Homebrew" in result.stdout
+    assert invocation_path.read_text(encoding="utf-8").strip() == ("install evcraddock/tap/newsrag")
+
+
+def test_install_script_reports_missing_homebrew(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env["PATH"] = str(tmp_path)
+
+    script = Path("scripts/install.sh").read_text(encoding="utf-8")
+    result = subprocess.run(
+        ["/bin/bash"],
+        input=script,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Homebrew is required" in result.stderr

--- a/tests/test_macos_artifact.py
+++ b/tests/test_macos_artifact.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tarfile
+from pathlib import Path
+
+
+def test_macos_artifact_script_builds_versioned_archive(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    uname = bin_dir / "uname"
+    uname.write_text(
+        """#!/usr/bin/env bash
+if [[ "$1" == "-s" ]]; then
+    echo Darwin
+else
+    echo arm64
+fi
+""",
+        encoding="utf-8",
+    )
+    uname.chmod(0o755)
+
+    uv = bin_dir / "uv"
+    uv.write_text(
+        """#!/usr/bin/env bash
+set -eu
+if [[ "$1" == "run" && "$2" == "python" ]]; then
+    echo 9.8.7
+    exit 0
+fi
+if [[ "$1" == "run" && "$2" == "pyinstaller" ]]; then
+    mkdir -p dist/macos-arm64/newsrag
+    cat > dist/macos-arm64/newsrag/newsrag <<'SCRIPT'
+#!/usr/bin/env bash
+set -eu
+if [[ "${1:-}" == "--version" ]]; then
+    echo "newsrag 9.8.7"
+    exit 0
+fi
+while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--data-dir" ]]; then
+        mkdir -p "$2"
+        touch "$2/newsrag.sqlite3"
+        exit 0
+    fi
+    shift
+done
+exit 1
+SCRIPT
+    chmod +x dist/macos-arm64/newsrag/newsrag
+    exit 0
+fi
+echo "unexpected uv invocation: $*" >&2
+exit 1
+""",
+        encoding="utf-8",
+    )
+    uv.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}/usr/bin{os.pathsep}/bin"
+    script = Path("scripts/build-macos-artifact.sh").resolve()
+    result = subprocess.run(
+        ["/bin/bash", str(script)],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    artifact = tmp_path / "dist/newsrag-9.8.7-macos-arm64.tar.gz"
+    assert artifact.is_file()
+    with tarfile.open(artifact) as archive:
+        assert "./newsrag" in archive.getnames()
+
+
+def test_ci_builds_macos_artifact() -> None:
+    workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    assert "macos-package:" in workflow
+    assert "runs-on: macos-15" in workflow
+    assert "./scripts/build-macos-artifact.sh" in workflow
+    assert "dist/newsrag-*-macos-arm64.tar.gz" in workflow
+
+
+def test_release_workflow_publishes_macos_artifact() -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+
+    assert "build-macos:" in workflow
+    assert "runs-on: macos-15" in workflow
+    assert "./scripts/build-macos-artifact.sh" in workflow
+    assert "dist/newsrag-*-macos-arm64.tar.gz" in workflow
+    assert "needs: [validate, build, build-macos]" in workflow
+
+
+def test_macos_artifact_script_rejects_unsupported_platform(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    uname = bin_dir / "uname"
+    uname.write_text("#!/usr/bin/env bash\necho Linux\n", encoding="utf-8")
+    uname.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}/usr/bin{os.pathsep}/bin"
+    result = subprocess.run(
+        ["/bin/bash", "scripts/build-macos-artifact.sh"],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "must be built on Apple Silicon" in result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,15 @@ wheels = [
 ]
 
 [[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -485,6 +494,18 @@ wheels = [
 ]
 
 [[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -582,6 +603,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pyinstaller" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "types-pyyaml" },
@@ -602,6 +624,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.18.0" },
+    { name = "pyinstaller", specifier = "==6.22.2" },
     { name = "pytest", specifier = ">=9.0.0" },
     { name = "ruff", specifier = ">=0.14.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
@@ -738,6 +761,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/37/9ca3519e92a8434eb93be570b131476cc0a4e840bb39c62ddb7813a39d53/pdfplumber-0.11.9.tar.gz", hash = "sha256:481224b678b2bbdbf376e2c39bf914144eef7c3d301b4a28eebf0f7f6109d6dc", size = 102768, upload-time = "2026-01-05T08:10:29.072Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/c8/cdbc975f5b634e249cfa6597e37c50f3078412474f21c015e508bfbfe3c3/pdfplumber-0.11.9-py3-none-any.whl", hash = "sha256:33ec5580959ba524e9100138746e090879504c42955df1b8a997604dd326c443", size = 60045, upload-time = "2026-01-05T08:10:27.512Z" },
+]
+
+[[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
 ]
 
 [[package]]
@@ -1022,6 +1054,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pyinstaller"
+version = "6.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/2b/836d9def811c02522e0921d8b8cdf0c16b0545a216e97e71041758057859/pyinstaller-6.22.2.tar.gz", hash = "sha256:89b65a3ad07d9dd5832253e37bc45f31872d10d7f9d5c9fd0fdd6088a83829dd", size = 4092631, upload-time = "2026-08-17T20:53:22.231Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/39/08cd53632276de70426e7c273820277a48253fee397b4048301ec03c3566/pyinstaller-6.22.2-py3-none-macosx_10_13_universal2.whl", hash = "sha256:ebd1b1ca932d7cf25d7366ce691aaf79a5ff9425811ed7328b5116e4471b6d6d", size = 1062734, upload-time = "2026-08-17T20:52:17.635Z" },
+    { url = "https://files.pythonhosted.org/packages/74/22/2d865896782cbb41e2388c7314207c17a98acdcc1b8e5eef668873505c9f/pyinstaller-6.22.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:f5ccb847451df4207bce18bf53a57b124c9bb4e7e4bad08c5ecc627bcf00b28c", size = 755697, upload-time = "2026-08-17T20:52:21.676Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2b/6c11e4d5a76e716ea68da1946ab706a4bdf6d8e68b0e1dea314366d046a0/pyinstaller-6.22.2-py3-none-manylinux2014_i686.whl", hash = "sha256:becb47ad78272bede87acf2ed830d7545a8f65ab11d06a68fe2b99ba1afaac6d", size = 768870, upload-time = "2026-08-17T20:52:25.511Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e2/dbfea6a58b68acf644f7193b11d570476d6ffaed57381b6d1dd9e898a971/pyinstaller-6.22.2-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:06d7b3827a8049db4a2d47e3ec4ae2f69a1041577d8833b8f169745cde573ab4", size = 767445, upload-time = "2026-08-17T20:52:29.629Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/db/f24a21af2f87ce1df4e07fdad95eec65ef9f284267a7c1e5eeea40f49aa4/pyinstaller-6.22.2-py3-none-manylinux2014_s390x.whl", hash = "sha256:7bee432404eca5dc3ef37c36811c266561b03988f6d3e70ab0fa5352dd5de9e4", size = 762113, upload-time = "2026-08-17T20:52:34.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/07/b304ff3f5f8333778065e3658b604b0e108cd934b920f3fbab825a0dd5b7/pyinstaller-6.22.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:9622686ecc5d5fa492fe6cde29d47df9dd41138cff8177be9f901ca3260f2096", size = 762173, upload-time = "2026-08-17T20:52:38.477Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/9b/0af69d93dfad2e3d590a5de5828d5bcd903747c0224bd9560ab476904dfe/pyinstaller-6.22.2-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:0260eaad6be3f6fbc1affffe6dc7b8e5b636dbca51b463224daba971610b6fc1", size = 761674, upload-time = "2026-08-17T20:52:42.646Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/4e/28b6094dcbd1e1bbb868daf4f8752999a20c1020ab64569232be42af2be8/pyinstaller-6.22.2-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:8c2c4b14caad38c1f3df8e9bf5276fc265e27fe8b4180cab4a37864288427bc0", size = 761053, upload-time = "2026-08-17T20:52:46.594Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/2c/f91b63fd01422111ac04e3b9bf61c039da5a3292acb4fe5248905f0be688/pyinstaller-6.22.2-py3-none-win32.whl", hash = "sha256:9a078877caa3920558a3242d0a7019fe5b825cff4b65ed380c7d1e1bd200ddd9", size = 1344474, upload-time = "2026-08-17T20:52:53.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/53/8ba1d0f6159b490f700eac6161a4be5f0d4672608a6dae9fd73679f183ee/pyinstaller-6.22.2-py3-none-win_amd64.whl", hash = "sha256:9b990fa6bbe143572f06644a984ad0d7aa2e2ccc6929d4916031343a5888e9a7", size = 1405725, upload-time = "2026-08-17T20:52:59.667Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/9a3062cc34c939f694d4262c4754681f6ffe853c21c124209ad2d08b8e84/pyinstaller-6.22.2-py3-none-win_arm64.whl", hash = "sha256:afb6f9a95d19b6dcd3a7decc40d9adb6ba9c4f8802ddd6c972dfb552953f384e", size = 1353806, upload-time = "2026-08-17T20:53:06.222Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/60/d881fa1ba8c160c18d8e6f782bb16ec4640c08bc08fc50f704c368ad4f9e/pyinstaller_hooks_contrib-2026.7.tar.gz", hash = "sha256:5fbcaacb22c4f4aac869a127dce283f67a4b4cfcc37d496f2446603e6d68aefa", size = 175992, upload-time = "2026-08-24T21:26:58.713Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/67/350377af7b50416344ab8792756d414eef7629c618a73e9a0b13bb1552d9/pyinstaller_hooks_contrib-2026.7-py3-none-any.whl", hash = "sha256:24257a04c7a5a7a034cf28e39dcee20fbeeb9f043076729480f2e1b69904408a", size = 459445, upload-time = "2026-08-24T21:26:57.274Z" },
+]
+
+[[package]]
 name = "pymupdf"
 version = "1.27.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1092,6 +1164,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -1185,6 +1266,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "84.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- build a self-contained Apple Silicon NewsRAG release artifact for Homebrew
- make Homebrew the supported macOS installation and retain curl as a wrapper
- document optional Ollama configuration and formula release maintenance
- publish the companion formula through evcraddock/homebrew-tap#2

## Why

LanceDB does not publish a source distribution, so Homebrew's standard Python virtual environment formula cannot package NewsRAG from source. The release artifact bundles the Python runtime and Python dependencies while the formula remains responsible for native OCR dependencies.

## Homebrew formula

- Companion PR: https://github.com/evcraddock/homebrew-tap/pull/2
- Immutable artifact: `newsrag-0.3.0-macos-arm64.tar.gz` on the v0.3.0 GitHub release
- Formula CI: macOS 15 and macOS 26 passed
- Local verification: style, strict audit, install, `brew test`, direct `newsrag --version`, and temporary storage initialization passed

## Verification

- `./scripts/build-macos-artifact.sh`
- `./scripts/pre-pr.sh`
- 125 tests passed
- NewsRAG CI and macOS package jobs passed

Task: `task-35ea8ae3`
