### PR TITLE
Unify embeddings on the OpenAI-compatible API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,18 +5,9 @@
 NEWSRAG_DATA_DIR=.newsrag
 NEWSRAG_CONFIG_PATH=${HOME}/.config/newsrag/config.yaml
 
-# Embedding provider selection
-# Supported planned values: ollama (default), openai
-NEWSRAG_EMBEDDING_PROVIDER=ollama
-
-# Ollama local embedding settings
-NEWSRAG_OLLAMA_HOST=http://127.0.0.1:11434
-NEWSRAG_OLLAMA_MODEL=nomic-embed-text
-
-# Optional hosted provider overrides
+# Embeddings are configured in ~/.config/newsrag/config.yaml.
+# Hosted services can read a bearer token from the configured environment variable.
 OPENAI_API_KEY=
-NEWSRAG_OPENAI_BASE_URL=
-NEWSRAG_OPENAI_EMBEDDING_MODEL=text-embedding-3-small
 
 # OCR defaults
 NEWSRAG_OCR_LANGUAGE=eng

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [Unreleased]
+
+### Changed
+- Replaced the native Ollama embedding integration with one OpenAI-compatible `/v1/embeddings` provider for llama.cpp, LM Studio, Ollama, OpenAI, and other compatible services.
+- Require explicit embedding provider, base URL, and model configuration before ingestion or vector search.
+
 ## [0.3.0] - 2026-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,22 +20,21 @@ NewsRAG installs as a standalone `newsrag` command. Installed usage does not req
 
 ### Configure embeddings
 
-Ollama is optional and is not installed with NewsRAG. To use the default local embedding model:
+NewsRAG uses one OpenAI-compatible embedding API for local and hosted services. An embedding provider must be configured explicitly before ingestion or vector search.
+
+For a local llama.cpp server exposing Nomic Embed Text v1.5:
 
 ```bash
-brew install ollama
-brew services start ollama
-ollama pull nomic-embed-text
 mkdir -p ~/.config/newsrag
 cat > ~/.config/newsrag/config.yaml <<'YAML'
 embedding:
-  provider: ollama
-  base_url: http://127.0.0.1:11434
-  model: nomic-embed-text
+  provider: openai_compatible
+  base_url: http://127.0.0.1:8080/v1
+  model: nomic-embed-text-v1.5
 YAML
 ```
 
-A hosted OpenAI-compatible embedding provider can be configured instead through `~/.config/newsrag/config.yaml`.
+NewsRAG also supports LM Studio, Ollama's `/v1` API, OpenAI, and other compatible services through the same provider. See [Embedding configuration](docs/embeddings.md) for server examples, hosted authentication, and migration instructions.
 
 ### Verify and initialize
 
@@ -70,7 +69,7 @@ NewsRAG uses a local-first stack:
 - SQLite with FTS5 for metadata and keyword search
 - LanceDB for vector search
 - OCRmyPDF, Tesseract, Ghostscript, and qpdf for OCR normalization
-- Ollama with `nomic-embed-text` for optional local embeddings
+- Any OpenAI-compatible `/v1/embeddings` service for local or hosted embeddings
 - Overmind for `make dev`
 
 The default development path does not require Docker because SQLite and LanceDB are embedded. For the full macOS development setup and validation steps, see [docs/development.md](docs/development.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,9 +103,9 @@ Search filters should use user-supplied civic metadata, including body, document
 
 ## Embeddings
 
-Embeddings are pluggable. The MVP is local-first and defaults to Ollama running `nomic-embed-text`. The architecture also supports `bge-base-en` as a local model option and OpenAI `text-embedding-3-small` as an optional hosted provider.
+Embeddings use one OpenAI-compatible `/v1/embeddings` integration. The configured service can be local, such as llama.cpp, LM Studio, or Ollama's compatible API, or hosted, such as OpenAI. NewsRAG has no implicit embedding provider because the base URL and model must be selected explicitly.
 
-Every embedding record should retain provider, model, and version information. This allows safe index rebuilds when the embedding model changes. `newsrag doctor` checks embedding provider availability, including whether Ollama is reachable and whether the configured model is installed or pullable.
+Every embedding record retains provider, model, and version information. This allows safe index rebuilds when the embedding model changes. `newsrag doctor` checks the configured `/v1/models` endpoint, optional API-key environment variable, and model availability without exposing secret values.
 
 ## Daemon and jobs
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,27 +7,15 @@ NewsRAG uses a local-first development stack. SQLite and LanceDB are embedded de
 Install the local tools NewsRAG expects on a fresh machine:
 
 ```bash
-brew install uv python@3.11 overmind tmux sqlite ocrmypdf tesseract ghostscript qpdf ollama
+brew install uv python@3.11 overmind tmux sqlite ocrmypdf tesseract ghostscript qpdf
 ```
 
 Notes:
 - Overmind uses tmux under the hood, so install both.
 - SQLite must include FTS5 support. The validation command below checks the Python runtime that NewsRAG will use.
-- Ollama must be running before local embedding checks will pass.
+- The test suite mocks embedding requests, so development checks do not require a running embedding service.
 
-Pull the default local embedding model:
-
-```bash
-ollama pull nomic-embed-text
-```
-
-If Ollama is not already running, start it with one of:
-
-```bash
-brew services start ollama
-# or
-ollama serve
-```
+For manual ingestion and vector-search testing, configure any OpenAI-compatible embedding service. See [Embedding configuration](embeddings.md) for llama.cpp, LM Studio, Ollama, and hosted OpenAI examples.
 
 ## Validate local prerequisites
 
@@ -42,8 +30,6 @@ ocrmypdf --version
 tesseract --version
 gs --version
 qpdf --version
-ollama --version
-ollama list | grep nomic-embed-text
 ```
 
 Validate SQLite FTS5 support through Python:

--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -1,0 +1,109 @@
+# Embedding configuration
+
+NewsRAG has one embedding integration: the OpenAI-compatible `/v1/embeddings` API. Local and hosted services use the same `openai_compatible` provider configuration.
+
+NewsRAG requires `embedding.provider`, `embedding.base_url`, and `embedding.model`. Set `embedding.api_key_env` when the service requires bearer authentication. NewsRAG reads the named environment variable at request time and never stores its value.
+
+Changing the embedding model changes the vector space. Do not mix vectors from different models in one corpus; use a separate data directory or rebuild the corpus embeddings when changing models.
+
+## llama.cpp
+
+For local Apple Silicon use, the recommended model is Nomic Embed Text v1.5 in GGUF format. Run an embedding-specific `llama-server` on localhost and give the model a stable API alias:
+
+```bash
+llama-server \
+  --model /path/to/nomic-embed-text-v1.5.f16.gguf \
+  --alias nomic-embed-text-v1.5 \
+  --embedding \
+  --pooling mean \
+  --host 127.0.0.1 \
+  --port 8080
+```
+
+Configure NewsRAG in `~/.config/newsrag/config.yaml`:
+
+```yaml
+embedding:
+  provider: openai_compatible
+  base_url: http://127.0.0.1:8080/v1
+  model: nomic-embed-text-v1.5
+```
+
+The llama.cpp executable, model file, and server lifecycle are managed separately from NewsRAG.
+
+## LM Studio
+
+Load an embedding model in LM Studio, start its local server, and use the model identifier returned by `GET /v1/models`:
+
+```yaml
+embedding:
+  provider: openai_compatible
+  base_url: http://127.0.0.1:1234/v1
+  model: your-loaded-embedding-model-id
+```
+
+## Ollama
+
+Ollama remains usable through its OpenAI-compatible API. Install and start Ollama separately, pull the desired model, and include `/v1` in the base URL:
+
+```bash
+ollama pull nomic-embed-text
+```
+
+```yaml
+embedding:
+  provider: openai_compatible
+  base_url: http://127.0.0.1:11434/v1
+  model: nomic-embed-text
+```
+
+NewsRAG does not use Ollama's native `/api/embed` endpoint.
+
+## Hosted OpenAI
+
+Export the API key without writing its value to NewsRAG configuration:
+
+```bash
+export OPENAI_API_KEY='your-api-key'
+```
+
+```yaml
+embedding:
+  provider: openai_compatible
+  base_url: https://api.openai.com/v1
+  model: text-embedding-3-small
+  api_key_env: OPENAI_API_KEY
+```
+
+The same pattern works for other hosted OpenAI-compatible services. Set `base_url`, `model`, and `api_key_env` to the values required by that service.
+
+## Verify the configuration
+
+Run:
+
+```bash
+newsrag doctor
+```
+
+The embedding check calls the configured service's `/v1/models` endpoint and confirms that the configured model is listed. Missing settings, unavailable services, missing API-key environment variables, malformed responses, and unavailable models produce actionable warnings or errors.
+
+You can also test a service directly:
+
+```bash
+curl http://127.0.0.1:8080/v1/embeddings \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"nomic-embed-text-v1.5","input":["city council agenda"]}'
+```
+
+## Migrate from the native Ollama provider
+
+The old configuration used `provider: ollama`, a base URL without `/v1`, and Ollama's native `/api/embed` endpoint. Replace it as follows:
+
+```yaml
+embedding:
+  provider: openai_compatible
+  base_url: http://127.0.0.1:11434/v1
+  model: nomic-embed-text
+```
+
+NewsRAG rejects `provider: ollama` with this migration guidance rather than silently changing endpoint behavior.

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -14,7 +14,7 @@ Native commands invoked by NewsRAG remain formula dependencies:
 - Ghostscript
 - qpdf
 
-Ollama is optional. The formula must not install Ollama or download an embedding model during installation.
+Embedding services are optional external runtimes. The formula must not install llama.cpp, LM Studio, Ollama, or an embedding model during installation; users configure any OpenAI-compatible service separately.
 
 ## Build and validate an artifact
 

--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -236,19 +236,24 @@ def daemon_run(
     import asyncio
 
     from newsrag.daemon import DaemonConfig, run_daemon
+    from newsrag.embeddings import EmbeddingError
 
     settings, _ = _resolve_runtime_settings(ctx)
     typer.echo(f"NewsRAG daemon running for {settings.data_dir}")
-    asyncio.run(
-        run_daemon(
-            DaemonConfig(
-                data_dir=settings.data_dir,
-                embedding_config=settings.config.embedding,
-                poll_interval=poll_interval,
-                max_loops=max_loops,
+    try:
+        asyncio.run(
+            run_daemon(
+                DaemonConfig(
+                    data_dir=settings.data_dir,
+                    embedding_config=settings.config.embedding,
+                    poll_interval=poll_interval,
+                    max_loops=max_loops,
+                )
             )
         )
-    )
+    except EmbeddingError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
 
 
 @app.command("ingest")
@@ -443,6 +448,7 @@ def search_command(
     )
 
     try:
+        filters.validate()
         engine = build_search_engine(
             database_path=storage_paths.database,
             lancedb_path=storage_paths.lancedb,
@@ -510,6 +516,7 @@ def packet_command(
     )
 
     try:
+        filters.validate()
         engine = build_search_engine(
             database_path=storage_paths.database,
             lancedb_path=storage_paths.lancedb,

--- a/newsrag/daemon.py
+++ b/newsrag/daemon.py
@@ -86,13 +86,12 @@ async def run_daemon(
     """Start the foreground daemon loop."""
 
     storage_paths = initialize_storage(config.data_dir)
-    resolved_handlers: dict[str, JobHandler] = {
-        INGEST_JOB_KIND: build_ingest_handler(
+    resolved_handlers = dict(handlers or {})
+    if INGEST_JOB_KIND not in resolved_handlers:
+        resolved_handlers[INGEST_JOB_KIND] = build_ingest_handler(
             data_dir=config.data_dir,
             embedding_config=config.embedding_config,
         )
-    }
-    resolved_handlers.update(handlers or {})
 
     runner = DaemonRunner(
         database_path=storage_paths.database,

--- a/newsrag/doctor.py
+++ b/newsrag/doctor.py
@@ -12,9 +12,7 @@ import httpx
 from newsrag.config import EmbeddingConfig, RuntimeSettings
 from newsrag.storage import build_storage_paths
 
-DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434"
-DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
-DEFAULT_OPENAI_API_KEY_ENV = "OPENAI_API_KEY"
+EMBEDDING_PROVIDER_OPENAI_COMPATIBLE = "openai_compatible"
 
 
 @dataclass(frozen=True)
@@ -122,50 +120,29 @@ def _binary_check(name: str, command: str) -> DoctorCheck:
 def _embedding_check(embedding: EmbeddingConfig, *, timeout_seconds: float) -> DoctorCheck:
     provider = embedding.provider
     if provider is None:
-        return DoctorCheck("embedding", "warn", "no embedding provider configured")
-
-    normalized_provider = provider.lower()
-    if normalized_provider == "ollama":
-        return _ollama_check(embedding, timeout_seconds=timeout_seconds)
-    if normalized_provider in {"openai", "openai_compatible"}:
-        return _openai_compatible_check(embedding, timeout_seconds=timeout_seconds)
-    return DoctorCheck("embedding", "error", f"unsupported provider '{provider}'")
-
-
-def _ollama_check(embedding: EmbeddingConfig, *, timeout_seconds: float) -> DoctorCheck:
-    if embedding.model is None:
         return DoctorCheck(
             "embedding",
             "warn",
-            "provider=ollama is configured but embedding.model is missing",
+            "no embedding provider configured; set embedding.provider=openai_compatible",
         )
 
-    base_url = embedding.base_url or DEFAULT_OLLAMA_BASE_URL
-    endpoint = f"{base_url.rstrip('/')}/api/tags"
-    payload = _json_get(
-        endpoint,
-        provider_label="ollama",
-        timeout_seconds=timeout_seconds,
-    )
-    if isinstance(payload, DoctorCheck):
-        return payload
-
-    model_names = _extract_ollama_model_names(payload)
-    if _model_available(embedding.model, model_names):
+    normalized_provider = provider.lower()
+    if normalized_provider == "ollama":
         return DoctorCheck(
             "embedding",
-            "ok",
-            f"provider=ollama base_url={base_url} model={embedding.model} is available",
+            "error",
+            (
+                "the native Ollama provider was removed; set provider=openai_compatible and "
+                "base_url=http://127.0.0.1:11434/v1"
+            ),
         )
-
-    return DoctorCheck(
-        "embedding",
-        "warn",
-        (
-            f"provider=ollama base_url={base_url} is reachable but model={embedding.model} "
-            f"is not installed; run 'ollama pull {embedding.model}'"
-        ),
-    )
+    if normalized_provider != EMBEDDING_PROVIDER_OPENAI_COMPATIBLE:
+        return DoctorCheck(
+            "embedding",
+            "error",
+            f"unsupported provider '{provider}'; use openai_compatible",
+        )
+    return _openai_compatible_check(embedding, timeout_seconds=timeout_seconds)
 
 
 def _openai_compatible_check(
@@ -173,7 +150,7 @@ def _openai_compatible_check(
     *,
     timeout_seconds: float,
 ) -> DoctorCheck:
-    provider = embedding.provider or "openai_compatible"
+    provider = EMBEDDING_PROVIDER_OPENAI_COMPATIBLE
     if embedding.model is None:
         return DoctorCheck(
             "embedding",
@@ -181,25 +158,18 @@ def _openai_compatible_check(
             f"provider={provider} is configured but embedding.model is missing",
         )
 
-    api_key_env = embedding.api_key_env
-    if provider.lower() == "openai" and api_key_env is None:
-        api_key_env = DEFAULT_OPENAI_API_KEY_ENV
-
     headers: dict[str, str] = {}
-    if api_key_env is not None:
-        api_key = os.getenv(api_key_env)
+    if embedding.api_key_env is not None:
+        api_key = os.getenv(embedding.api_key_env)
         if not api_key:
             return DoctorCheck(
                 "embedding",
                 "warn",
-                f"provider={provider} expects environment variable {api_key_env}",
+                f"provider={provider} expects environment variable {embedding.api_key_env}",
             )
         headers["Authorization"] = f"Bearer {api_key}"
 
     base_url = embedding.base_url
-    if provider.lower() == "openai" and base_url is None:
-        base_url = DEFAULT_OPENAI_BASE_URL
-
     if base_url is None:
         return DoctorCheck(
             "embedding",
@@ -218,7 +188,13 @@ def _openai_compatible_check(
         return payload
 
     model_names = _extract_openai_compatible_model_names(payload)
-    if model_names and not _model_available(embedding.model, model_names):
+    if model_names is None:
+        return DoctorCheck(
+            "embedding",
+            "warn",
+            f"provider={provider} endpoint {endpoint} returned an unexpected models payload",
+        )
+    if not _model_available(embedding.model, model_names):
         return DoctorCheck(
             "embedding",
             "warn",
@@ -325,24 +301,10 @@ def _nearest_existing_parent(path: Path) -> Path | None:
     return current
 
 
-def _extract_ollama_model_names(payload: dict[str, Any]) -> set[str]:
-    models = payload.get("models")
-    if not isinstance(models, list):
-        return set()
-
-    names: set[str] = set()
-    for model in models:
-        if isinstance(model, dict):
-            name = model.get("name")
-            if isinstance(name, str):
-                names.add(name)
-    return names
-
-
-def _extract_openai_compatible_model_names(payload: dict[str, Any]) -> set[str]:
+def _extract_openai_compatible_model_names(payload: dict[str, Any]) -> set[str] | None:
     data = payload.get("data")
     if not isinstance(data, list):
-        return set()
+        return None
 
     names: set[str] = set()
     for model in data:

--- a/newsrag/embeddings.py
+++ b/newsrag/embeddings.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+import os
 import sqlite3
 import uuid
 from collections.abc import Sequence
@@ -11,9 +13,9 @@ import httpx
 
 from newsrag.config import EmbeddingConfig
 
-DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434"
-DEFAULT_OLLAMA_MODEL = "nomic-embed-text"
-EMBEDDING_PROVIDER_OLLAMA = "ollama"
+EMBEDDING_PROVIDER_OPENAI_COMPATIBLE = "openai_compatible"
+DEFAULT_EMBEDDING_BATCH_SIZE = 64
+DEFAULT_EMBEDDING_TIMEOUT_SECONDS = 30.0
 
 
 class EmbeddingError(Exception):
@@ -58,25 +60,30 @@ class EmbeddingProvider(Protocol):
 
 
 @dataclass(frozen=True)
-class OllamaEmbeddingProvider:
-    """Embedding provider backed by the Ollama HTTP API."""
+class OpenAICompatibleEmbeddingProvider:
+    """Embedding provider backed by the OpenAI-compatible embeddings API."""
 
-    model: str = DEFAULT_OLLAMA_MODEL
-    base_url: str = DEFAULT_OLLAMA_BASE_URL
+    base_url: str
+    model: str
+    api_key_env: str | None = None
+    batch_size: int = DEFAULT_EMBEDDING_BATCH_SIZE
+    timeout_seconds: float = DEFAULT_EMBEDDING_TIMEOUT_SECONDS
+
+    def __post_init__(self) -> None:
+        if self.batch_size < 1:
+            raise EmbeddingError("Embedding batch size must be at least 1")
 
     @property
     def metadata(self) -> EmbeddingMetadata:
         model_name, version = _split_model_identity(self.model)
         return EmbeddingMetadata(
-            provider=EMBEDDING_PROVIDER_OLLAMA,
+            provider=EMBEDDING_PROVIDER_OPENAI_COMPATIBLE,
             model=model_name,
             version=version,
         )
 
     def embed_query(self, text: str) -> QueryEmbedding:
         vectors = self._embed_inputs([text])
-        if len(vectors) != 1:
-            raise EmbeddingError(f"Ollama returned {len(vectors)} vectors for 1 query")
         return QueryEmbedding(text=text, vector=vectors[0], metadata=self.metadata)
 
     def embed_chunks(self, texts: Sequence[str]) -> list[ChunkEmbedding]:
@@ -85,11 +92,6 @@ class OllamaEmbeddingProvider:
             return []
 
         vectors = self._embed_inputs(resolved_texts)
-        if len(vectors) != len(resolved_texts):
-            raise EmbeddingError(
-                f"Ollama returned {len(vectors)} vectors for {len(resolved_texts)} inputs"
-            )
-
         metadata = self.metadata
         return [
             ChunkEmbedding(text=text, vector=vector, metadata=metadata)
@@ -97,19 +99,59 @@ class OllamaEmbeddingProvider:
         ]
 
     def _embed_inputs(self, texts: list[str]) -> list[tuple[float, ...]]:
-        endpoint = f"{self.base_url.rstrip('/')}/api/embed"
+        headers = self._request_headers()
+        vectors: list[tuple[float, ...]] = []
+        expected_dimensions: int | None = None
+
+        for start in range(0, len(texts), self.batch_size):
+            batch = texts[start : start + self.batch_size]
+            batch_vectors = self._request_batch(batch, headers=headers)
+            batch_dimensions = len(batch_vectors[0])
+            if expected_dimensions is None:
+                expected_dimensions = batch_dimensions
+            elif batch_dimensions != expected_dimensions:
+                raise EmbeddingError(
+                    "OpenAI-compatible response contained inconsistent embedding dimensions"
+                )
+            vectors.extend(batch_vectors)
+
+        return vectors
+
+    def _request_batch(
+        self,
+        texts: list[str],
+        *,
+        headers: dict[str, str] | None,
+    ) -> list[tuple[float, ...]]:
+        endpoint = f"{self.base_url.rstrip('/')}/embeddings"
         try:
             response = httpx.post(
-                endpoint, json={"model": self.model, "input": texts}, timeout=30.0
+                endpoint,
+                json={"model": self.model, "input": texts},
+                timeout=self.timeout_seconds,
+                headers=headers,
             )
             response.raise_for_status()
             payload = response.json()
         except httpx.HTTPError as exc:
-            raise EmbeddingError(f"Ollama embedding request failed: {exc}") from exc
+            raise EmbeddingError(
+                f"OpenAI-compatible embedding request failed for {endpoint}: {exc}"
+            ) from exc
         except ValueError as exc:
-            raise EmbeddingError("Ollama embedding response was not valid JSON") from exc
+            raise EmbeddingError("OpenAI-compatible embedding response was not valid JSON") from exc
 
-        return _extract_embedding_vectors(payload)
+        return _extract_embedding_vectors(payload, expected_count=len(texts))
+
+    def _request_headers(self) -> dict[str, str] | None:
+        if self.api_key_env is None:
+            return None
+
+        api_key = os.getenv(self.api_key_env)
+        if not api_key:
+            raise EmbeddingError(
+                f"Embedding API key environment variable {self.api_key_env} is not set"
+            )
+        return {"Authorization": f"Bearer {api_key}"}
 
 
 @dataclass(frozen=True)
@@ -127,20 +169,34 @@ class EmbeddingRecord:
 
 
 def build_embedding_provider(config: EmbeddingConfig) -> EmbeddingProvider:
-    """Build an embedding provider from resolved config."""
+    """Build the OpenAI-compatible embedding provider from resolved config."""
 
     provider = config.provider
     if provider is None:
-        raise EmbeddingError("No embedding provider configured")
-
-    normalized_provider = provider.lower()
-    if normalized_provider == EMBEDDING_PROVIDER_OLLAMA:
-        return OllamaEmbeddingProvider(
-            model=config.model or DEFAULT_OLLAMA_MODEL,
-            base_url=config.base_url or DEFAULT_OLLAMA_BASE_URL,
+        raise EmbeddingError(
+            "No embedding provider configured; set embedding.provider=openai_compatible"
         )
 
-    raise EmbeddingError(f"Embedding provider '{provider}' is not implemented")
+    normalized_provider = provider.lower()
+    if normalized_provider == "ollama":
+        raise EmbeddingError(
+            "The native Ollama provider was removed; set provider=openai_compatible and "
+            "base_url=http://127.0.0.1:11434/v1"
+        )
+    if normalized_provider != EMBEDDING_PROVIDER_OPENAI_COMPATIBLE:
+        raise EmbeddingError(
+            f"Embedding provider '{provider}' is not supported; use openai_compatible"
+        )
+    if config.base_url is None:
+        raise EmbeddingError("embedding.base_url is required for provider=openai_compatible")
+    if config.model is None:
+        raise EmbeddingError("embedding.model is required for provider=openai_compatible")
+
+    return OpenAICompatibleEmbeddingProvider(
+        base_url=config.base_url,
+        model=config.model,
+        api_key_env=config.api_key_env,
+    )
 
 
 def create_embedding_record(
@@ -220,33 +276,70 @@ def list_embedding_records(database_path: Path) -> list[EmbeddingRecord]:
     return [_row_to_embedding_record(row) for row in rows]
 
 
-def _extract_embedding_vectors(payload: Any) -> list[tuple[float, ...]]:
+def _extract_embedding_vectors(
+    payload: Any,
+    *,
+    expected_count: int,
+) -> list[tuple[float, ...]]:
     if not isinstance(payload, dict):
-        raise EmbeddingError("Ollama embedding response had an unexpected payload shape")
+        raise EmbeddingError("OpenAI-compatible embedding response had an unexpected payload shape")
 
-    embeddings = payload.get("embeddings")
-    if not isinstance(embeddings, list):
-        raise EmbeddingError("Ollama embedding response is missing an embeddings list")
+    data = payload.get("data")
+    if not isinstance(data, list):
+        raise EmbeddingError("OpenAI-compatible embedding response is missing a data list")
+    if len(data) != expected_count:
+        raise EmbeddingError(
+            f"OpenAI-compatible embedding response returned {len(data)} vectors for "
+            f"{expected_count} inputs"
+        )
 
-    vectors: list[tuple[float, ...]] = []
-    for embedding in embeddings:
+    vectors_by_index: dict[int, tuple[float, ...]] = {}
+    dimensions: int | None = None
+    for item in data:
+        if not isinstance(item, dict):
+            raise EmbeddingError(
+                "OpenAI-compatible embedding response contained a non-object data item"
+            )
+
+        index = item.get("index")
+        if isinstance(index, bool) or not isinstance(index, int) or not 0 <= index < expected_count:
+            raise EmbeddingError(
+                f"OpenAI-compatible embedding response contained invalid index {index!r}"
+            )
+        if index in vectors_by_index:
+            raise EmbeddingError(
+                f"OpenAI-compatible embedding response contained duplicate index {index}"
+            )
+
+        embedding = item.get("embedding")
         if not isinstance(embedding, list):
-            raise EmbeddingError("Ollama embedding response contained a non-list embedding")
-
+            raise EmbeddingError(
+                "OpenAI-compatible embedding response is missing an embedding vector"
+            )
         vector = tuple(_coerce_vector_value(value) for value in embedding)
         if not vector:
-            raise EmbeddingError("Ollama embedding response contained an empty embedding vector")
-        vectors.append(vector)
+            raise EmbeddingError(
+                "OpenAI-compatible embedding response contained an empty embedding vector"
+            )
+        if dimensions is None:
+            dimensions = len(vector)
+        elif len(vector) != dimensions:
+            raise EmbeddingError(
+                "OpenAI-compatible response contained inconsistent embedding dimensions"
+            )
+        vectors_by_index[index] = vector
 
-    if not vectors:
-        raise EmbeddingError("Ollama embedding response did not return any vectors")
-    return vectors
+    return [vectors_by_index[index] for index in range(expected_count)]
 
 
 def _coerce_vector_value(value: object) -> float:
-    if isinstance(value, int | float):
-        return float(value)
-    raise EmbeddingError("Ollama embedding response contained a non-numeric value")
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise EmbeddingError("OpenAI-compatible embedding response contained a non-numeric value")
+
+    resolved_value = float(value)
+    if not math.isfinite(resolved_value):
+        raise EmbeddingError("OpenAI-compatible embedding response contained a non-finite value")
+    return resolved_value
 
 
 def _split_model_identity(model: str) -> tuple[str, str]:

--- a/newsrag/ingest.py
+++ b/newsrag/ingest.py
@@ -33,7 +33,6 @@ from newsrag.search import LanceDbPassageVectorStore, PassageVectorRecord
 from newsrag.storage import StoragePaths, initialize_storage
 
 INGEST_JOB_KIND = "ingest-file"
-DEFAULT_EMBEDDING_PROVIDER = "ollama"
 DEFAULT_CHUNK_MAX_CHARS = 2000
 DEFAULT_CHUNK_OVERLAP_CHARS = 200
 DEFAULT_DOWNLOAD_TIMEOUT_SECONDS = 30.0
@@ -419,9 +418,7 @@ class IngestionPipeline:
         self.ocr_runner = ocr_runner or SubprocessOcrRunner()
         self.text_extractor = text_extractor
         self.chunker = chunker or PageChunker()
-        self.embedding_provider = embedding_provider or build_embedding_provider(
-            _resolve_embedding_config(embedding_config)
-        )
+        self.embedding_provider = embedding_provider or build_embedding_provider(embedding_config)
         self.vector_store = vector_store or LanceDbVectorStore(storage_paths.lancedb)
         self.passage_vector_store = LanceDbPassageVectorStore(storage_paths.lancedb)
 
@@ -760,18 +757,6 @@ def _iter_pdf_inputs(source_path: Path) -> tuple[Path, ...]:
         return pdf_paths
 
     raise IngestError(f"No PDF files found under {resolved_path}")
-
-
-def _resolve_embedding_config(embedding_config: EmbeddingConfig) -> EmbeddingConfig:
-    if embedding_config.provider is not None:
-        return embedding_config
-
-    return EmbeddingConfig(
-        provider=DEFAULT_EMBEDDING_PROVIDER,
-        base_url=embedding_config.base_url,
-        model=embedding_config.model,
-        api_key_env=embedding_config.api_key_env,
-    )
 
 
 def _payload_path(payload: dict[str, Any]) -> Path:

--- a/newsrag/search.py
+++ b/newsrag/search.py
@@ -12,6 +12,7 @@ import lancedb  # type: ignore[import-untyped]
 
 from newsrag.config import EmbeddingConfig
 from newsrag.embeddings import (
+    EmbeddingError,
     EmbeddingMetadata,
     EmbeddingProvider,
     QueryEmbedding,
@@ -27,7 +28,6 @@ DEFAULT_MAX_VECTOR_DISTANCE = 1.0
 DEFAULT_VECTOR_DISTANCE_MARGIN_WITH_KEYWORD = 0.08
 DEFAULT_STRONG_VECTOR_DISTANCE_WITH_KEYWORD = 0.98
 DEFAULT_SNIPPET_LENGTH = 700
-DEFAULT_EMBEDDING_PROVIDER = "ollama"
 PASSAGE_VECTOR_TABLE_NAME = "passage_embeddings"
 
 
@@ -310,9 +310,12 @@ def build_search_engine(
 ) -> SearchEngine:
     """Build the default hybrid search engine for one corpus."""
 
-    resolved_embedding_provider = embedding_provider or build_embedding_provider(
-        _resolve_embedding_config(embedding_config)
-    )
+    try:
+        resolved_embedding_provider = embedding_provider or build_embedding_provider(
+            embedding_config
+        )
+    except EmbeddingError as exc:
+        raise SearchError(str(exc)) from exc
     resolved_vector_store = vector_store or LanceDbPassageVectorStore(lancedb_path)
     resolved_vector_searcher = vector_searcher or LanceDbPassageVectorSearcher(lancedb_path)
     return SearchEngine(
@@ -662,18 +665,6 @@ def _expand_contextual_keyword_candidates(
             seen_passage_ids.add(neighbor.passage_id)
 
     return expanded
-
-
-def _resolve_embedding_config(embedding_config: EmbeddingConfig) -> EmbeddingConfig:
-    if embedding_config.provider is not None:
-        return embedding_config
-
-    return EmbeddingConfig(
-        provider=DEFAULT_EMBEDDING_PROVIDER,
-        base_url=embedding_config.base_url,
-        model=embedding_config.model,
-        api_key_env=embedding_config.api_key_env,
-    )
 
 
 def _normalize_lower_better_scores(scores: dict[str, float | None]) -> dict[str, float]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -121,20 +121,20 @@ def test_doctor_command_applies_embedding_overrides(
             str(config_path),
             "doctor",
             "--embedding-provider",
-            "ollama",
+            "openai_compatible",
             "--embedding-base-url",
-            "http://localhost:11434",
+            "http://localhost:8080/v1",
             "--embedding-model",
-            "nomic-embed-text",
+            "nomic-embed-text-v1.5",
         ],
     )
 
     assert result.exit_code == 0
     assert seen_embedding == [
         EmbeddingConfig(
-            provider="ollama",
-            base_url="http://localhost:11434",
-            model="nomic-embed-text",
+            provider="openai_compatible",
+            base_url="http://localhost:8080/v1",
+            model="nomic-embed-text-v1.5",
             api_key_env=None,
         )
     ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -111,13 +111,13 @@ def test_apply_embedding_overrides_replaces_selected_fields() -> None:
 
     updated = apply_embedding_overrides(
         embedding,
-        provider="ollama",
-        model="nomic-embed-text",
+        base_url="http://127.0.0.1:8080/v1",
+        model="nomic-embed-text-v1.5",
     )
 
     assert updated == EmbeddingConfig(
-        provider="ollama",
-        base_url="http://localhost:1234/v1",
-        model="nomic-embed-text",
+        provider="openai_compatible",
+        base_url="http://127.0.0.1:8080/v1",
+        model="nomic-embed-text-v1.5",
         api_key_env="OPENAI_API_KEY",
     )

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -15,6 +15,40 @@ runner = CliRunner()
 
 def test_daemon_run_command_starts_against_initialized_storage(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+embedding:
+  provider: openai_compatible
+  base_url: http://127.0.0.1:8080/v1
+  model: nomic-embed-text-v1.5
+""".strip(),
+        encoding="utf-8",
+    )
+    initialize_storage(data_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            "--config-path",
+            str(config_path),
+            "--data-dir",
+            str(data_dir),
+            "daemon",
+            "run",
+            "--poll-interval",
+            "0",
+            "--max-loops",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "NewsRAG daemon running" in result.stdout
+
+
+def test_daemon_run_command_requires_embedding_configuration(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
     initialize_storage(data_dir)
 
     result = runner.invoke(
@@ -31,8 +65,9 @@ def test_daemon_run_command_starts_against_initialized_storage(tmp_path: Path) -
         ],
     )
 
-    assert result.exit_code == 0
-    assert "NewsRAG daemon running" in result.stdout
+    assert result.exit_code == 1
+    assert "No embedding provider configured" in result.stdout
+    assert "embedding.provider=openai_compatible" in result.stdout
 
 
 def test_mocked_job_moves_from_pending_to_running_to_done(tmp_path: Path) -> None:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -49,6 +49,7 @@ def test_run_doctor_warns_when_embedding_provider_is_unconfigured(tmp_path: Path
     embedding_check = next(check for check in report.checks if check.name == "embedding")
     assert embedding_check.status == "warn"
     assert "no embedding provider configured" in embedding_check.detail
+    assert "provider=openai_compatible" in embedding_check.detail
     assert report.summary == "warn"
 
 
@@ -90,50 +91,25 @@ def test_run_doctor_reports_actionable_watcher_health_failures(tmp_path: Path) -
     assert "remove/re-add the watch" in watcher_check.detail
 
 
-def test_run_doctor_handles_malformed_ollama_response(
+def test_run_doctor_checks_openai_compatible_provider(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    settings = RuntimeSettings(
-        config_path=tmp_path / "config.yaml",
-        data_dir=tmp_path / ".newsrag",
-        config=AppConfig(
-            source_path=tmp_path / "config.yaml",
-            embedding=EmbeddingConfig(provider="ollama", model="nomic-embed-text"),
+    monkeypatch.setenv("TEST_OPENAI_API_KEY", "secret-value")
+    settings = _settings_with_embedding(
+        tmp_path,
+        EmbeddingConfig(
+            provider="openai_compatible",
+            base_url="https://api.example.test/v1",
+            model="text-embedding-3-small",
+            api_key_env="TEST_OPENAI_API_KEY",
         ),
     )
 
     def fake_get(url: str, timeout: float, headers: dict[str, str] | None = None) -> httpx.Response:
-        request = httpx.Request("GET", url)
-        return httpx.Response(200, request=request, content=b"not-json")
-
-    monkeypatch.setattr("newsrag.doctor.httpx.get", fake_get)
-
-    report = run_doctor(settings)
-
-    embedding_check = next(check for check in report.checks if check.name == "embedding")
-    assert embedding_check.status == "warn"
-    assert "malformed JSON" in embedding_check.detail
-
-
-def test_run_doctor_checks_generic_openai_compatible_provider(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    settings = RuntimeSettings(
-        config_path=tmp_path / "config.yaml",
-        data_dir=tmp_path / ".newsrag",
-        config=AppConfig(
-            source_path=tmp_path / "config.yaml",
-            embedding=EmbeddingConfig(
-                provider="openai_compatible",
-                base_url="http://localhost:1234/v1",
-                model="text-embedding-3-small",
-            ),
-        ),
-    )
-
-    def fake_get(url: str, timeout: float, headers: dict[str, str] | None = None) -> httpx.Response:
+        del timeout
+        assert url == "https://api.example.test/v1/models"
+        assert headers == {"Authorization": "Bearer secret-value"}
         request = httpx.Request("GET", url, headers=headers)
         return httpx.Response(
             200,
@@ -148,44 +124,146 @@ def test_run_doctor_checks_generic_openai_compatible_provider(
     embedding_check = next(check for check in report.checks if check.name == "embedding")
     assert embedding_check.status == "ok"
     assert "provider=openai_compatible" in embedding_check.detail
+    assert "text-embedding-3-small" in embedding_check.detail
+    assert "secret-value" not in embedding_check.detail
 
 
-def test_run_doctor_warns_when_ollama_model_is_missing(tmp_path: Path) -> None:
-    settings = RuntimeSettings(
-        config_path=tmp_path / "config.yaml",
-        data_dir=tmp_path / ".newsrag",
-        config=AppConfig(
-            source_path=tmp_path / "config.yaml",
-            embedding=EmbeddingConfig(provider="ollama"),
+def test_run_doctor_rejects_removed_native_ollama_provider(tmp_path: Path) -> None:
+    settings = _settings_with_embedding(
+        tmp_path,
+        EmbeddingConfig(
+            provider="ollama",
+            base_url="http://127.0.0.1:11434",
+            model="nomic-embed-text",
         ),
     )
 
     report = run_doctor(settings)
 
     embedding_check = next(check for check in report.checks if check.name == "embedding")
+    assert embedding_check.status == "error"
+    assert "native Ollama provider was removed" in embedding_check.detail
+    assert "http://127.0.0.1:11434/v1" in embedding_check.detail
+
+
+@pytest.mark.parametrize(
+    ("embedding", "message"),
+    [
+        (
+            EmbeddingConfig(
+                provider="openai_compatible",
+                base_url="http://127.0.0.1:8080/v1",
+            ),
+            "embedding.model is missing",
+        ),
+        (
+            EmbeddingConfig(
+                provider="openai_compatible",
+                model="nomic-embed-text-v1.5",
+            ),
+            "embedding.base_url is missing",
+        ),
+        (
+            EmbeddingConfig(
+                provider="openai_compatible",
+                base_url="https://api.example.test/v1",
+                model="text-embedding-3-small",
+                api_key_env="MISSING_EMBEDDING_API_KEY",
+            ),
+            "expects environment variable MISSING_EMBEDDING_API_KEY",
+        ),
+    ],
+)
+def test_run_doctor_reports_incomplete_openai_compatible_configuration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    embedding: EmbeddingConfig,
+    message: str,
+) -> None:
+    monkeypatch.delenv("MISSING_EMBEDDING_API_KEY", raising=False)
+    settings = _settings_with_embedding(tmp_path, embedding)
+
+    report = run_doctor(settings)
+
+    embedding_check = next(check for check in report.checks if check.name == "embedding")
     assert embedding_check.status == "warn"
-    assert "embedding.model is missing" in embedding_check.detail
+    assert message in embedding_check.detail
 
 
-def test_run_doctor_warns_when_ollama_is_unreachable(
+def test_run_doctor_handles_malformed_openai_compatible_response(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    settings = RuntimeSettings(
-        config_path=tmp_path / "config.yaml",
-        data_dir=tmp_path / ".newsrag",
-        config=AppConfig(
-            source_path=tmp_path / "config.yaml",
-            embedding=EmbeddingConfig(
-                provider="ollama",
-                base_url="http://127.0.0.1:11434",
-                model="nomic-embed-text",
-            ),
+    settings = _settings_with_embedding(
+        tmp_path,
+        EmbeddingConfig(
+            provider="openai_compatible",
+            base_url="http://127.0.0.1:8080/v1",
+            model="nomic-embed-text-v1.5",
         ),
     )
 
     def fake_get(url: str, timeout: float, headers: dict[str, str] | None = None) -> httpx.Response:
-        request = httpx.Request("GET", url, headers=headers)
+        del timeout, headers
+        request = httpx.Request("GET", url)
+        return httpx.Response(200, request=request, content=b"not-json")
+
+    monkeypatch.setattr("newsrag.doctor.httpx.get", fake_get)
+
+    report = run_doctor(settings)
+
+    embedding_check = next(check for check in report.checks if check.name == "embedding")
+    assert embedding_check.status == "warn"
+    assert "malformed JSON" in embedding_check.detail
+
+
+def test_run_doctor_warns_when_openai_compatible_model_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings_with_embedding(
+        tmp_path,
+        EmbeddingConfig(
+            provider="openai_compatible",
+            base_url="http://127.0.0.1:8080/v1",
+            model="missing-model",
+        ),
+    )
+
+    def fake_get(url: str, timeout: float, headers: dict[str, str] | None = None) -> httpx.Response:
+        del timeout, headers
+        request = httpx.Request("GET", url)
+        return httpx.Response(
+            200,
+            request=request,
+            json={"data": [{"id": "nomic-embed-text-v1.5"}]},
+        )
+
+    monkeypatch.setattr("newsrag.doctor.httpx.get", fake_get)
+
+    report = run_doctor(settings)
+
+    embedding_check = next(check for check in report.checks if check.name == "embedding")
+    assert embedding_check.status == "warn"
+    assert "model=missing-model is not listed" in embedding_check.detail
+
+
+def test_run_doctor_warns_when_openai_compatible_service_is_unreachable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings_with_embedding(
+        tmp_path,
+        EmbeddingConfig(
+            provider="openai_compatible",
+            base_url="http://127.0.0.1:8080/v1",
+            model="nomic-embed-text-v1.5",
+        ),
+    )
+
+    def fake_get(url: str, timeout: float, headers: dict[str, str] | None = None) -> httpx.Response:
+        del timeout, headers
+        request = httpx.Request("GET", url)
         raise httpx.ConnectError("boom", request=request)
 
     monkeypatch.setattr("newsrag.doctor.httpx.get", fake_get)
@@ -197,35 +275,10 @@ def test_run_doctor_warns_when_ollama_is_unreachable(
     assert "is unreachable" in embedding_check.detail
 
 
-def test_run_doctor_checks_ollama_provider_when_selected(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    settings = RuntimeSettings(
-        config_path=tmp_path / "config.yaml",
+def _settings_with_embedding(tmp_path: Path, embedding: EmbeddingConfig) -> RuntimeSettings:
+    config_path = tmp_path / "config.yaml"
+    return RuntimeSettings(
+        config_path=config_path,
         data_dir=tmp_path / ".newsrag",
-        config=AppConfig(
-            source_path=tmp_path / "config.yaml",
-            embedding=EmbeddingConfig(
-                provider="ollama",
-                base_url="http://127.0.0.1:11434",
-                model="nomic-embed-text",
-            ),
-        ),
+        config=AppConfig(source_path=config_path, embedding=embedding),
     )
-
-    def fake_get(url: str, timeout: float, headers: dict[str, str] | None = None) -> httpx.Response:
-        request = httpx.Request("GET", url)
-        return httpx.Response(
-            200,
-            request=request,
-            json={"models": [{"name": "nomic-embed-text:latest"}]},
-        )
-
-    monkeypatch.setattr("newsrag.doctor.httpx.get", fake_get)
-
-    report = run_doctor(settings)
-
-    embedding_check = next(check for check in report.checks if check.name == "embedding")
-    assert embedding_check.status == "ok"
-    assert "provider=ollama" in embedding_check.detail

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import httpx
 import pytest
@@ -11,6 +12,7 @@ from newsrag.embeddings import (
     EmbeddingError,
     EmbeddingMetadata,
     EmbeddingProvider,
+    OpenAICompatibleEmbeddingProvider,
     QueryEmbedding,
     build_embedding_provider,
     create_embedding_record,
@@ -19,55 +21,335 @@ from newsrag.embeddings import (
 from newsrag.storage import initialize_storage
 
 
-def test_ollama_provider_supports_query_and_chunk_embeddings(
+def test_openai_compatible_provider_supports_local_query_and_chunk_embeddings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    provider = build_embedding_provider(EmbeddingConfig(provider="ollama"))
+    provider = build_embedding_provider(
+        EmbeddingConfig(
+            provider="openai_compatible",
+            base_url="http://127.0.0.1:8080/v1",
+            model="nomic-embed-text-v1.5",
+        )
+    )
 
-    def fake_post(url: str, *, json: dict[str, object], timeout: float) -> httpx.Response:
+    def fake_post(
+        url: str,
+        *,
+        json: dict[str, object],
+        timeout: float,
+        headers: dict[str, str] | None,
+    ) -> httpx.Response:
         del timeout
-        assert url == "http://127.0.0.1:11434/api/embed"
-        assert json["model"] == "nomic-embed-text"
+        assert url == "http://127.0.0.1:8080/v1/embeddings"
+        assert json["model"] == "nomic-embed-text-v1.5"
+        assert headers is None
         inputs = json["input"]
         assert isinstance(inputs, list)
 
         request = httpx.Request("POST", url)
         if len(inputs) == 1:
-            return httpx.Response(200, request=request, json={"embeddings": [[0.1, 0.2]]})
-        return httpx.Response(
-            200,
-            request=request,
-            json={"embeddings": [[0.3, 0.4], [0.5, 0.6]]},
-        )
+            data = [{"index": 0, "embedding": [0.1, 0.2]}]
+        else:
+            data = [
+                {"index": 0, "embedding": [0.3, 0.4]},
+                {"index": 1, "embedding": [0.5, 0.6]},
+            ]
+        return httpx.Response(200, request=request, json={"data": data})
 
     monkeypatch.setattr("newsrag.embeddings.httpx.post", fake_post)
 
     query_embedding, chunk_embeddings = _exercise_provider(provider)
 
     assert query_embedding.vector == (0.1, 0.2)
-    assert query_embedding.metadata.provider == "ollama"
-    assert query_embedding.metadata.model == "nomic-embed-text"
+    assert query_embedding.metadata.provider == "openai_compatible"
+    assert query_embedding.metadata.model == "nomic-embed-text-v1.5"
     assert query_embedding.metadata.version == "latest"
     assert [chunk.text for chunk in chunk_embeddings] == ["chunk one", "chunk two"]
     assert [chunk.vector for chunk in chunk_embeddings] == [(0.3, 0.4), (0.5, 0.6)]
 
 
-def test_ollama_provider_raises_for_malformed_payload(
+def test_openai_compatible_provider_reads_api_key_from_environment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("TEST_EMBEDDING_API_KEY", "secret-value")
     provider = build_embedding_provider(
-        EmbeddingConfig(provider="ollama", model="nomic-embed-text")
+        EmbeddingConfig(
+            provider="openai_compatible",
+            base_url="https://api.example.test/v1",
+            model="text-embedding-3-small",
+            api_key_env="TEST_EMBEDDING_API_KEY",
+        )
     )
 
-    def fake_post(url: str, *, json: dict[str, object], timeout: float) -> httpx.Response:
+    def fake_post(
+        url: str,
+        *,
+        json: dict[str, object],
+        timeout: float,
+        headers: dict[str, str] | None,
+    ) -> httpx.Response:
         del json, timeout
+        assert headers == {"Authorization": "Bearer secret-value"}
         request = httpx.Request("POST", url)
-        return httpx.Response(200, request=request, json={"embeddings": ["bad"]})
+        return httpx.Response(
+            200,
+            request=request,
+            json={"data": [{"index": 0, "embedding": [0.1, 0.2]}]},
+        )
 
     monkeypatch.setattr("newsrag.embeddings.httpx.post", fake_post)
 
-    with pytest.raises(EmbeddingError, match="non-list embedding"):
+    provider.embed_query("agenda")
+
+
+def test_openai_compatible_provider_batches_and_restores_input_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = OpenAICompatibleEmbeddingProvider(
+        base_url="http://127.0.0.1:8080/v1",
+        model="nomic-embed-text-v1.5",
+        batch_size=2,
+    )
+    batches: list[list[str]] = []
+
+    def fake_post(
+        url: str,
+        *,
+        json: dict[str, object],
+        timeout: float,
+        headers: dict[str, str] | None,
+    ) -> httpx.Response:
+        del timeout, headers
+        inputs = json["input"]
+        assert isinstance(inputs, list)
+        batch = [str(value) for value in inputs]
+        batches.append(batch)
+        data = [
+            {"index": index, "embedding": [float(int(text[-1])), 0.0]}
+            for index, text in reversed(list(enumerate(batch)))
+        ]
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, request=request, json={"data": data})
+
+    monkeypatch.setattr("newsrag.embeddings.httpx.post", fake_post)
+
+    embeddings = provider.embed_chunks(["chunk 1", "chunk 2", "chunk 3"])
+
+    assert batches == [["chunk 1", "chunk 2"], ["chunk 3"]]
+    assert [embedding.vector for embedding in embeddings] == [
+        (1.0, 0.0),
+        (2.0, 0.0),
+        (3.0, 0.0),
+    ]
+
+
+def test_openai_compatible_provider_rejects_dimensions_that_change_between_batches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = OpenAICompatibleEmbeddingProvider(
+        base_url="http://127.0.0.1:8080/v1",
+        model="nomic-embed-text-v1.5",
+        batch_size=1,
+    )
+    request_count = 0
+
+    def fake_post(
+        url: str,
+        *,
+        json: dict[str, object],
+        timeout: float,
+        headers: dict[str, str] | None,
+    ) -> httpx.Response:
+        nonlocal request_count
+        del json, timeout, headers
+        request_count += 1
+        vector = [0.1] if request_count == 1 else [0.2, 0.3]
+        request = httpx.Request("POST", url)
+        return httpx.Response(
+            200,
+            request=request,
+            json={"data": [{"index": 0, "embedding": vector}]},
+        )
+
+    monkeypatch.setattr("newsrag.embeddings.httpx.post", fake_post)
+
+    with pytest.raises(EmbeddingError, match="inconsistent embedding dimensions"):
+        provider.embed_chunks(["one", "two"])
+
+
+def test_openai_compatible_provider_requires_configured_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MISSING_EMBEDDING_API_KEY", raising=False)
+    provider = OpenAICompatibleEmbeddingProvider(
+        base_url="https://api.example.test/v1",
+        model="text-embedding-3-small",
+        api_key_env="MISSING_EMBEDDING_API_KEY",
+    )
+
+    with pytest.raises(EmbeddingError, match="MISSING_EMBEDDING_API_KEY is not set"):
         provider.embed_query("agenda")
+
+
+@pytest.mark.parametrize(
+    ("payload", "inputs", "message"),
+    [
+        ([], ["one"], "unexpected payload shape"),
+        ({}, ["one"], "missing a data list"),
+        ({"data": [{"index": 0}]}, ["one"], "missing an embedding vector"),
+        (
+            {
+                "data": [
+                    {"index": 0, "embedding": [0.1]},
+                    {"index": 0, "embedding": [0.2]},
+                ]
+            },
+            ["one", "two"],
+            "duplicate index 0",
+        ),
+        (
+            {"data": [{"index": 1, "embedding": [0.1]}]},
+            ["one"],
+            "invalid index 1",
+        ),
+        (
+            {"data": [{"index": 0, "embedding": [0.1]}]},
+            ["one", "two"],
+            "returned 1 vectors for 2 inputs",
+        ),
+        (
+            {
+                "data": [
+                    {"index": 0, "embedding": [0.1]},
+                    {"index": 1, "embedding": [0.2, 0.3]},
+                ]
+            },
+            ["one", "two"],
+            "inconsistent embedding dimensions",
+        ),
+        (
+            {"data": [{"index": 0, "embedding": ["bad"]}]},
+            ["one"],
+            "non-numeric value",
+        ),
+    ],
+)
+def test_openai_compatible_provider_rejects_malformed_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: Any,
+    inputs: list[str],
+    message: str,
+) -> None:
+    provider = OpenAICompatibleEmbeddingProvider(
+        base_url="http://127.0.0.1:8080/v1",
+        model="nomic-embed-text-v1.5",
+    )
+
+    def fake_post(
+        url: str,
+        *,
+        json: dict[str, object],
+        timeout: float,
+        headers: dict[str, str] | None,
+    ) -> httpx.Response:
+        del json, timeout, headers
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, request=request, json=payload)
+
+    monkeypatch.setattr("newsrag.embeddings.httpx.post", fake_post)
+
+    with pytest.raises(EmbeddingError, match=message):
+        provider.embed_chunks(inputs)
+
+
+def test_openai_compatible_provider_does_not_expose_api_key_on_http_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TEST_EMBEDDING_API_KEY", "secret-value")
+    provider = OpenAICompatibleEmbeddingProvider(
+        base_url="https://api.example.test/v1",
+        model="text-embedding-3-small",
+        api_key_env="TEST_EMBEDDING_API_KEY",
+    )
+
+    def fake_post(
+        url: str,
+        *,
+        json: dict[str, object],
+        timeout: float,
+        headers: dict[str, str] | None,
+    ) -> httpx.Response:
+        del json, timeout
+        request = httpx.Request("POST", url, headers=headers)
+        return httpx.Response(401, request=request)
+
+    monkeypatch.setattr("newsrag.embeddings.httpx.post", fake_post)
+
+    with pytest.raises(EmbeddingError) as error:
+        provider.embed_query("agenda")
+
+    assert "401 Unauthorized" in str(error.value)
+    assert "secret-value" not in str(error.value)
+
+
+def test_openai_compatible_provider_reports_http_and_json_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = OpenAICompatibleEmbeddingProvider(
+        base_url="http://127.0.0.1:8080/v1",
+        model="nomic-embed-text-v1.5",
+    )
+
+    def failed_post(
+        url: str,
+        *,
+        json: dict[str, object],
+        timeout: float,
+        headers: dict[str, str] | None,
+    ) -> httpx.Response:
+        del json, timeout, headers
+        request = httpx.Request("POST", url)
+        raise httpx.ConnectError("boom", request=request)
+
+    monkeypatch.setattr("newsrag.embeddings.httpx.post", failed_post)
+    with pytest.raises(EmbeddingError, match="embedding request failed"):
+        provider.embed_query("agenda")
+
+    def malformed_post(
+        url: str,
+        *,
+        json: dict[str, object],
+        timeout: float,
+        headers: dict[str, str] | None,
+    ) -> httpx.Response:
+        del json, timeout, headers
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, request=request, content=b"not-json")
+
+    monkeypatch.setattr("newsrag.embeddings.httpx.post", malformed_post)
+    with pytest.raises(EmbeddingError, match="response was not valid JSON"):
+        provider.embed_query("agenda")
+
+
+def test_build_embedding_provider_rejects_missing_and_removed_configuration() -> None:
+    with pytest.raises(EmbeddingError, match="No embedding provider configured"):
+        build_embedding_provider(EmbeddingConfig())
+
+    with pytest.raises(EmbeddingError, match="native Ollama provider was removed"):
+        build_embedding_provider(EmbeddingConfig(provider="ollama"))
+
+    with pytest.raises(EmbeddingError, match="embedding.base_url is required"):
+        build_embedding_provider(
+            EmbeddingConfig(provider="openai_compatible", model="nomic-embed-text-v1.5")
+        )
+
+    with pytest.raises(EmbeddingError, match="embedding.model is required"):
+        build_embedding_provider(
+            EmbeddingConfig(
+                provider="openai_compatible",
+                base_url="http://127.0.0.1:8080/v1",
+            )
+        )
 
 
 def test_create_embedding_record_stores_provider_model_and_version(tmp_path: Path) -> None:
@@ -76,8 +358,8 @@ def test_create_embedding_record_stores_provider_model_and_version(tmp_path: Pat
         text="chunk one",
         vector=(0.1, 0.2, 0.3),
         metadata=EmbeddingMetadata(
-            provider="ollama",
-            model="nomic-embed-text",
+            provider="openai_compatible",
+            model="nomic-embed-text-v1.5",
             version="latest",
         ),
     )
@@ -93,8 +375,8 @@ def test_create_embedding_record_stores_provider_model_and_version(tmp_path: Pat
     assert record.id == "embedding-1"
     assert record.source_kind == "chunk"
     assert record.source_key == "chunk-1"
-    assert record.provider == "ollama"
-    assert record.model == "nomic-embed-text"
+    assert record.provider == "openai_compatible"
+    assert record.model == "nomic-embed-text-v1.5"
     assert record.version == "latest"
     assert record.dimensions == 3
     assert list_embedding_records(paths.database) == [record]

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -477,7 +477,7 @@ def test_mocked_local_pdf_job_creates_document_pages_chunks_and_vector_records(
     assert len(vectors) == 2
     assert len(embedding_records) == 4
     assert {record.source_kind for record in embedding_records} == {"chunk", "passage"}
-    assert {record.provider for record in embedding_records} == {"ollama"}
+    assert {record.provider for record in embedding_records} == {"openai_compatible"}
     assert {vector["document_id"] for vector in vectors} == {documents[0].id}
 
 
@@ -741,8 +741,8 @@ class FailingTextExtractor:
 @dataclass(frozen=True)
 class FakeEmbeddingProvider:
     metadata: EmbeddingMetadata = EmbeddingMetadata(
-        provider="ollama",
-        model="nomic-embed-text",
+        provider="openai_compatible",
+        model="nomic-embed-text-v1.5",
         version="latest",
     )
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -33,8 +33,8 @@ def _strip_ansi(value: str) -> str:
 @dataclass(frozen=True)
 class FakeQueryEmbeddingProvider:
     metadata: EmbeddingMetadata = EmbeddingMetadata(
-        provider="ollama",
-        model="nomic-embed-text",
+        provider="openai_compatible",
+        model="nomic-embed-text-v1.5",
         version="latest",
     )
 
@@ -423,14 +423,15 @@ def test_format_search_results_returns_full_matching_passage() -> None:
     assert "NewsRAG Search" in output
 
 
-def test_search_command_reports_no_evidence_for_empty_corpus(tmp_path: Path) -> None:
+def test_search_command_requires_explicit_embedding_configuration(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
     initialize_storage(data_dir)
 
     result = runner.invoke(app, ["--data-dir", str(data_dir), "search", "stormwater"])
 
-    assert result.exit_code == 0
-    assert result.stdout.strip() == "No evidence found."
+    assert result.exit_code == 1
+    assert "No embedding provider configured" in result.stdout
+    assert "embedding.provider=openai_compatible" in result.stdout
 
 
 def _seed_search_corpus(tmp_path: Path) -> Path:


### PR DESCRIPTION
## Summary

Replace the native Ollama embedding path with one OpenAI-compatible `/v1/embeddings` implementation for local and hosted services.

## Task

`task-8b26dfd3`

## Changes

- Added bounded, order-preserving OpenAI-compatible embedding requests with optional environment-based bearer authentication and strict response validation.
- Removed implicit Ollama defaults and added actionable migration errors for native `provider: ollama` configuration.
- Unified doctor model checks on `/v1/models` and preserved embedding provenance.
- Documented llama.cpp, LM Studio, Ollama-compatible, and hosted OpenAI configurations.
- Added coverage for local and hosted requests, batching, malformed responses, secret handling, doctor behavior, and explicit configuration requirements.

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] `make check`
- [x] `./scripts/pre-pr.sh`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated
- [x] No unrelated changes included
