### PR TITLE
feat: add source artifacts and units

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,11 +39,14 @@ The daemon is global and may manage many data directories over time. Search beha
 NewsRAG is organized around a small set of durable entities rather than a server-side application model.
 
 - **Corpus/data directory**: a local collection of documents, metadata, artifacts, and indexes stored under the default user data directory or configured equivalent.
-- **Document**: a source PDF and its user-supplied civic metadata, such as title, source URL, meeting date, body or committee, document type, and jurisdiction.
-- **Normalized PDF artifact**: the OCR-normalized/searchable PDF produced from the source document and used for text extraction.
-- **Page**: canonical extracted page text with page number and extraction quality information. Pages are the source of citation truth.
-- **Chunk**: a searchable passage derived from page text. MVP chunking is page-first, with long pages split into overlapping chunks. Chunks retain page start/end and allow future structure fields such as section title, heading path, agenda item, and bounding box.
-- **Embedding**: a vector representation of a chunk stored in LanceDB, linked back to the chunk identifier and tagged with embedding provider, model, and version.
+- **Source**: the submitted URL or local path, stored separately from the bytes retrieved from it.
+- **Source artifact**: the immutable raw bytes acquired from a source, identified by content hash and retaining media type, byte size, acquisition time, and stored path.
+- **Document**: the searchable representation of one source artifact plus user-supplied civic metadata, such as title, meeting date, body or committee, document type, and jurisdiction.
+- **Normalized PDF artifact**: the OCR-normalized/searchable PDF derived from a raw PDF source artifact and used for text extraction.
+- **Source unit**: one ordered canonical text unit with a typed machine location, human label, normalized text, structure metadata, and extractor identity. PDF pages are represented as page source units; future formats may use blocks, lines, cells, or timestamps.
+- **Page**: the PDF-specific compatibility record linked one-to-one to a page source unit. Existing page numbers and page citations remain the source of citation truth for PDFs.
+- **Chunk**: searchable text derived from source units. Chunks retain both the existing PDF page span and a source-unit range for source-neutral retrieval.
+- **Embedding**: a vector representation of a chunk or passage stored in LanceDB, linked back to its source record, source-unit range, and embedding provider/model/version.
 - **Job**: durable processing work tracked through pending, running, done, and failed states, with error details and retry support.
 - **Watch**: a configured folder watcher with default metadata used when new PDFs appear.
 - **Packet**: a generated Markdown evidence file assembled from retrieved chunks and source metadata.
@@ -64,9 +67,9 @@ documents:
     jurisdiction: Example City
 ```
 
-Processing is idempotent. The system hashes source content to avoid duplicate indexing and to detect changed documents. Each document is normalized through OCR first, then text is extracted from the normalized PDF. This makes scanned and born-digital PDFs follow the same downstream path.
+Processing is idempotent. The system hashes source content to avoid duplicate indexing and to detect changed documents. Raw bytes are retained as an immutable source artifact. Each PDF is normalized through OCR, then text is extracted from the normalized PDF. This makes scanned and born-digital PDFs follow the same downstream path.
 
-The OCR stage uses `ocrmypdf` with Tesseract and its required supporting tools. Text extraction uses PyMuPDF as the primary extractor and pdfplumber as a fallback or table-oriented extraction path. Page text is stored before chunking so citations remain stable and inspectable.
+The OCR stage uses `ocrmypdf` with Tesseract and its required supporting tools. Text extraction uses PyMuPDF as the primary extractor and pdfplumber as a fallback or table-oriented extraction path. Each extracted page is stored as an ordered page source unit before chunking, and source-unit ranges propagate through chunks, passages, embeddings, and search results while existing page citations remain stable.
 
 ## Chunking and citations
 

--- a/newsrag/embeddings.py
+++ b/newsrag/embeddings.py
@@ -166,6 +166,8 @@ class EmbeddingRecord:
     version: str
     dimensions: int
     created_at: str
+    source_unit_start_id: str | None = None
+    source_unit_end_id: str | None = None
 
 
 def build_embedding_provider(config: EmbeddingConfig) -> EmbeddingProvider:
@@ -206,6 +208,8 @@ def create_embedding_record(
     source_key: str,
     embedding: QueryEmbedding | ChunkEmbedding,
     record_id: str | None = None,
+    source_unit_start_id: str | None = None,
+    source_unit_end_id: str | None = None,
 ) -> EmbeddingRecord:
     """Persist provider/model/version provenance for one embedding result."""
 
@@ -222,9 +226,11 @@ def create_embedding_record(
                 provider,
                 model,
                 version,
-                dimensions
+                dimensions,
+                source_unit_start_id,
+                source_unit_end_id
             )
-            VALUES(?, ?, ?, ?, ?, ?, ?)
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 resolved_record_id,
@@ -234,6 +240,8 @@ def create_embedding_record(
                 metadata.model,
                 metadata.version,
                 len(embedding.vector),
+                source_unit_start_id,
+                source_unit_end_id,
             ),
         )
         connection.commit()
@@ -248,7 +256,17 @@ def get_embedding_record(database_path: Path, record_id: str) -> EmbeddingRecord
         connection.row_factory = sqlite3.Row
         row = connection.execute(
             """
-            SELECT id, source_kind, source_key, provider, model, version, dimensions, created_at
+            SELECT
+                id,
+                source_kind,
+                source_key,
+                provider,
+                model,
+                version,
+                dimensions,
+                created_at,
+                source_unit_start_id,
+                source_unit_end_id
             FROM embedding_records
             WHERE id = ?
             """,
@@ -267,7 +285,17 @@ def list_embedding_records(database_path: Path) -> list[EmbeddingRecord]:
         connection.row_factory = sqlite3.Row
         rows = connection.execute(
             """
-            SELECT id, source_kind, source_key, provider, model, version, dimensions, created_at
+            SELECT
+                id,
+                source_kind,
+                source_key,
+                provider,
+                model,
+                version,
+                dimensions,
+                created_at,
+                source_unit_start_id,
+                source_unit_end_id
             FROM embedding_records
             ORDER BY created_at ASC, id ASC
             """
@@ -362,4 +390,10 @@ def _row_to_embedding_record(row: sqlite3.Row) -> EmbeddingRecord:
         version=str(row["version"]),
         dimensions=int(row["dimensions"]),
         created_at=str(row["created_at"]),
+        source_unit_start_id=(
+            str(row["source_unit_start_id"]) if row["source_unit_start_id"] is not None else None
+        ),
+        source_unit_end_id=(
+            str(row["source_unit_end_id"]) if row["source_unit_end_id"] is not None else None
+        ),
     )

--- a/newsrag/ingest.py
+++ b/newsrag/ingest.py
@@ -30,6 +30,14 @@ from newsrag.embeddings import (
 from newsrag.jobs import Job, create_job
 from newsrag.passages import build_passage_rows
 from newsrag.search import LanceDbPassageVectorStore, PassageVectorRecord
+from newsrag.sources import (
+    PAGE_LOCATION_TYPE,
+    PDF_MEDIA_TYPE,
+    SourceIdentity,
+    artifact_id_for_hash,
+    build_source_identity,
+    source_unit_id_for_page,
+)
 from newsrag.storage import StoragePaths, initialize_storage
 
 INGEST_JOB_KIND = "ingest-file"
@@ -98,6 +106,7 @@ class PageRecord:
     text: str
     extractor: str
     created_at: str
+    source_unit_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -110,6 +119,8 @@ class ChunkRecord:
     page_end: int
     text: str
     created_at: str
+    source_unit_start_id: str | None = None
+    source_unit_end_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -123,6 +134,8 @@ class ChunkVectorRecord:
     text: str
     vector: tuple[float, ...]
     metadata: EmbeddingMetadata
+    source_unit_start_id: str | None = None
+    source_unit_end_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -378,6 +391,8 @@ class LanceDbVectorStore:
                 "document_id": chunk.document_id,
                 "page_start": chunk.page_start,
                 "page_end": chunk.page_end,
+                "source_unit_start_id": chunk.source_unit_start_id,
+                "source_unit_end_id": chunk.source_unit_end_id,
                 "text": chunk.text,
                 "vector": list(chunk.vector),
                 "provider": chunk.metadata.provider,
@@ -461,16 +476,26 @@ class IngestionPipeline:
                 )
 
             document_id = f"document-{uuid.uuid4().hex[:8]}"
+            artifact_id = artifact_id_for_hash(source_hash)
+            source_identity = build_source_identity(
+                source_path=source_path,
+                source_url=source_url,
+            )
             document_metadata = _build_document_metadata(metadata, source_path, source_copy_path)
-            page_rows = _build_page_rows(document_id, pages)
+            page_rows, source_unit_rows, page_unit_ids = _build_page_and_source_unit_rows(
+                document_id,
+                artifact_id,
+                pages,
+            )
             chunk_rows, vector_rows = _build_chunk_and_vector_rows(
                 document_id,
                 chunks,
                 chunk_embeddings,
+                page_unit_ids=page_unit_ids,
             )
             passage_rows = _build_passage_rows_from_chunks(chunk_rows)
             passage_embeddings = self.embedding_provider.embed_chunks(
-                [passage_row[6] for passage_row in passage_rows]
+                [passage_row[8] for passage_row in passage_rows]
             )
             if len(passage_embeddings) != len(passage_rows):
                 raise IngestError(
@@ -483,12 +508,18 @@ class IngestionPipeline:
             _persist_document_bundle(
                 self.storage_paths.database,
                 document_id=document_id,
+                source_identity=source_identity,
+                artifact_id=artifact_id,
+                artifact_byte_size=source_copy_path.stat().st_size,
+                artifact_stored_path=source_copy_path,
+                artifact_acquired_at=_metadata_retrieved_at(metadata) or _current_timestamp(),
                 source_path=source_path,
                 source_url=source_url,
                 title=_resolve_document_title(metadata, source_path),
                 source_hash=source_hash,
                 normalized_path=normalized_path,
                 metadata=document_metadata,
+                source_units=source_unit_rows,
                 pages=page_rows,
                 chunks=chunk_rows,
                 chunk_embeddings=chunk_embeddings,
@@ -646,7 +677,7 @@ def list_pages(database_path: Path) -> list[PageRecord]:
         connection.row_factory = sqlite3.Row
         rows = connection.execute(
             """
-            SELECT id, document_id, page_number, text, extractor, created_at
+            SELECT id, document_id, page_number, text, extractor, created_at, source_unit_id
             FROM pages
             ORDER BY document_id ASC, page_number ASC, id ASC
             """
@@ -660,6 +691,9 @@ def list_pages(database_path: Path) -> list[PageRecord]:
             text=str(row["text"]),
             extractor=str(row["extractor"]),
             created_at=str(row["created_at"]),
+            source_unit_id=(
+                str(row["source_unit_id"]) if row["source_unit_id"] is not None else None
+            ),
         )
         for row in rows
     ]
@@ -672,7 +706,15 @@ def list_chunks(database_path: Path) -> list[ChunkRecord]:
         connection.row_factory = sqlite3.Row
         rows = connection.execute(
             """
-            SELECT id, document_id, page_start, page_end, text, created_at
+            SELECT
+                id,
+                document_id,
+                page_start,
+                page_end,
+                text,
+                created_at,
+                source_unit_start_id,
+                source_unit_end_id
             FROM chunks
             ORDER BY document_id ASC, page_start ASC, id ASC
             """
@@ -686,6 +728,14 @@ def list_chunks(database_path: Path) -> list[ChunkRecord]:
             page_end=int(row["page_end"]),
             text=str(row["text"]),
             created_at=str(row["created_at"]),
+            source_unit_start_id=(
+                str(row["source_unit_start_id"])
+                if row["source_unit_start_id"] is not None
+                else None
+            ),
+            source_unit_end_id=(
+                str(row["source_unit_end_id"]) if row["source_unit_end_id"] is not None else None
+            ),
         )
         for row in rows
     ]
@@ -795,6 +845,13 @@ def _metadata_source_url(metadata: dict[str, Any]) -> str | None:
     return None
 
 
+def _metadata_retrieved_at(metadata: dict[str, Any]) -> str | None:
+    retrieved_at = metadata.get("retrieved_at")
+    if isinstance(retrieved_at, str) and retrieved_at.strip():
+        return retrieved_at.strip()
+    return None
+
+
 def _hash_bytes(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
@@ -854,32 +911,75 @@ def _resolve_document_title(metadata: dict[str, Any], source_path: Path) -> str:
     return source_path.stem
 
 
-def _build_page_rows(
-    document_id: str, pages: Sequence[ExtractedPage]
-) -> list[tuple[str, str, int, str, str]]:
-    return [
-        (
-            f"page-{uuid.uuid4().hex[:8]}",
-            document_id,
-            page.page_number,
-            page.text,
-            page.extractor,
+def _build_page_and_source_unit_rows(
+    document_id: str,
+    artifact_id: str,
+    pages: Sequence[ExtractedPage],
+) -> tuple[
+    list[tuple[str, str, int, str, str, str]],
+    list[tuple[str, str, str, int, str, str, str, str, str, str, str | None]],
+    dict[int, str],
+]:
+    page_rows: list[tuple[str, str, int, str, str, str]] = []
+    source_unit_rows: list[tuple[str, str, str, int, str, str, str, str, str, str, str | None]] = []
+    page_unit_ids: dict[int, str] = {}
+
+    for page in pages:
+        page_id = f"page-{uuid.uuid4().hex[:8]}"
+        unit_id = source_unit_id_for_page(page_id)
+        page_unit_ids[page.page_number] = unit_id
+        page_rows.append(
+            (page_id, document_id, page.page_number, unit_id, page.text, page.extractor)
         )
-        for page in pages
-    ]
+        source_unit_rows.append(
+            (
+                unit_id,
+                artifact_id,
+                document_id,
+                page.page_number,
+                PAGE_LOCATION_TYPE,
+                json.dumps({"page_number": page.page_number}, sort_keys=True),
+                f"p. {page.page_number}",
+                page.text,
+                "{}",
+                page.extractor,
+                None,
+            )
+        )
+
+    return page_rows, source_unit_rows, page_unit_ids
 
 
 def _build_chunk_and_vector_rows(
     document_id: str,
     chunks: Sequence[ChunkDraft],
     embeddings: Sequence[ChunkEmbedding],
-) -> tuple[list[tuple[str, str, int, int, str]], list[ChunkVectorRecord]]:
-    chunk_rows: list[tuple[str, str, int, int, str]] = []
+    *,
+    page_unit_ids: dict[int, str],
+) -> tuple[list[tuple[str, str, int, int, str, str, str]], list[ChunkVectorRecord]]:
+    chunk_rows: list[tuple[str, str, int, int, str, str, str]] = []
     vector_rows: list[ChunkVectorRecord] = []
 
     for chunk, embedding in zip(chunks, embeddings, strict=True):
         chunk_id = f"chunk-{uuid.uuid4().hex[:8]}"
-        chunk_rows.append((chunk_id, document_id, chunk.page_start, chunk.page_end, chunk.text))
+        try:
+            source_unit_start_id = page_unit_ids[chunk.page_start]
+            source_unit_end_id = page_unit_ids[chunk.page_end]
+        except KeyError as exc:
+            raise IngestError(
+                f"Chunk references missing PDF page {exc.args[0]} for document {document_id}"
+            ) from exc
+        chunk_rows.append(
+            (
+                chunk_id,
+                document_id,
+                chunk.page_start,
+                chunk.page_end,
+                source_unit_start_id,
+                source_unit_end_id,
+                chunk.text,
+            )
+        )
         vector_rows.append(
             ChunkVectorRecord(
                 chunk_id=chunk_id,
@@ -889,6 +989,8 @@ def _build_chunk_and_vector_rows(
                 text=chunk.text,
                 vector=embedding.vector,
                 metadata=embedding.metadata,
+                source_unit_start_id=source_unit_start_id,
+                source_unit_end_id=source_unit_end_id,
             )
         )
 
@@ -896,10 +998,18 @@ def _build_chunk_and_vector_rows(
 
 
 def _build_passage_rows_from_chunks(
-    chunks: Sequence[tuple[str, str, int, int, str]],
-) -> list[tuple[str, str, str, int, int, int, str]]:
-    passage_rows: list[tuple[str, str, str, int, int, int, str]] = []
-    for chunk_id, document_id, page_start, page_end, text in chunks:
+    chunks: Sequence[tuple[str, str, int, int, str, str, str]],
+) -> list[tuple[str, str, str, int, int, str, str, int, str]]:
+    passage_rows: list[tuple[str, str, str, int, int, str, str, int, str]] = []
+    for (
+        chunk_id,
+        document_id,
+        page_start,
+        page_end,
+        source_unit_start_id,
+        source_unit_end_id,
+        text,
+    ) in chunks:
         for passage in build_passage_rows(
             chunk_id=chunk_id,
             document_id=document_id,
@@ -914,6 +1024,8 @@ def _build_passage_rows_from_chunks(
                     passage.document_id,
                     passage.page_start,
                     passage.page_end,
+                    source_unit_start_id,
+                    source_unit_end_id,
                     passage.ordinal,
                     passage.text,
                 )
@@ -922,7 +1034,7 @@ def _build_passage_rows_from_chunks(
 
 
 def _build_passage_vector_rows(
-    passages: Sequence[tuple[str, str, str, int, int, int, str]],
+    passages: Sequence[tuple[str, str, str, int, int, str, str, int, str]],
     embeddings: Sequence[ChunkEmbedding],
 ) -> list[PassageVectorRecord]:
     return [
@@ -934,10 +1046,20 @@ def _build_passage_vector_rows(
             text=text,
             vector=embedding.vector,
             metadata=embedding.metadata,
+            source_unit_start_id=source_unit_start_id,
+            source_unit_end_id=source_unit_end_id,
         )
-        for (passage_id, _, document_id, page_start, page_end, _, text), embedding in zip(
-            passages, embeddings, strict=True
-        )
+        for (
+            passage_id,
+            _,
+            document_id,
+            page_start,
+            page_end,
+            source_unit_start_id,
+            source_unit_end_id,
+            _,
+            text,
+        ), embedding in zip(passages, embeddings, strict=True)
     ]
 
 
@@ -945,21 +1067,70 @@ def _persist_document_bundle(
     database_path: Path,
     *,
     document_id: str,
+    source_identity: SourceIdentity,
+    artifact_id: str,
+    artifact_byte_size: int,
+    artifact_stored_path: Path,
+    artifact_acquired_at: str,
     source_path: Path,
     source_url: str | None,
     title: str,
     source_hash: str,
     normalized_path: Path,
     metadata: dict[str, Any],
-    pages: Sequence[tuple[str, str, int, str, str]],
-    chunks: Sequence[tuple[str, str, int, int, str]],
+    source_units: Sequence[tuple[str, str, str, int, str, str, str, str, str, str, str | None]],
+    pages: Sequence[tuple[str, str, int, str, str, str]],
+    chunks: Sequence[tuple[str, str, int, int, str, str, str]],
     chunk_embeddings: Sequence[ChunkEmbedding],
-    passages: Sequence[tuple[str, str, str, int, int, int, str]],
+    passages: Sequence[tuple[str, str, str, int, int, str, str, int, str]],
     passage_embeddings: Sequence[ChunkEmbedding],
 ) -> None:
     metadata_json = json.dumps(metadata, sort_keys=True)
 
     with sqlite3.connect(database_path) as connection:
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute(
+            """
+            INSERT OR IGNORE INTO sources(
+                id,
+                kind,
+                submitted_reference,
+                normalized_reference,
+                resolved_reference
+            )
+            VALUES(?, ?, ?, ?, ?)
+            """,
+            (
+                source_identity.id,
+                source_identity.kind,
+                source_identity.submitted_reference,
+                source_identity.normalized_reference,
+                source_identity.resolved_reference,
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO source_artifacts(
+                id,
+                source_id,
+                media_type,
+                byte_size,
+                content_hash,
+                stored_path,
+                acquired_at
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                artifact_id,
+                source_identity.id,
+                PDF_MEDIA_TYPE,
+                artifact_byte_size,
+                source_hash,
+                str(artifact_stored_path),
+                artifact_acquired_at,
+            ),
+        )
         connection.execute(
             """
             INSERT INTO documents(
@@ -969,9 +1140,10 @@ def _persist_document_bundle(
                 title,
                 source_hash,
                 normalized_path,
-                metadata_json
+                metadata_json,
+                artifact_id
             )
-            VALUES(?, ?, ?, ?, ?, ?, ?)
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 document_id,
@@ -981,19 +1153,47 @@ def _persist_document_bundle(
                 source_hash,
                 str(normalized_path),
                 metadata_json,
+                artifact_id,
             ),
         )
         connection.executemany(
             """
-            INSERT INTO pages(id, document_id, page_number, text, extractor)
-            VALUES(?, ?, ?, ?, ?)
+            INSERT INTO source_units(
+                id,
+                artifact_id,
+                document_id,
+                ordinal,
+                location_type,
+                location_json,
+                human_label,
+                normalized_text,
+                structure_json,
+                extractor,
+                extractor_version
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            source_units,
+        )
+        connection.executemany(
+            """
+            INSERT INTO pages(id, document_id, page_number, source_unit_id, text, extractor)
+            VALUES(?, ?, ?, ?, ?, ?)
             """,
             pages,
         )
         connection.executemany(
             """
-            INSERT INTO chunks(id, document_id, page_start, page_end, text)
-            VALUES(?, ?, ?, ?, ?)
+            INSERT INTO chunks(
+                id,
+                document_id,
+                page_start,
+                page_end,
+                source_unit_start_id,
+                source_unit_end_id,
+                text
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?)
             """,
             chunks,
         )
@@ -1002,12 +1202,22 @@ def _persist_document_bundle(
             INSERT INTO chunks_fts(chunk_id, text)
             VALUES(?, ?)
             """,
-            [(chunk_id, text) for chunk_id, _, _, _, text in chunks],
+            [(chunk_id, text) for chunk_id, _, _, _, _, _, text in chunks],
         )
         connection.executemany(
             """
-            INSERT INTO passages(id, chunk_id, document_id, page_start, page_end, ordinal, text)
-            VALUES(?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO passages(
+                id,
+                chunk_id,
+                document_id,
+                page_start,
+                page_end,
+                source_unit_start_id,
+                source_unit_end_id,
+                ordinal,
+                text
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             passages,
         )
@@ -1016,7 +1226,7 @@ def _persist_document_bundle(
             INSERT INTO passages_fts(passage_id, text)
             VALUES(?, ?)
             """,
-            [(passage_id, text) for passage_id, _, _, _, _, _, text in passages],
+            [(passage_id, text) for passage_id, _, _, _, _, _, _, _, text in passages],
         )
         connection.commit()
 
@@ -1026,6 +1236,8 @@ def _persist_document_bundle(
             source_kind="chunk",
             source_key=chunk_row[0],
             embedding=embedding,
+            source_unit_start_id=chunk_row[4],
+            source_unit_end_id=chunk_row[5],
         )
 
     for passage_row, embedding in zip(passages, passage_embeddings, strict=True):
@@ -1034,6 +1246,8 @@ def _persist_document_bundle(
             source_kind="passage",
             source_key=passage_row[0],
             embedding=embedding,
+            source_unit_start_id=passage_row[5],
+            source_unit_end_id=passage_row[6],
         )
 
 

--- a/newsrag/search.py
+++ b/newsrag/search.py
@@ -89,6 +89,8 @@ class PassageVectorRecord:
     text: str
     vector: tuple[float, ...]
     metadata: EmbeddingMetadata
+    source_unit_start_id: str | None = None
+    source_unit_end_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -107,6 +109,8 @@ class SearchCandidate:
     jurisdiction: str | None = None
     source_url: str | None = None
     source_path: str | None = None
+    source_unit_start_id: str | None = None
+    source_unit_end_id: str | None = None
     keyword_score: float | None = None
     vector_score: float | None = None
 
@@ -131,6 +135,8 @@ class SearchResult:
     jurisdiction: str | None = None
     source_url: str | None = None
     source_path: str | None = None
+    source_unit_start_id: str | None = None
+    source_unit_end_id: str | None = None
 
 
 class Reranker(Protocol):
@@ -179,6 +185,8 @@ class LanceDbPassageVectorStore:
                 "document_id": passage.document_id,
                 "page_start": passage.page_start,
                 "page_end": passage.page_end,
+                "source_unit_start_id": passage.source_unit_start_id,
+                "source_unit_end_id": passage.source_unit_end_id,
                 "text": passage.text,
                 "vector": list(passage.vector),
                 "provider": passage.metadata.provider,
@@ -230,6 +238,8 @@ class LanceDbPassageVectorSearcher:
                     text=str(row["text"]),
                     title=None,
                     meeting_date=None,
+                    source_unit_start_id=_optional_string(row.get("source_unit_start_id")),
+                    source_unit_end_id=_optional_string(row.get("source_unit_end_id")),
                     vector_score=distance,
                 )
             )
@@ -344,6 +354,8 @@ def search_keyword_candidates(
                 passages.document_id AS document_id,
                 passages.page_start AS page_start,
                 passages.page_end AS page_end,
+                passages.source_unit_start_id AS source_unit_start_id,
+                passages.source_unit_end_id AS source_unit_end_id,
                 passages.text AS passage_text,
                 documents.title AS title,
                 documents.source_url AS source_url,
@@ -380,6 +392,8 @@ def search_keyword_candidates(
                 source_path=_optional_string(row["source_path"])
                 or _optional_string(metadata.get("stored_source_path"))
                 or _optional_string(metadata.get("source_filename")),
+                source_unit_start_id=_optional_string(row["source_unit_start_id"]),
+                source_unit_end_id=_optional_string(row["source_unit_end_id"]),
                 keyword_score=float(row["keyword_score"]),
             )
         )
@@ -446,6 +460,8 @@ def merge_search_candidates(
             jurisdiction=context.jurisdiction,
             source_url=context.source_url,
             source_path=context.source_path,
+            source_unit_start_id=context.source_unit_start_id,
+            source_unit_end_id=context.source_unit_end_id,
         )
 
     return sorted(
@@ -516,6 +532,8 @@ def _ensure_passage_embeddings(
                     text=passage.text,
                     vector=embedding.vector,
                     metadata=embedding.metadata,
+                    source_unit_start_id=passage.source_unit_start_id,
+                    source_unit_end_id=passage.source_unit_end_id,
                 )
                 for passage, embedding in zip(batch, embeddings, strict=True)
             ]
@@ -526,6 +544,8 @@ def _ensure_passage_embeddings(
                 source_kind="passage",
                 source_key=passage.passage_id,
                 embedding=embedding,
+                source_unit_start_id=passage.source_unit_start_id,
+                source_unit_end_id=passage.source_unit_end_id,
             )
 
 
@@ -536,6 +556,8 @@ class _PassageForEmbedding:
     page_start: int
     page_end: int
     text: str
+    source_unit_start_id: str | None
+    source_unit_end_id: str | None
 
 
 def _load_missing_passages(
@@ -551,7 +573,9 @@ def _load_missing_passages(
                 passages.document_id AS document_id,
                 passages.page_start AS page_start,
                 passages.page_end AS page_end,
-                passages.text AS passage_text
+                passages.text AS passage_text,
+                passages.source_unit_start_id AS source_unit_start_id,
+                passages.source_unit_end_id AS source_unit_end_id
             FROM passages
             LEFT JOIN embedding_records
                 ON embedding_records.source_kind = 'passage'
@@ -572,6 +596,8 @@ def _load_missing_passages(
             page_start=int(row["page_start"]),
             page_end=int(row["page_end"]),
             text=str(row["passage_text"]),
+            source_unit_start_id=_optional_string(row["source_unit_start_id"]),
+            source_unit_end_id=_optional_string(row["source_unit_end_id"]),
         )
         for row in rows
     ]
@@ -659,6 +685,8 @@ def _expand_contextual_keyword_candidates(
                     jurisdiction=neighbor.jurisdiction,
                     source_url=neighbor.source_url,
                     source_path=neighbor.source_path,
+                    source_unit_start_id=neighbor.source_unit_start_id,
+                    source_unit_end_id=neighbor.source_unit_end_id,
                     keyword_score=(candidate.keyword_score or 0.0) + 0.5,
                 )
             )
@@ -712,6 +740,8 @@ def _load_passage_context(
                     passages.document_id AS document_id,
                     passages.page_start AS page_start,
                     passages.page_end AS page_end,
+                    passages.source_unit_start_id AS source_unit_start_id,
+                    passages.source_unit_end_id AS source_unit_end_id,
                     passages.text AS passage_text,
                     documents.title AS title,
                     documents.source_url AS source_url,
@@ -742,6 +772,8 @@ def _load_passage_context(
                 source_path=_optional_string(row["source_path"])
                 or _optional_string(metadata.get("stored_source_path"))
                 or _optional_string(metadata.get("source_filename")),
+                source_unit_start_id=_optional_string(row["source_unit_start_id"]),
+                source_unit_end_id=_optional_string(row["source_unit_end_id"]),
             )
 
     for candidate in vector_candidates:
@@ -759,6 +791,8 @@ def _load_passage_context(
             jurisdiction=existing.jurisdiction,
             source_url=existing.source_url,
             source_path=existing.source_path,
+            source_unit_start_id=existing.source_unit_start_id,
+            source_unit_end_id=existing.source_unit_end_id,
             keyword_score=existing.keyword_score,
             vector_score=candidate.vector_score,
         )
@@ -814,6 +848,8 @@ def _load_adjacent_passages(
                 passages.document_id AS document_id,
                 passages.page_start AS page_start,
                 passages.page_end AS page_end,
+                passages.source_unit_start_id AS source_unit_start_id,
+                passages.source_unit_end_id AS source_unit_end_id,
                 passages.text AS passage_text,
                 documents.title AS title,
                 documents.source_url AS source_url,
@@ -849,6 +885,8 @@ def _load_adjacent_passages(
                 source_path=_optional_string(row["source_path"])
                 or _optional_string(metadata.get("stored_source_path"))
                 or _optional_string(metadata.get("source_filename")),
+                source_unit_start_id=_optional_string(row["source_unit_start_id"]),
+                source_unit_end_id=_optional_string(row["source_unit_end_id"]),
             )
         )
     return candidates

--- a/newsrag/sources.py
+++ b/newsrag/sources.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import SplitResult, urlsplit, urlunsplit
+
+SOURCE_KIND_LOCAL_PATH = "local_path"
+SOURCE_KIND_URL = "url"
+PDF_MEDIA_TYPE = "application/pdf"
+PAGE_LOCATION_TYPE = "page"
+
+
+@dataclass(frozen=True)
+class SourceIdentity:
+    """Stable identity fields for one submitted source reference."""
+
+    id: str
+    kind: str
+    submitted_reference: str
+    normalized_reference: str
+    resolved_reference: str | None
+
+
+def build_source_identity(*, source_path: Path, source_url: str | None) -> SourceIdentity:
+    """Build the corpus-local identity fields for a URL or local path."""
+
+    if source_url is not None:
+        submitted_reference = source_url.strip()
+        normalized_reference = normalize_url_reference(submitted_reference)
+        return SourceIdentity(
+            id=_stable_id("source", SOURCE_KIND_URL, normalized_reference),
+            kind=SOURCE_KIND_URL,
+            submitted_reference=submitted_reference,
+            normalized_reference=normalized_reference,
+            resolved_reference=normalized_reference,
+        )
+
+    submitted_reference = str(source_path)
+    normalized_reference = str(source_path.expanduser().resolve())
+    return SourceIdentity(
+        id=_stable_id("source", SOURCE_KIND_LOCAL_PATH, normalized_reference),
+        kind=SOURCE_KIND_LOCAL_PATH,
+        submitted_reference=submitted_reference,
+        normalized_reference=normalized_reference,
+        resolved_reference=normalized_reference,
+    )
+
+
+def normalize_url_reference(url: str) -> str:
+    """Normalize only the URL components defined by the source identity policy."""
+
+    parsed = urlsplit(url)
+    scheme = parsed.scheme.lower()
+    host = (parsed.hostname or "").lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+
+    port = parsed.port
+    if port is not None and not (
+        (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
+    ):
+        host = f"{host}:{port}"
+
+    normalized = SplitResult(
+        scheme=scheme,
+        netloc=host,
+        path=parsed.path,
+        query=parsed.query,
+        fragment="",
+    )
+    return urlunsplit(normalized)
+
+
+def artifact_id_for_hash(content_hash: str) -> str:
+    """Return a stable artifact ID for one raw content hash."""
+
+    return _stable_id("artifact", content_hash)
+
+
+def source_unit_id_for_page(page_id: str) -> str:
+    """Return a stable source-unit ID for one existing page record."""
+
+    return _stable_id("source-unit", page_id)
+
+
+def _stable_id(prefix: str, *parts: str) -> str:
+    identity = "\0".join(parts).encode("utf-8")
+    return f"{prefix}-{hashlib.sha256(identity).hexdigest()}"

--- a/newsrag/storage.py
+++ b/newsrag/storage.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
+import json
 import os
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 
+import lancedb  # type: ignore[import-untyped]
+import pyarrow as pa
+
 from newsrag.jobs import DONE, FAILED, PENDING, RUNNING
 from newsrag.passages import build_passage_rows
+from newsrag.sources import (
+    PAGE_LOCATION_TYPE,
+    PDF_MEDIA_TYPE,
+    artifact_id_for_hash,
+    build_source_identity,
+    source_unit_id_for_page,
+)
 
 
 class StorageError(Exception):
@@ -68,8 +79,11 @@ DIRECTORY_NAMES: tuple[tuple[str, str], ...] = (
     ("artifacts", "artifacts"),
 )
 DATABASE_FILENAME = "newsrag.sqlite3"
-SCHEMA_VERSION = "1"
+SCHEMA_VERSION = "2"
 REQUIRED_TABLES = {
+    "sources",
+    "source_artifacts",
+    "source_units",
     "documents",
     "pages",
     "chunks",
@@ -96,6 +110,30 @@ SCHEMA_STATEMENTS = (
     )
     """,
     """
+    CREATE TABLE IF NOT EXISTS sources (
+        id TEXT PRIMARY KEY,
+        kind TEXT NOT NULL,
+        submitted_reference TEXT NOT NULL,
+        normalized_reference TEXT NOT NULL,
+        resolved_reference TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(kind, normalized_reference)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS source_artifacts (
+        id TEXT PRIMARY KEY,
+        source_id TEXT NOT NULL,
+        media_type TEXT NOT NULL,
+        byte_size INTEGER,
+        content_hash TEXT NOT NULL UNIQUE,
+        stored_path TEXT NOT NULL,
+        acquired_at TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(source_id) REFERENCES sources(id)
+    )
+    """,
+    """
     CREATE TABLE IF NOT EXISTS documents (
         id TEXT PRIMARY KEY,
         source_path TEXT,
@@ -104,7 +142,9 @@ SCHEMA_STATEMENTS = (
         source_hash TEXT,
         normalized_path TEXT,
         metadata_json TEXT NOT NULL DEFAULT '{}',
-        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        artifact_id TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(artifact_id) REFERENCES source_artifacts(id)
     )
     """,
     """
@@ -112,10 +152,31 @@ SCHEMA_STATEMENTS = (
         id TEXT PRIMARY KEY,
         document_id TEXT NOT NULL,
         page_number INTEGER NOT NULL,
+        source_unit_id TEXT,
         text TEXT NOT NULL DEFAULT '',
         extractor TEXT NOT NULL DEFAULT 'unknown',
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        FOREIGN KEY(document_id) REFERENCES documents(id)
+        FOREIGN KEY(document_id) REFERENCES documents(id),
+        FOREIGN KEY(source_unit_id) REFERENCES source_units(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS source_units (
+        id TEXT PRIMARY KEY,
+        artifact_id TEXT NOT NULL,
+        document_id TEXT NOT NULL,
+        ordinal INTEGER NOT NULL,
+        location_type TEXT NOT NULL,
+        location_json TEXT NOT NULL DEFAULT '{}',
+        human_label TEXT NOT NULL,
+        normalized_text TEXT NOT NULL DEFAULT '',
+        structure_json TEXT NOT NULL DEFAULT '{}',
+        extractor TEXT NOT NULL,
+        extractor_version TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(artifact_id) REFERENCES source_artifacts(id),
+        FOREIGN KEY(document_id) REFERENCES documents(id),
+        UNIQUE(document_id, ordinal)
     )
     """,
     """
@@ -124,9 +185,13 @@ SCHEMA_STATEMENTS = (
         document_id TEXT NOT NULL,
         page_start INTEGER NOT NULL,
         page_end INTEGER NOT NULL,
+        source_unit_start_id TEXT,
+        source_unit_end_id TEXT,
         text TEXT NOT NULL DEFAULT '',
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        FOREIGN KEY(document_id) REFERENCES documents(id)
+        FOREIGN KEY(document_id) REFERENCES documents(id),
+        FOREIGN KEY(source_unit_start_id) REFERENCES source_units(id),
+        FOREIGN KEY(source_unit_end_id) REFERENCES source_units(id)
     )
     """,
     """
@@ -142,11 +207,15 @@ SCHEMA_STATEMENTS = (
         document_id TEXT NOT NULL,
         page_start INTEGER NOT NULL,
         page_end INTEGER NOT NULL,
+        source_unit_start_id TEXT,
+        source_unit_end_id TEXT,
         ordinal INTEGER NOT NULL,
         text TEXT NOT NULL DEFAULT '',
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY(chunk_id) REFERENCES chunks(id),
-        FOREIGN KEY(document_id) REFERENCES documents(id)
+        FOREIGN KEY(document_id) REFERENCES documents(id),
+        FOREIGN KEY(source_unit_start_id) REFERENCES source_units(id),
+        FOREIGN KEY(source_unit_end_id) REFERENCES source_units(id)
     )
     """,
     """
@@ -193,7 +262,11 @@ SCHEMA_STATEMENTS = (
         model TEXT NOT NULL,
         version TEXT NOT NULL,
         dimensions INTEGER NOT NULL,
-        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        source_unit_start_id TEXT,
+        source_unit_end_id TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY(source_unit_start_id) REFERENCES source_units(id),
+        FOREIGN KEY(source_unit_end_id) REFERENCES source_units(id)
     )
     """,
     """
@@ -304,7 +377,10 @@ def initialize_storage(data_dir: Path) -> StoragePaths:
     for directory in _iter_directories(paths):
         directory.mkdir(parents=True, exist_ok=True)
 
-    _initialize_database(paths.database)
+    vector_migration_required = _initialize_database(paths.database)
+    if vector_migration_required:
+        _backfill_vector_source_unit_ranges(paths.database, paths.lancedb)
+    _set_schema_version(paths.database)
     return paths
 
 
@@ -454,20 +530,55 @@ def _iter_directories(paths: StoragePaths) -> tuple[Path, ...]:
     return tuple(directory for _, directory in _directory_checks(paths))
 
 
-def _initialize_database(database_path: Path) -> None:
+def _initialize_database(database_path: Path) -> bool:
     with sqlite3.connect(database_path) as connection:
         connection.execute("PRAGMA foreign_keys = ON")
         for statement in SCHEMA_STATEMENTS:
             connection.execute(statement)
+        previous_schema_version = connection.execute(
+            "SELECT value FROM metadata WHERE key = 'schema_version'"
+        ).fetchone()
         _ensure_column(connection, "documents", "source_hash", "TEXT")
         _ensure_column(connection, "documents", "normalized_path", "TEXT")
         _ensure_column(connection, "documents", "metadata_json", "TEXT NOT NULL DEFAULT '{}'")
+        _ensure_column(
+            connection,
+            "documents",
+            "artifact_id",
+            "TEXT REFERENCES source_artifacts(id)",
+        )
         _ensure_column(connection, "pages", "extractor", "TEXT NOT NULL DEFAULT 'unknown'")
+        _ensure_column(
+            connection,
+            "pages",
+            "source_unit_id",
+            "TEXT REFERENCES source_units(id)",
+        )
+        for table_name in ("chunks", "passages", "embedding_records"):
+            _ensure_column(
+                connection,
+                table_name,
+                "source_unit_start_id",
+                "TEXT REFERENCES source_units(id)",
+            )
+            _ensure_column(
+                connection,
+                table_name,
+                "source_unit_end_id",
+                "TEXT REFERENCES source_units(id)",
+            )
         _ensure_column(connection, "document_profiles", "provider", "TEXT")
         _ensure_column(connection, "document_briefs", "provider", "TEXT")
         _ensure_column(connection, "discovery_items", "provider", "TEXT")
         connection.execute(
             "CREATE INDEX IF NOT EXISTS idx_documents_source_hash ON documents(source_hash)"
+        )
+        connection.execute(
+            "CREATE INDEX IF NOT EXISTS idx_documents_artifact_id ON documents(artifact_id)"
+        )
+        connection.execute(
+            "CREATE INDEX IF NOT EXISTS idx_source_units_document_ordinal "
+            "ON source_units(document_id, ordinal)"
         )
         connection.execute(
             """
@@ -478,6 +589,7 @@ def _initialize_database(database_path: Path) -> None:
             """
         )
         _backfill_passages(connection)
+        _backfill_pdf_source_model(connection)
         connection.execute(
             """
             INSERT INTO passages_fts(passage_id, text)
@@ -486,11 +598,302 @@ def _initialize_database(database_path: Path) -> None:
             WHERE passages.id NOT IN (SELECT passage_id FROM passages_fts)
             """
         )
+        connection.commit()
+
+    return previous_schema_version is None or str(previous_schema_version[0]) != SCHEMA_VERSION
+
+
+def _set_schema_version(database_path: Path) -> None:
+    with sqlite3.connect(database_path) as connection:
         connection.execute(
-            "INSERT OR IGNORE INTO metadata(key, value) VALUES(?, ?)",
+            """
+            INSERT INTO metadata(key, value) VALUES(?, ?)
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            """,
             ("schema_version", SCHEMA_VERSION),
         )
         connection.commit()
+
+
+def _backfill_vector_source_unit_ranges(database_path: Path, lancedb_path: Path) -> None:
+    database = lancedb.connect(lancedb_path)
+    table_specs = (
+        ("chunk_embeddings", "chunk_id", "chunks"),
+        ("passage_embeddings", "passage_id", "passages"),
+    )
+    for table_name, key_column, sqlite_table in table_specs:
+        try:
+            table = database.open_table(table_name)
+        except ValueError:
+            continue
+
+        missing_fields = [
+            pa.field(column_name, pa.string())
+            for column_name in ("source_unit_start_id", "source_unit_end_id")
+            if column_name not in table.schema.names
+        ]
+        if missing_fields:
+            table.add_columns(missing_fields)
+
+        with sqlite3.connect(database_path) as connection:
+            rows = connection.execute(
+                f"""
+                SELECT id, source_unit_start_id, source_unit_end_id
+                FROM {sqlite_table}
+                WHERE source_unit_start_id IS NOT NULL
+                    AND source_unit_end_id IS NOT NULL
+                ORDER BY id ASC
+                """
+            ).fetchall()
+
+        for source_key, source_unit_start_id, source_unit_end_id in rows:
+            escaped_key = str(source_key).replace("'", "''")
+            table.update(
+                where=(
+                    f"{key_column} = '{escaped_key}' AND "
+                    "(source_unit_start_id IS NULL OR source_unit_end_id IS NULL)"
+                ),
+                values={
+                    "source_unit_start_id": str(source_unit_start_id),
+                    "source_unit_end_id": str(source_unit_end_id),
+                },
+            )
+
+
+def _backfill_pdf_source_model(connection: sqlite3.Connection) -> None:
+    document_rows = connection.execute(
+        """
+        SELECT
+            id,
+            source_path,
+            source_url,
+            source_hash,
+            metadata_json,
+            created_at
+        FROM documents
+        WHERE artifact_id IS NULL
+            AND source_hash IS NOT NULL
+            AND (source_path IS NOT NULL OR source_url IS NOT NULL)
+        ORDER BY created_at ASC, id ASC
+        """
+    ).fetchall()
+
+    for row in document_rows:
+        document_id = str(row[0])
+        raw_source_path = str(row[1]) if row[1] is not None else ""
+        source_url = str(row[2]) if row[2] is not None else None
+        content_hash = str(row[3])
+        metadata = _load_metadata_json(row[4])
+        stored_path = _artifact_stored_path(metadata, raw_source_path)
+        if stored_path is None:
+            continue
+
+        source_identity = build_source_identity(
+            source_path=Path(raw_source_path),
+            source_url=source_url,
+        )
+        artifact_id = artifact_id_for_hash(content_hash)
+        acquired_at = _metadata_text(metadata, "retrieved_at") or str(row[5])
+        byte_size = _artifact_byte_size(metadata, stored_path)
+
+        connection.execute(
+            """
+            INSERT OR IGNORE INTO sources(
+                id,
+                kind,
+                submitted_reference,
+                normalized_reference,
+                resolved_reference
+            )
+            VALUES(?, ?, ?, ?, ?)
+            """,
+            (
+                source_identity.id,
+                source_identity.kind,
+                source_identity.submitted_reference,
+                source_identity.normalized_reference,
+                source_identity.resolved_reference,
+            ),
+        )
+        connection.execute(
+            """
+            INSERT OR IGNORE INTO source_artifacts(
+                id,
+                source_id,
+                media_type,
+                byte_size,
+                content_hash,
+                stored_path,
+                acquired_at
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                artifact_id,
+                source_identity.id,
+                PDF_MEDIA_TYPE,
+                byte_size,
+                content_hash,
+                stored_path,
+                acquired_at,
+            ),
+        )
+        connection.execute(
+            "UPDATE documents SET artifact_id = ? WHERE id = ?",
+            (artifact_id, document_id),
+        )
+
+    page_rows = connection.execute(
+        """
+        SELECT
+            pages.id,
+            pages.document_id,
+            pages.page_number,
+            pages.text,
+            pages.extractor,
+            documents.artifact_id
+        FROM pages
+        JOIN documents ON documents.id = pages.document_id
+        WHERE pages.source_unit_id IS NULL
+            AND documents.artifact_id IS NOT NULL
+        ORDER BY pages.document_id ASC, pages.page_number ASC, pages.id ASC
+        """
+    ).fetchall()
+    for row in page_rows:
+        page_id = str(row[0])
+        document_id = str(row[1])
+        page_number = int(row[2])
+        unit_id = source_unit_id_for_page(page_id)
+        connection.execute(
+            """
+            INSERT OR IGNORE INTO source_units(
+                id,
+                artifact_id,
+                document_id,
+                ordinal,
+                location_type,
+                location_json,
+                human_label,
+                normalized_text,
+                structure_json,
+                extractor
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, '{}', ?)
+            """,
+            (
+                unit_id,
+                str(row[5]),
+                document_id,
+                page_number,
+                PAGE_LOCATION_TYPE,
+                json.dumps({"page_number": page_number}, sort_keys=True),
+                f"p. {page_number}",
+                str(row[3]),
+                str(row[4]),
+            ),
+        )
+        connection.execute(
+            "UPDATE pages SET source_unit_id = ? WHERE id = ?",
+            (unit_id, page_id),
+        )
+
+    for table_name in ("chunks", "passages"):
+        connection.execute(
+            f"""
+            UPDATE {table_name}
+            SET source_unit_start_id = COALESCE(
+                    source_unit_start_id,
+                    (
+                        SELECT pages.source_unit_id
+                        FROM pages
+                        WHERE pages.document_id = {table_name}.document_id
+                            AND pages.page_number = {table_name}.page_start
+                    )
+                ),
+                source_unit_end_id = COALESCE(
+                    source_unit_end_id,
+                    (
+                        SELECT pages.source_unit_id
+                        FROM pages
+                        WHERE pages.document_id = {table_name}.document_id
+                            AND pages.page_number = {table_name}.page_end
+                    )
+                )
+            WHERE document_id IN (
+                    SELECT documents.id
+                    FROM documents
+                    JOIN source_artifacts
+                        ON source_artifacts.id = documents.artifact_id
+                    WHERE source_artifacts.media_type = ?
+                )
+                AND (source_unit_start_id IS NULL OR source_unit_end_id IS NULL)
+            """,
+            (PDF_MEDIA_TYPE,),
+        )
+
+    for source_kind, table_name in (("chunk", "chunks"), ("passage", "passages")):
+        connection.execute(
+            f"""
+            UPDATE embedding_records
+            SET source_unit_start_id = COALESCE(
+                    source_unit_start_id,
+                    (
+                        SELECT {table_name}.source_unit_start_id
+                        FROM {table_name}
+                        WHERE {table_name}.id = embedding_records.source_key
+                    )
+                ),
+                source_unit_end_id = COALESCE(
+                    source_unit_end_id,
+                    (
+                        SELECT {table_name}.source_unit_end_id
+                        FROM {table_name}
+                        WHERE {table_name}.id = embedding_records.source_key
+                    )
+                )
+            WHERE source_kind = ?
+                AND (source_unit_start_id IS NULL OR source_unit_end_id IS NULL)
+            """,
+            (source_kind,),
+        )
+
+
+def _load_metadata_json(raw_metadata: object) -> dict[str, object]:
+    if not isinstance(raw_metadata, str):
+        return {}
+    try:
+        metadata = json.loads(raw_metadata)
+    except ValueError:
+        return {}
+    if not isinstance(metadata, dict):
+        return {}
+    return metadata
+
+
+def _metadata_text(metadata: dict[str, object], key: str) -> str | None:
+    value = metadata.get(key)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _artifact_stored_path(metadata: dict[str, object], source_path: str) -> str | None:
+    stored_path = _metadata_text(metadata, "stored_source_path")
+    if stored_path is not None:
+        return stored_path
+    if source_path:
+        return source_path
+    return None
+
+
+def _artifact_byte_size(metadata: dict[str, object], stored_path: str) -> int | None:
+    stored_size = metadata.get("source_size_bytes")
+    if isinstance(stored_size, int) and not isinstance(stored_size, bool) and stored_size >= 0:
+        return stored_size
+    try:
+        return Path(stored_path).stat().st_size
+    except OSError:
+        return None
 
 
 def _backfill_passages(connection: sqlite3.Connection) -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import sqlite3
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
+import lancedb  # type: ignore[import-untyped]
 import pytest
 from typer.testing import CliRunner
 
@@ -189,10 +192,21 @@ def test_url_ingest_stores_source_url_and_retrieved_at(
     )
 
     documents = list_documents(paths.database)
+    with sqlite3.connect(paths.database) as connection:
+        connection.row_factory = sqlite3.Row
+        source = connection.execute("SELECT * FROM sources").fetchone()
+        artifact = connection.execute("SELECT * FROM source_artifacts").fetchone()
 
     assert len(documents) == 1
     assert documents[0].source_url == url
     assert documents[0].metadata["retrieved_at"] == retrieved_at
+    assert source is not None
+    assert source["kind"] == "url"
+    assert source["submitted_reference"] == url
+    assert source["normalized_reference"] == url
+    assert artifact is not None
+    assert artifact["source_id"] == source["id"]
+    assert artifact["acquired_at"] == retrieved_at
 
 
 def test_ingest_url_rejects_non_pdf_responses(
@@ -465,6 +479,30 @@ def test_mocked_local_pdf_job_creates_document_pages_chunks_and_vector_records(
     chunks = list_chunks(paths.database)
     vectors = list_chunk_vectors(paths.lancedb)
     embedding_records = list_embedding_records(paths.database)
+    with sqlite3.connect(paths.database) as connection:
+        connection.row_factory = sqlite3.Row
+        source = connection.execute("SELECT * FROM sources").fetchone()
+        artifact = connection.execute("SELECT * FROM source_artifacts").fetchone()
+        source_units = connection.execute(
+            "SELECT * FROM source_units ORDER BY ordinal ASC"
+        ).fetchall()
+        chunk_ranges = connection.execute(
+            """
+            SELECT source_unit_start_id, source_unit_end_id
+            FROM chunks
+            ORDER BY page_start ASC
+            """
+        ).fetchall()
+        passage_ranges = connection.execute(
+            """
+            SELECT source_unit_start_id, source_unit_end_id
+            FROM passages
+            ORDER BY page_start ASC, ordinal ASC
+            """
+        ).fetchall()
+    passage_vectors = (
+        lancedb.connect(paths.lancedb).open_table("passage_embeddings").to_arrow().to_pylist()
+    )
 
     assert processed is True
     assert get_job(paths.database, job.id).status == "done"
@@ -478,7 +516,36 @@ def test_mocked_local_pdf_job_creates_document_pages_chunks_and_vector_records(
     assert len(embedding_records) == 4
     assert {record.source_kind for record in embedding_records} == {"chunk", "passage"}
     assert {record.provider for record in embedding_records} == {"openai_compatible"}
+    assert source is not None
+    assert source["kind"] == "local_path"
+    assert source["submitted_reference"] == str(source_pdf.resolve())
+    assert artifact is not None
+    assert artifact["source_id"] == source["id"]
+    assert artifact["content_hash"] == documents[0].source_hash
+    assert artifact["byte_size"] == source_pdf.stat().st_size
+    assert len(source_units) == 2
+    assert [unit["ordinal"] for unit in source_units] == [1, 2]
+    assert [json.loads(unit["location_json"]) for unit in source_units] == [
+        {"page_number": 1},
+        {"page_number": 2},
+    ]
+    assert [unit["human_label"] for unit in source_units] == ["p. 1", "p. 2"]
+    unit_ids = [str(unit["id"]) for unit in source_units]
+    assert [tuple(row) for row in chunk_ranges] == [
+        (unit_ids[0], unit_ids[0]),
+        (unit_ids[1], unit_ids[1]),
+    ]
+    assert [tuple(row) for row in passage_ranges] == [
+        (unit_ids[0], unit_ids[0]),
+        (unit_ids[1], unit_ids[1]),
+    ]
     assert {vector["document_id"] for vector in vectors} == {documents[0].id}
+    assert {vector["source_unit_start_id"] for vector in vectors} == set(unit_ids)
+    assert {vector["source_unit_end_id"] for vector in vectors} == set(unit_ids)
+    assert {vector["source_unit_start_id"] for vector in passage_vectors} == set(unit_ids)
+    assert {vector["source_unit_end_id"] for vector in passage_vectors} == set(unit_ids)
+    assert {record.source_unit_start_id for record in embedding_records} == set(unit_ids)
+    assert {record.source_unit_end_id for record in embedding_records} == set(unit_ids)
 
 
 def test_build_pdf_text_extractor_can_choose_extraction_path_under_test() -> None:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -19,6 +19,7 @@ from newsrag.search import (
     build_search_engine,
     format_citation,
     format_search_results,
+    merge_search_candidates,
     search_keyword_candidates,
 )
 from newsrag.storage import initialize_storage
@@ -119,6 +120,126 @@ def test_search_over_indexed_passages_returns_ranked_cited_passages(tmp_path: Pa
         "passage-e",
         "passage-f",
     }
+
+
+def test_search_candidates_and_results_retain_source_unit_ranges(tmp_path: Path) -> None:
+    database_path = initialize_storage(tmp_path / ".newsrag").database
+
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+            VALUES('source-1', 'local_path', '/tmp/report.pdf', '/tmp/report.pdf')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, byte_size, content_hash, stored_path, acquired_at
+            )
+            VALUES('artifact-1', 'source-1', 'application/pdf', 10, 'hash-1', '/tmp/report.pdf', CURRENT_TIMESTAMP)
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO documents(
+                id, source_path, title, source_hash, metadata_json, artifact_id
+            )
+            VALUES(
+                'document-1',
+                '/tmp/report.pdf',
+                'Stormwater Report',
+                'hash-1',
+                '{"meeting_date": "2026-05-01"}',
+                'artifact-1'
+            )
+            """
+        )
+        connection.executemany(
+            """
+            INSERT INTO source_units(
+                id,
+                artifact_id,
+                document_id,
+                ordinal,
+                location_type,
+                location_json,
+                human_label,
+                normalized_text,
+                extractor
+            )
+            VALUES(?, 'artifact-1', 'document-1', ?, 'page', ?, ?, ?, 'pymupdf')
+            """,
+            [
+                ("unit-1", 1, '{"page_number": 1}', "p. 1", "stormwater"),
+                ("unit-2", 2, '{"page_number": 2}', "p. 2", "improvements"),
+            ],
+        )
+        connection.execute(
+            """
+            INSERT INTO chunks(
+                id,
+                document_id,
+                page_start,
+                page_end,
+                source_unit_start_id,
+                source_unit_end_id,
+                text
+            )
+            VALUES('chunk-1', 'document-1', 1, 2, 'unit-1', 'unit-2', 'stormwater improvements')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO passages(
+                id,
+                chunk_id,
+                document_id,
+                page_start,
+                page_end,
+                source_unit_start_id,
+                source_unit_end_id,
+                ordinal,
+                text
+            )
+            VALUES(
+                'passage-1',
+                'chunk-1',
+                'document-1',
+                1,
+                2,
+                'unit-1',
+                'unit-2',
+                1,
+                'stormwater improvements'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO passages_fts(passage_id, text)
+            VALUES('passage-1', 'stormwater improvements')
+            """
+        )
+        connection.commit()
+
+    candidates = search_keyword_candidates(database_path, "stormwater", limit=5)
+    results = merge_search_candidates(
+        candidates,
+        [],
+        database_path=database_path,
+        limit=5,
+        keyword_weight=0.6,
+        vector_weight=0.4,
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].source_unit_start_id == "unit-1"
+    assert candidates[0].source_unit_end_id == "unit-2"
+    assert len(results) == 1
+    assert results[0].source_unit_start_id == "unit-1"
+    assert results[0].source_unit_end_id == "unit-2"
+    assert results[0].citation == "Stormwater Report — 2026-05-01 — p. 1"
 
 
 def test_search_filters_by_document_metadata_and_meeting_date(tmp_path: Path) -> None:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from newsrag.sources import (
+    SOURCE_KIND_LOCAL_PATH,
+    SOURCE_KIND_URL,
+    artifact_id_for_hash,
+    build_source_identity,
+    normalize_url_reference,
+    source_unit_id_for_page,
+)
+
+
+def test_normalize_url_reference_uses_conservative_identity_rules() -> None:
+    assert (
+        normalize_url_reference("HTTPS://Example.COM:443/Reports/Packet/?view=full#page-2")
+        == "https://example.com/Reports/Packet/?view=full"
+    )
+    assert normalize_url_reference("http://Example.COM:8080/a") == "http://example.com:8080/a"
+
+
+def test_build_source_identity_distinguishes_urls_and_local_paths(tmp_path: Path) -> None:
+    local_path = tmp_path / "Packet.PDF"
+    local_identity = build_source_identity(source_path=local_path, source_url=None)
+    url_identity = build_source_identity(
+        source_path=local_path,
+        source_url="https://example.test/Packet.PDF",
+    )
+
+    assert local_identity.kind == SOURCE_KIND_LOCAL_PATH
+    assert local_identity.submitted_reference == str(local_path)
+    assert local_identity.normalized_reference == str(local_path.resolve())
+    assert url_identity.kind == SOURCE_KIND_URL
+    assert url_identity.submitted_reference == "https://example.test/Packet.PDF"
+    assert url_identity.normalized_reference == "https://example.test/Packet.PDF"
+    assert local_identity.id != url_identity.id
+
+
+def test_derived_artifact_and_source_unit_ids_are_stable() -> None:
+    assert artifact_id_for_hash("hash-a") == artifact_id_for_hash("hash-a")
+    assert artifact_id_for_hash("hash-a") != artifact_id_for_hash("hash-b")
+    assert source_unit_id_for_page("page-1") == source_unit_id_for_page("page-1")
+    assert source_unit_id_for_page("page-1") != source_unit_id_for_page("page-2")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import sqlite3
 from pathlib import Path
 
+import lancedb  # type: ignore[import-untyped]
 import pytest
 from typer.testing import CliRunner
 
 from newsrag.cli import app
-from newsrag.storage import REQUIRED_TABLES, StorageError, _existing_tables, initialize_storage
+from newsrag.storage import (
+    REQUIRED_TABLES,
+    StorageError,
+    _existing_tables,
+    build_storage_paths,
+    initialize_storage,
+)
 from newsrag.watches import add_watch
 
 runner = CliRunner()
@@ -60,6 +69,12 @@ def test_initialize_storage_backfills_passages_from_existing_chunks(tmp_path: Pa
         )
         connection.execute(
             """
+            INSERT INTO pages(id, document_id, page_number, text, extractor)
+            VALUES('page-1', 'document-1', 10, 'City agenda', 'pymupdf')
+            """
+        )
+        connection.execute(
+            """
             INSERT INTO chunks(id, document_id, page_start, page_end, text)
             VALUES(?, ?, ?, ?, ?)
             """,
@@ -77,7 +92,11 @@ def test_initialize_storage_backfills_passages_from_existing_chunks(tmp_path: Pa
 
     with sqlite3.connect(paths.database) as connection:
         passage_rows = connection.execute(
-            "SELECT id, text FROM passages ORDER BY ordinal ASC"
+            """
+            SELECT id, text, source_unit_start_id, source_unit_end_id
+            FROM passages
+            ORDER BY ordinal ASC
+            """
         ).fetchall()
         fts_rows = connection.execute(
             "SELECT passage_id, text FROM passages_fts ORDER BY passage_id ASC"
@@ -86,7 +105,289 @@ def test_initialize_storage_backfills_passages_from_existing_chunks(tmp_path: Pa
     assert len(passage_rows) == 2
     assert "Paperbacks & Playdates Book Club" in passage_rows[0][1]
     assert "Brown Bag Book Club" in passage_rows[1][1]
+    assert passage_rows[0][2] is not None
+    assert passage_rows[0][2] == passage_rows[0][3]
+    assert passage_rows[1][2] == passage_rows[0][2]
+    assert passage_rows[1][3] == passage_rows[0][3]
     assert len(fts_rows) == 2
+
+
+def test_initialize_storage_migrates_pdf_records_to_source_units(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    source_pdf = tmp_path / "report.pdf"
+    source_bytes = b"%PDF-1.4\nlegacy"
+    source_pdf.write_bytes(source_bytes)
+    source_hash = hashlib.sha256(source_bytes).hexdigest()
+    paths = build_storage_paths(data_dir)
+    paths.data_dir.mkdir(parents=True)
+    paths.lancedb.mkdir()
+
+    with sqlite3.connect(paths.database) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            INSERT INTO metadata(key, value) VALUES('schema_version', '1');
+
+            CREATE TABLE documents (
+                id TEXT PRIMARY KEY,
+                source_path TEXT,
+                source_url TEXT,
+                title TEXT,
+                source_hash TEXT,
+                normalized_path TEXT,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE pages (
+                id TEXT PRIMARY KEY,
+                document_id TEXT NOT NULL,
+                page_number INTEGER NOT NULL,
+                text TEXT NOT NULL DEFAULT '',
+                extractor TEXT NOT NULL DEFAULT 'unknown',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE chunks (
+                id TEXT PRIMARY KEY,
+                document_id TEXT NOT NULL,
+                page_start INTEGER NOT NULL,
+                page_end INTEGER NOT NULL,
+                text TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE passages (
+                id TEXT PRIMARY KEY,
+                chunk_id TEXT NOT NULL,
+                document_id TEXT NOT NULL,
+                page_start INTEGER NOT NULL,
+                page_end INTEGER NOT NULL,
+                ordinal INTEGER NOT NULL,
+                text TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE embedding_records (
+                id TEXT PRIMARY KEY,
+                source_kind TEXT NOT NULL,
+                source_key TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                model TEXT NOT NULL,
+                version TEXT NOT NULL,
+                dimensions INTEGER NOT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO documents(id, source_path, title, source_hash, normalized_path, metadata_json)
+            VALUES(?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "document-1",
+                str(source_pdf),
+                "Report",
+                source_hash,
+                "/tmp/report-ocr.pdf",
+                json.dumps(
+                    {
+                        "source_size_bytes": len(source_bytes),
+                        "stored_source_path": str(source_pdf),
+                    }
+                ),
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO pages(id, document_id, page_number, text, extractor)
+            VALUES(?, ?, ?, ?, ?)
+            """,
+            ("page-1", "document-1", 1, "Council agenda", "pymupdf"),
+        )
+        connection.execute(
+            """
+            INSERT INTO chunks(id, document_id, page_start, page_end, text)
+            VALUES(?, ?, ?, ?, ?)
+            """,
+            ("chunk-1", "document-1", 1, 1, "Council agenda"),
+        )
+        connection.execute(
+            """
+            INSERT INTO passages(id, chunk_id, document_id, page_start, page_end, ordinal, text)
+            VALUES(?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("passage-1", "chunk-1", "document-1", 1, 1, 1, "Council agenda"),
+        )
+        connection.execute(
+            """
+            INSERT INTO embedding_records(
+                id, source_kind, source_key, provider, model, version, dimensions
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("embedding-1", "passage", "passage-1", "test", "model", "v1", 2),
+        )
+        connection.commit()
+
+    lance_database = lancedb.connect(paths.lancedb)
+    lance_database.create_table(
+        "chunk_embeddings",
+        data=[
+            {
+                "chunk_id": "chunk-1",
+                "document_id": "document-1",
+                "page_start": 1,
+                "page_end": 1,
+                "text": "Council agenda",
+                "vector": [0.1, 0.2],
+            }
+        ],
+    )
+    lance_database.create_table(
+        "passage_embeddings",
+        data=[
+            {
+                "passage_id": "passage-1",
+                "document_id": "document-1",
+                "page_start": 1,
+                "page_end": 1,
+                "text": "Council agenda",
+                "vector": [0.1, 0.2],
+            }
+        ],
+    )
+
+    initialize_storage(data_dir)
+
+    with sqlite3.connect(paths.database) as connection:
+        connection.row_factory = sqlite3.Row
+        source = connection.execute("SELECT * FROM sources").fetchone()
+        artifact = connection.execute("SELECT * FROM source_artifacts").fetchone()
+        document = connection.execute(
+            "SELECT artifact_id FROM documents WHERE id = 'document-1'"
+        ).fetchone()
+        unit = connection.execute("SELECT * FROM source_units").fetchone()
+        page = connection.execute("SELECT source_unit_id FROM pages WHERE id = 'page-1'").fetchone()
+        chunk = connection.execute(
+            "SELECT source_unit_start_id, source_unit_end_id FROM chunks WHERE id = 'chunk-1'"
+        ).fetchone()
+        passage = connection.execute(
+            "SELECT source_unit_start_id, source_unit_end_id FROM passages WHERE id = 'passage-1'"
+        ).fetchone()
+        embedding = connection.execute(
+            """
+            SELECT source_unit_start_id, source_unit_end_id
+            FROM embedding_records
+            WHERE id = 'embedding-1'
+            """
+        ).fetchone()
+    chunk_vector = lance_database.open_table("chunk_embeddings").to_arrow().to_pylist()[0]
+    passage_vector = lance_database.open_table("passage_embeddings").to_arrow().to_pylist()[0]
+
+    assert source is not None
+    assert source["kind"] == "local_path"
+    assert source["submitted_reference"] == str(source_pdf)
+    assert source["normalized_reference"] == str(source_pdf.resolve())
+    assert artifact is not None
+    assert artifact["source_id"] == source["id"]
+    assert artifact["media_type"] == "application/pdf"
+    assert artifact["byte_size"] == len(source_bytes)
+    assert artifact["content_hash"] == source_hash
+    assert artifact["stored_path"] == str(source_pdf)
+    assert document is not None
+    assert document["artifact_id"] == artifact["id"]
+    assert unit is not None
+    assert unit["artifact_id"] == artifact["id"]
+    assert unit["document_id"] == "document-1"
+    assert unit["ordinal"] == 1
+    assert unit["location_type"] == "page"
+    assert json.loads(unit["location_json"]) == {"page_number": 1}
+    assert unit["human_label"] == "p. 1"
+    assert unit["normalized_text"] == "Council agenda"
+    assert unit["extractor"] == "pymupdf"
+    assert page is not None
+    assert page["source_unit_id"] == unit["id"]
+    assert chunk is not None
+    assert tuple(chunk) == (unit["id"], unit["id"])
+    assert passage is not None
+    assert tuple(passage) == (unit["id"], unit["id"])
+    assert embedding is not None
+    assert tuple(embedding) == (unit["id"], unit["id"])
+    assert chunk_vector["source_unit_start_id"] == unit["id"]
+    assert chunk_vector["source_unit_end_id"] == unit["id"]
+    assert passage_vector["source_unit_start_id"] == unit["id"]
+    assert passage_vector["source_unit_end_id"] == unit["id"]
+
+
+def test_source_unit_locations_can_represent_non_page_units(tmp_path: Path) -> None:
+    paths = initialize_storage(tmp_path / ".newsrag")
+
+    with sqlite3.connect(paths.database) as connection:
+        connection.execute(
+            """
+            INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+            VALUES('source-html', 'url', 'https://example.test/update', 'https://example.test/update')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, byte_size, content_hash, stored_path, acquired_at
+            )
+            VALUES('artifact-html', 'source-html', 'text/html', 10, 'hash-html', '/tmp/update.html', CURRENT_TIMESTAMP)
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO documents(id, title, source_hash, metadata_json, artifact_id)
+            VALUES('document-html', 'Update', 'hash-html', '{}', 'artifact-html')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_units(
+                id,
+                artifact_id,
+                document_id,
+                ordinal,
+                location_type,
+                location_json,
+                human_label,
+                normalized_text,
+                structure_json,
+                extractor
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "source-unit-html-1",
+                "artifact-html",
+                "document-html",
+                1,
+                "html_block",
+                json.dumps({"block_number": 1, "heading_path": ["Budget"]}),
+                "Budget — block 1",
+                "Proposed budget",
+                json.dumps({"content_kind": "paragraph"}),
+                "static-html-v1",
+            ),
+        )
+        connection.commit()
+
+        row = connection.execute(
+            """
+            SELECT location_type, location_json, human_label, structure_json
+            FROM source_units
+            WHERE id = 'source-unit-html-1'
+            """
+        ).fetchone()
+
+    assert row is not None
+    assert row[0] == "html_block"
+    assert json.loads(row[1]) == {"block_number": 1, "heading_path": ["Budget"]}
+    assert row[2] == "Budget — block 1"
+    assert json.loads(row[3]) == {"content_kind": "paragraph"}
 
 
 def test_initialize_storage_rejects_file_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Add the source-neutral storage foundation for immutable raw artifacts and ordered canonical source units while preserving current PDF behavior and citations.

## Task

task-dbf01cd8

## Changes

- Add corpus-local source identities, immutable artifact records, and typed ordered source units.
- Migrate existing PDF documents, pages, chunks, passages, embedding provenance, and LanceDB vectors to source-unit references.
- Persist new PDF ingestion through the shared source/artifact/unit model.
- Carry source-unit ranges through vector rows, search candidates, and search results without changing page citations.
- Document the shared entities and add migration, ingestion, retrieval, and identity tests.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- `./scripts/pre-pr.sh` — 156 tests passed; Ruff and mypy passed.

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
