### PR TITLE
Filter documents by ingestion date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [Unreleased]
+
+### Added
+- Added inclusive UTC ingestion-date filters to `newsrag documents list` with `--ingested-since` and `--ingested-until`.
+
 ## [0.4.0] - 2026-09-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ newsrag doctor
 newsrag status --initialize
 ```
 
+List documents ingested during an inclusive UTC calendar-date range:
+
+```bash
+newsrag documents list --ingested-since 2026-09-01 --ingested-until 2026-09-02
+```
+
+The existing `--since` and `--until` document filters continue to apply to meeting dates.
+
 ## Development prerequisites
 
 NewsRAG uses a local-first stack:

--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -563,6 +563,16 @@ def documents_list_command(
         "--until",
         help="Only list documents with meeting dates on or before YYYY-MM-DD.",
     ),
+    ingested_since: str | None = typer.Option(
+        None,
+        "--ingested-since",
+        help="Only list documents ingested on or after YYYY-MM-DD (UTC).",
+    ),
+    ingested_until: str | None = typer.Option(
+        None,
+        "--ingested-until",
+        help="Only list documents ingested on or before YYYY-MM-DD (UTC).",
+    ),
     query: str | None = typer.Option(
         None,
         "--query",
@@ -591,6 +601,8 @@ def documents_list_command(
         source_url=source_url,
         since=since,
         until=until,
+        ingested_since=ingested_since,
+        ingested_until=ingested_until,
         query=query,
     )
     try:

--- a/newsrag/documents.py
+++ b/newsrag/documents.py
@@ -29,6 +29,8 @@ class DocumentFilters:
     source_url: str | None = None
     since: str | None = None
     until: str | None = None
+    ingested_since: str | None = None
+    ingested_until: str | None = None
     query: str | None = None
 
 
@@ -268,6 +270,16 @@ def _build_filter_query(filters: DocumentFilters) -> _QueryParts:
         clauses.append("json_extract(documents.metadata_json, '$.meeting_date') <= ?")
         parameters.append(until)
 
+    ingested_since = _normalized_optional_string(filters.ingested_since)
+    if ingested_since is not None:
+        clauses.append("date(documents.created_at) >= ?")
+        parameters.append(ingested_since)
+
+    ingested_until = _normalized_optional_string(filters.ingested_until)
+    if ingested_until is not None:
+        clauses.append("date(documents.created_at) <= ?")
+        parameters.append(ingested_until)
+
     query = _normalized_optional_string(filters.query)
     if query is not None:
         like_query = f"%{query.lower()}%"
@@ -300,6 +312,23 @@ def _validate_filters(filters: DocumentFilters) -> None:
     until_date = _parse_filter_date(filters.until, option_name="--until")
     if since_date is not None and until_date is not None and since_date > until_date:
         raise DocumentError("Invalid date range: --since must be on or before --until")
+
+    ingested_since_date = _parse_filter_date(
+        filters.ingested_since,
+        option_name="--ingested-since",
+    )
+    ingested_until_date = _parse_filter_date(
+        filters.ingested_until,
+        option_name="--ingested-until",
+    )
+    if (
+        ingested_since_date is not None
+        and ingested_until_date is not None
+        and ingested_since_date > ingested_until_date
+    ):
+        raise DocumentError(
+            "Invalid ingestion date range: --ingested-since must be on or before --ingested-until"
+        )
 
 
 def _parse_filter_date(value: str | None, *, option_name: str) -> date | None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -49,11 +49,14 @@ embedding:
 
 def test_daemon_run_command_requires_embedding_configuration(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
+    config_path = tmp_path / "missing-config.yaml"
     initialize_storage(data_dir)
 
     result = runner.invoke(
         app,
         [
+            "--config-path",
+            str(config_path),
             "--data-dir",
             str(data_dir),
             "daemon",

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import sqlite3
 from pathlib import Path
 
@@ -14,6 +15,10 @@ from newsrag.documents import (
 from newsrag.storage import initialize_storage
 
 runner = CliRunner()
+
+
+def _strip_ansi(value: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", value)
 
 
 def test_documents_list_empty_corpus(tmp_path: Path) -> None:
@@ -230,13 +235,14 @@ def test_documents_list_rejects_invalid_and_reversed_ingestion_dates(tmp_path: P
 
 def test_documents_list_help_distinguishes_ingestion_and_meeting_dates() -> None:
     result = runner.invoke(app, ["documents", "list", "--help"])
+    output = _strip_ansi(result.stdout)
 
     assert result.exit_code == 0
-    assert "--ingested-since" in result.stdout
-    assert "--ingested-until" in result.stdout
-    assert "Only list documents ingested on or after" in result.stdout
-    assert "YYYY-MM-DD (UTC)." in result.stdout
-    assert "Only list documents with meeting dates on" in result.stdout
+    assert "--ingested-since" in output
+    assert "--ingested-until" in output
+    assert "Only list documents ingested on or after" in output
+    assert "YYYY-MM-DD (UTC)." in output
+    assert "Only list documents with meeting dates on" in output
 
 
 def test_documents_list_rejects_invalid_limit_and_date(tmp_path: Path) -> None:

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -98,6 +98,147 @@ def test_documents_list_supports_metadata_date_query_and_pagination_filters(
     assert page.total == 1
 
 
+def test_documents_list_filters_on_or_after_ingestion_date(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    database_path = _seed_document_inventory(data_dir)
+
+    page = list_document_summaries(
+        database_path,
+        filters=DocumentFilters(ingested_since="2026-04-02"),
+    )
+
+    assert [document.id for document in page.documents] == ["document-c", "document-b"]
+
+
+def test_documents_list_filters_on_or_before_entire_ingestion_day(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    database_path = _seed_document_inventory(data_dir)
+
+    page = list_document_summaries(
+        database_path,
+        filters=DocumentFilters(ingested_until="2026-04-02"),
+    )
+
+    assert [document.id for document in page.documents] == ["document-b", "document-a"]
+    assert page.documents[0].created_at == "2026-04-02T23:59:59+00:00"
+
+
+def test_documents_list_filters_within_ingestion_date_range(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    database_path = _seed_document_inventory(data_dir)
+
+    page = list_document_summaries(
+        database_path,
+        filters=DocumentFilters(
+            ingested_since="2026-04-02",
+            ingested_until="2026-04-02",
+        ),
+    )
+
+    assert [document.id for document in page.documents] == ["document-b"]
+
+
+def test_documents_list_combines_ingestion_and_existing_filters(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    database_path = _seed_document_inventory(data_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            "--data-dir",
+            str(data_dir),
+            "documents",
+            "list",
+            "--ingested-since",
+            "2026-04-03",
+            "--body",
+            "Planning Commission",
+            "--query",
+            "zoning",
+        ],
+    )
+    page = list_document_summaries(
+        database_path,
+        filters=DocumentFilters(
+            body="Planning Commission",
+            query="zoning",
+            ingested_since="2026-04-03",
+        ),
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "document-c | Zoning Packet" in result.stdout
+    assert [document.id for document in page.documents] == ["document-c"]
+
+
+def test_documents_list_ingestion_filters_can_return_empty_results(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    _seed_document_inventory(data_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            "--data-dir",
+            str(data_dir),
+            "documents",
+            "list",
+            "--ingested-since",
+            "2030-01-01",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "documents: none" in result.stdout
+
+
+def test_documents_list_rejects_invalid_and_reversed_ingestion_dates(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    initialize_storage(data_dir)
+
+    invalid_result = runner.invoke(
+        app,
+        [
+            "--data-dir",
+            str(data_dir),
+            "documents",
+            "list",
+            "--ingested-since",
+            "04-01-2026",
+        ],
+    )
+    reversed_result = runner.invoke(
+        app,
+        [
+            "--data-dir",
+            str(data_dir),
+            "documents",
+            "list",
+            "--ingested-since",
+            "2026-04-03",
+            "--ingested-until",
+            "2026-04-02",
+        ],
+    )
+
+    assert invalid_result.exit_code == 1
+    assert "Invalid --ingested-since date: expected YYYY-MM-DD" in invalid_result.stdout
+    assert reversed_result.exit_code == 1
+    assert (
+        "Invalid ingestion date range: --ingested-since must be on or before --ingested-until"
+    ) in reversed_result.stdout
+
+
+def test_documents_list_help_distinguishes_ingestion_and_meeting_dates() -> None:
+    result = runner.invoke(app, ["documents", "list", "--help"])
+
+    assert result.exit_code == 0
+    assert "--ingested-since" in result.stdout
+    assert "--ingested-until" in result.stdout
+    assert "Only list documents ingested on or after" in result.stdout
+    assert "YYYY-MM-DD (UTC)." in result.stdout
+    assert "Only list documents with meeting dates on" in result.stdout
+
+
 def test_documents_list_rejects_invalid_limit_and_date(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
     initialize_storage(data_dir)
@@ -190,7 +331,7 @@ def _seed_document_inventory(data_dir: Path) -> Path:
                     "hash-b",
                     "/tmp/budget-ocr.pdf",
                     '{"body": "City Council", "document_type": "agenda_packet", "jurisdiction": "Example City", "meeting_date": "2026-04-20", "source_filename": "budget.pdf"}',
-                    "2026-04-02T00:00:00+00:00",
+                    "2026-04-02T23:59:59+00:00",
                 ),
                 (
                     "document-c",

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -425,9 +425,20 @@ def test_format_search_results_returns_full_matching_passage() -> None:
 
 def test_search_command_requires_explicit_embedding_configuration(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
+    config_path = tmp_path / "missing-config.yaml"
     initialize_storage(data_dir)
 
-    result = runner.invoke(app, ["--data-dir", str(data_dir), "search", "stormwater"])
+    result = runner.invoke(
+        app,
+        [
+            "--config-path",
+            str(config_path),
+            "--data-dir",
+            str(data_dir),
+            "search",
+            "stormwater",
+        ],
+    )
 
     assert result.exit_code == 1
     assert "No embedding provider configured" in result.stdout


### PR DESCRIPTION
## Summary

Add inclusive UTC ingestion-date filtering to the document inventory while preserving existing meeting-date filters and newest-first ordering.

## Task

`task-170d9f7c`

## Changes

- Added `--ingested-since` and `--ingested-until` to `newsrag documents list`.
- Filtered `documents.created_at` by inclusive UTC calendar dates and validated invalid or reversed ranges.
- Covered lower, upper, bounded, combined, empty, ordering, error, and help behavior.
- Made two embedding-configuration tests independent of the user's global NewsRAG configuration.
- Documented the new options and their distinction from meeting-date filters.

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] `make check`
- [x] `./scripts/pre-pr.sh`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated
- [x] No unrelated production changes included
