### PR TITLE
Add shared source adapter pipeline

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,6 +71,14 @@ Processing is idempotent. The system hashes source content to avoid duplicate in
 
 The OCR stage uses `ocrmypdf` with Tesseract and its required supporting tools. Text extraction uses PyMuPDF as the primary extractor and pdfplumber as a fallback or table-oriented extraction path. Each extracted page is stored as an ordered page source unit before chunking, and source-unit ranges propagate through chunks, passages, embeddings, and search results while existing page citations remain stable.
 
+## Source adapter contract
+
+A format adapter receives an `AdapterInput` identifying one immutable raw artifact, its validated media type and content hash, an isolated work directory, and format-specific options. Its `extract` method must validate the artifact and return an `AdapterResult` containing ordered `CanonicalSourceUnit` values, extractor identity, validated media type, and any derived artifact used for extraction.
+
+Each canonical source unit has a contiguous one-based ordinal, typed machine location, human-readable location label, normalized text, structure metadata, and extractor name/version. Adapters do not chunk, embed, index, publish documents, or modify source identity. Those stages belong to the shared ingestion pipeline.
+
+PDF is the first implementation of this contract. The PDF adapter validates the raw PDF, runs the existing OCR and extraction fallback behavior, and emits one page source unit per PDF page. The shared pipeline then performs page-compatible chunking, passage generation, embeddings, FTS/vector indexing, and publication. SQLite publication is transactional; failed vector publication rolls back the document bundle and removes staged vectors so incomplete documents cannot appear in search.
+
 ## Chunking and citations
 
 The MVP uses page-first chunking. Each page is stored as canonical extracted text. Short pages may produce one chunk; long pages are split into overlapping passages while preserving page start/end. This keeps citations simple and reliable for city hall PDFs, where page numbers are often the most important reference.

--- a/newsrag/adapters.py
+++ b/newsrag/adapters.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+
+class AdapterError(Exception):
+    """Raised when a source adapter cannot validate or extract an artifact."""
+
+
+@dataclass(frozen=True)
+class ExtractorIdentity:
+    """Stable identity metadata for one source extractor."""
+
+    name: str
+    version: str | None = None
+
+
+@dataclass(frozen=True)
+class AdapterInput:
+    """One immutable raw artifact supplied to a format adapter."""
+
+    artifact_path: Path
+    content_hash: str
+    media_type: str
+    work_dir: Path
+    options: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CanonicalSourceUnit:
+    """One ordered, source-neutral unit emitted by an adapter."""
+
+    ordinal: int
+    location_type: str
+    location: dict[str, object]
+    human_label: str
+    normalized_text: str
+    structure: dict[str, object]
+    extractor: ExtractorIdentity
+
+
+@dataclass(frozen=True)
+class AdapterResult:
+    """Validated canonical output from one source adapter."""
+
+    media_type: str
+    units: tuple[CanonicalSourceUnit, ...]
+    extractor: ExtractorIdentity
+    derived_artifact_path: Path | None = None
+
+
+class SourceAdapter(Protocol):
+    """Validate one raw artifact and return ordered canonical source units."""
+
+    @property
+    def media_types(self) -> Sequence[str]:
+        """Return the validated media types accepted by this adapter."""
+
+    def extract(self, artifact: AdapterInput) -> AdapterResult:
+        """Validate and extract one immutable raw artifact."""

--- a/newsrag/ingest.py
+++ b/newsrag/ingest.py
@@ -5,30 +5,56 @@ import hashlib
 import json
 import shutil
 import sqlite3
-import subprocess
 import uuid
-from collections.abc import Awaitable, Callable, Sequence
-from dataclasses import dataclass, field
+from collections.abc import Awaitable, Callable, Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal, Protocol
+from typing import Any, Protocol
 from urllib.parse import unquote, urlparse
 
-import fitz  # type: ignore[import-untyped]
 import httpx
 import lancedb  # type: ignore[import-untyped]
-import pdfplumber
 
+from newsrag.adapters import (
+    AdapterError,
+    AdapterInput,
+    AdapterResult,
+    CanonicalSourceUnit,
+    ExtractorIdentity,
+    SourceAdapter,
+)
 from newsrag.config import EmbeddingConfig
 from newsrag.embeddings import (
     ChunkEmbedding,
     EmbeddingMetadata,
     EmbeddingProvider,
     build_embedding_provider,
-    create_embedding_record,
 )
 from newsrag.jobs import Job, create_job
 from newsrag.passages import build_passage_rows
+from newsrag.pdf_adapter import (
+    PDF_EXTRACTOR_AUTO,
+    PDF_EXTRACTOR_PDFPLUMBER,
+    PDF_EXTRACTOR_PYMUPDF,
+    PDF_EXTRACTOR_TABLE,
+    ExtractedPage,
+    FallbackTextExtractor,
+    OcrRunner,
+    PdfExtractorMode,
+    PdfPlumberTextExtractor,
+    PdfSourceAdapter,
+    PyMuPdfTextExtractor,
+    SubprocessOcrRunner,
+    TextExtractor,
+)
+from newsrag.pdf_adapter import (
+    build_pdf_text_extractor as _build_pdf_text_extractor,
+)
+from newsrag.pdf_adapter import (
+    normalize_pdf_extractor_mode as _normalize_pdf_extractor_mode,
+)
 from newsrag.search import LanceDbPassageVectorStore, PassageVectorRecord
 from newsrag.sources import (
     PAGE_LOCATION_TYPE,
@@ -36,41 +62,36 @@ from newsrag.sources import (
     SourceIdentity,
     artifact_id_for_hash,
     build_source_identity,
+    source_unit_id_for_ordinal,
     source_unit_id_for_page,
 )
 from newsrag.storage import StoragePaths, initialize_storage
+
+__all__ = [
+    "ExtractedPage",
+    "FallbackTextExtractor",
+    "PDF_EXTRACTOR_AUTO",
+    "PDF_EXTRACTOR_PDFPLUMBER",
+    "PDF_EXTRACTOR_PYMUPDF",
+    "PDF_EXTRACTOR_TABLE",
+    "PreparedSourceArtifact",
+    "PdfPlumberTextExtractor",
+    "PyMuPdfTextExtractor",
+    "SourceAdapter",
+    "SourceProcessingPipeline",
+    "build_pdf_text_extractor",
+    "normalize_pdf_extractor_mode",
+]
 
 INGEST_JOB_KIND = "ingest-file"
 DEFAULT_CHUNK_MAX_CHARS = 2000
 DEFAULT_CHUNK_OVERLAP_CHARS = 200
 DEFAULT_DOWNLOAD_TIMEOUT_SECONDS = 30.0
 VECTOR_TABLE_NAME = "chunk_embeddings"
-PDF_EXTRACTOR_AUTO: Literal["auto"] = "auto"
-PDF_EXTRACTOR_PYMUPDF: Literal["pymupdf"] = "pymupdf"
-PDF_EXTRACTOR_PDFPLUMBER: Literal["pdfplumber"] = "pdfplumber"
-PDF_EXTRACTOR_TABLE: Literal["table"] = "table"
-PDF_EXTRACTOR_MODES = frozenset(
-    {
-        PDF_EXTRACTOR_AUTO,
-        PDF_EXTRACTOR_PYMUPDF,
-        PDF_EXTRACTOR_PDFPLUMBER,
-        PDF_EXTRACTOR_TABLE,
-    }
-)
-PdfExtractorMode = Literal["auto", "pymupdf", "pdfplumber", "table"]
 
 
 class IngestError(Exception):
     """Raised when local PDF ingestion cannot complete."""
-
-
-@dataclass(frozen=True)
-class ExtractedPage:
-    """Canonical page text extracted from one PDF page."""
-
-    page_number: int
-    text: str
-    extractor: str = "unknown"
 
 
 @dataclass(frozen=True)
@@ -80,6 +101,8 @@ class ChunkDraft:
     text: str
     page_start: int
     page_end: int
+    source_unit_start_ordinal: int | None = None
+    source_unit_end_ordinal: int | None = None
 
 
 @dataclass(frozen=True)
@@ -155,32 +178,31 @@ class PdfDownloader(Protocol):
         """Download one direct PDF into the corpus data directory."""
 
 
-class OcrRunner(Protocol):
-    """Protocol for OCR normalization."""
-
-    def normalize_pdf(self, source_path: Path, output_path: Path) -> None:
-        """Create an OCR-normalized PDF artifact."""
-
-
-class TextExtractor(Protocol):
-    """Protocol for page-text extraction."""
-
-    def extract_pages(self, pdf_path: Path) -> list[ExtractedPage]:
-        """Extract canonical page text from one PDF."""
-
-
 class Chunker(Protocol):
-    """Protocol for page-to-chunk conversion."""
+    """Protocol for canonical-source-unit chunking."""
 
-    def chunk_pages(self, pages: Sequence[ExtractedPage]) -> list[ChunkDraft]:
-        """Split extracted pages into searchable chunks."""
+    def chunk_units(self, units: Sequence[CanonicalSourceUnit]) -> list[ChunkDraft]:
+        """Split canonical source units into searchable chunks."""
 
 
 class VectorStore(Protocol):
-    """Protocol for vector persistence."""
+    """Protocol for chunk-vector persistence."""
 
     def add_chunks(self, chunks: Sequence[ChunkVectorRecord]) -> None:
         """Persist embedded chunk vectors."""
+
+    def delete_document(self, document_id: str) -> None:
+        """Remove staged vectors for one failed document publication."""
+
+
+class PassageVectorStore(Protocol):
+    """Protocol for passage-vector persistence."""
+
+    def add_passages(self, passages: Sequence[PassageVectorRecord]) -> None:
+        """Persist embedded passage vectors."""
+
+    def delete_document(self, document_id: str) -> None:
+        """Remove staged vectors for one failed document publication."""
 
 
 @dataclass(frozen=True)
@@ -215,147 +237,65 @@ class HttpxPdfDownloader:
         )
 
 
-@dataclass(frozen=True)
-class SubprocessOcrRunner:
-    """OCR normalization backed by the `ocrmypdf` CLI."""
-
-    def normalize_pdf(self, source_path: Path, output_path: Path) -> None:
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            subprocess.run(
-                [
-                    "ocrmypdf",
-                    "--skip-text",
-                    "--quiet",
-                    str(source_path),
-                    str(output_path),
-                ],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as exc:
-            detail = (exc.stderr or exc.stdout or str(exc)).strip()
-            raise IngestError(f"ocrmypdf failed for {source_path}: {detail}") from exc
-
-
-@dataclass(frozen=True)
-class PyMuPdfTextExtractor:
-    """Text extraction backed by PyMuPDF."""
-
-    extractor_name: str = PDF_EXTRACTOR_PYMUPDF
-
-    def extract_pages(self, pdf_path: Path) -> list[ExtractedPage]:
-        try:
-            pages: list[ExtractedPage] = []
-            with fitz.open(pdf_path) as document:
-                for index, page in enumerate(document, start=1):
-                    pages.append(
-                        ExtractedPage(
-                            page_number=index,
-                            text=page.get_text().strip(),
-                            extractor=self.extractor_name,
-                        )
-                    )
-            return pages
-        except Exception as exc:
-            raise IngestError(f"PyMuPDF extraction failed for {pdf_path}: {exc}") from exc
-
-
-@dataclass(frozen=True)
-class PdfPlumberTextExtractor:
-    """Text extraction backed by pdfplumber."""
-
-    extractor_name: str = PDF_EXTRACTOR_PDFPLUMBER
-
-    def extract_pages(self, pdf_path: Path) -> list[ExtractedPage]:
-        try:
-            pages: list[ExtractedPage] = []
-            with pdfplumber.open(pdf_path) as document:
-                for index, page in enumerate(document.pages, start=1):
-                    text = page.extract_text() or ""
-                    pages.append(
-                        ExtractedPage(
-                            page_number=index,
-                            text=text.strip(),
-                            extractor=self.extractor_name,
-                        )
-                    )
-            return pages
-        except Exception as exc:
-            raise IngestError(f"pdfplumber extraction failed for {pdf_path}: {exc}") from exc
-
-
-@dataclass(frozen=True)
-class FallbackTextExtractor:
-    """Run a primary extractor and fall back when page text quality is unusable."""
-
-    primary: TextExtractor = field(default_factory=PyMuPdfTextExtractor)
-    fallback: TextExtractor = field(default_factory=PdfPlumberTextExtractor)
-
-    def extract_pages(self, pdf_path: Path) -> list[ExtractedPage]:
-        primary_pages = _extract_with_stage_context(
-            self.primary,
-            pdf_path,
-            stage="primary",
-        )
-        if not _has_usable_page_text(primary_pages):
-            return _extract_with_stage_context(
-                self.fallback,
-                pdf_path,
-                stage="fallback",
-            )
-        return primary_pages
-
-
 def build_pdf_text_extractor(mode: PdfExtractorMode = PDF_EXTRACTOR_AUTO) -> TextExtractor:
     """Build the configured PDF text extraction path."""
 
-    if mode == PDF_EXTRACTOR_AUTO:
-        return FallbackTextExtractor()
-    if mode == PDF_EXTRACTOR_PYMUPDF:
-        return PyMuPdfTextExtractor()
-    if mode in {PDF_EXTRACTOR_PDFPLUMBER, PDF_EXTRACTOR_TABLE}:
-        return PdfPlumberTextExtractor()
-    raise IngestError(f"Unsupported PDF extractor mode: {mode}")
+    try:
+        return _build_pdf_text_extractor(mode)
+    except AdapterError as exc:
+        raise IngestError(str(exc)) from exc
 
 
 def normalize_pdf_extractor_mode(value: str | None) -> PdfExtractorMode:
     """Normalize and validate a PDF extractor mode option."""
 
-    if value is None or not value.strip():
-        return PDF_EXTRACTOR_AUTO
-
-    normalized = value.strip().lower()
-    if normalized == PDF_EXTRACTOR_AUTO:
-        return PDF_EXTRACTOR_AUTO
-    if normalized == PDF_EXTRACTOR_PYMUPDF:
-        return PDF_EXTRACTOR_PYMUPDF
-    if normalized == PDF_EXTRACTOR_PDFPLUMBER:
-        return PDF_EXTRACTOR_PDFPLUMBER
-    if normalized == PDF_EXTRACTOR_TABLE:
-        return PDF_EXTRACTOR_TABLE
-
-    allowed = ", ".join(sorted(PDF_EXTRACTOR_MODES))
-    raise IngestError(f"Unsupported PDF extractor mode: {value}; expected one of: {allowed}")
+    try:
+        return _normalize_pdf_extractor_mode(value)
+    except AdapterError as exc:
+        raise IngestError(str(exc)) from exc
 
 
 @dataclass(frozen=True)
 class PageChunker:
-    """Page-first chunking with simple overlap for long pages."""
+    """Source-unit chunking that preserves existing page-first PDF behavior."""
 
     max_chars: int = DEFAULT_CHUNK_MAX_CHARS
     overlap_chars: int = DEFAULT_CHUNK_OVERLAP_CHARS
 
     def chunk_pages(self, pages: Sequence[ExtractedPage]) -> list[ChunkDraft]:
+        """Retain the existing page-based entry point for compatibility."""
+
+        return self.chunk_units(
+            [
+                CanonicalSourceUnit(
+                    ordinal=page.page_number,
+                    location_type=PAGE_LOCATION_TYPE,
+                    location={"page_number": page.page_number},
+                    human_label=f"p. {page.page_number}",
+                    normalized_text=page.text,
+                    structure={},
+                    extractor=_extractor_identity(page.extractor),
+                )
+                for page in pages
+            ]
+        )
+
+    def chunk_units(self, units: Sequence[CanonicalSourceUnit]) -> list[ChunkDraft]:
         chunks: list[ChunkDraft] = []
-        for page in pages:
-            text = page.text.strip()
+        for unit in units:
+            page_number = _page_number(unit)
+            text = unit.normalized_text.strip()
             if not text:
                 continue
             if len(text) <= self.max_chars:
                 chunks.append(
-                    ChunkDraft(text=text, page_start=page.page_number, page_end=page.page_number)
+                    ChunkDraft(
+                        text=text,
+                        page_start=page_number,
+                        page_end=page_number,
+                        source_unit_start_ordinal=unit.ordinal,
+                        source_unit_end_ordinal=unit.ordinal,
+                    )
                 )
                 continue
 
@@ -367,8 +307,10 @@ class PageChunker:
                     chunks.append(
                         ChunkDraft(
                             text=chunk_text,
-                            page_start=page.page_number,
-                            page_end=page.page_number,
+                            page_start=page_number,
+                            page_end=page_number,
+                            source_unit_start_ordinal=unit.ordinal,
+                            source_unit_end_ordinal=unit.ordinal,
                         )
                     )
                 if end >= len(text):
@@ -414,28 +356,168 @@ class LanceDbVectorStore:
 
         table.add(records)
 
+    def delete_document(self, document_id: str) -> None:
+        database = lancedb.connect(self.lancedb_path)
+        try:
+            table = database.open_table(self.table_name)
+        except ValueError:
+            return
+        escaped_document_id = document_id.replace("'", "''")
+        table.delete(f"document_id = '{escaped_document_id}'")
+
+
+@dataclass(frozen=True)
+class PreparedSourceArtifact:
+    """One acquired artifact ready for source-neutral processing."""
+
+    source_path: Path
+    artifact_path: Path
+    content_hash: str
+    media_type: str
+    source_url: str | None
+    acquired_at: str
+    work_dir: Path
+    metadata: dict[str, Any]
+    adapter_options: dict[str, object]
+
+
+class SourceProcessingPipeline:
+    """Shared adapter, indexing, and atomic publication pipeline."""
+
+    def __init__(
+        self,
+        *,
+        storage_paths: StoragePaths,
+        adapter: SourceAdapter,
+        chunker: Chunker,
+        embedding_provider: EmbeddingProvider,
+        vector_store: VectorStore,
+        passage_vector_store: PassageVectorStore,
+    ) -> None:
+        self.storage_paths = storage_paths
+        self.adapter = adapter
+        self.chunker = chunker
+        self.embedding_provider = embedding_provider
+        self.vector_store = vector_store
+        self.passage_vector_store = passage_vector_store
+
+    def process(self, artifact: PreparedSourceArtifact) -> None:
+        adapter_result = self._extract_source_units(artifact)
+        chunks = self.chunker.chunk_units(adapter_result.units)
+        chunk_embeddings = self.embedding_provider.embed_chunks([chunk.text for chunk in chunks])
+        if len(chunk_embeddings) != len(chunks):
+            raise IngestError(
+                f"Embedded {len(chunk_embeddings)} chunks for {len(chunks)} chunk drafts"
+            )
+
+        document_id = f"document-{uuid.uuid4().hex[:8]}"
+        artifact_id = artifact_id_for_hash(artifact.content_hash)
+        source_identity = build_source_identity(
+            source_path=artifact.source_path,
+            source_url=artifact.source_url,
+        )
+        document_metadata = _build_document_metadata(
+            artifact.metadata,
+            artifact.source_path,
+            artifact.artifact_path,
+        )
+        page_rows, source_unit_rows, source_unit_ids = _build_source_unit_rows(
+            document_id,
+            artifact_id,
+            adapter_result.units,
+        )
+        chunk_rows, vector_rows = _build_chunk_and_vector_rows(
+            document_id,
+            chunks,
+            chunk_embeddings,
+            source_unit_ids=source_unit_ids,
+        )
+        passage_rows = _build_passage_rows_from_chunks(chunk_rows)
+        passage_embeddings = self.embedding_provider.embed_chunks(
+            [passage_row[8] for passage_row in passage_rows]
+        )
+        if len(passage_embeddings) != len(passage_rows):
+            raise IngestError(
+                f"Embedded {len(passage_embeddings)} passages for {len(passage_rows)} passage rows"
+            )
+        passage_vector_rows = _build_passage_vector_rows(
+            passage_rows,
+            passage_embeddings,
+        )
+
+        _publish_document_bundle(
+            self.storage_paths.database,
+            document_id=document_id,
+            source_identity=source_identity,
+            artifact_id=artifact_id,
+            artifact_byte_size=artifact.artifact_path.stat().st_size,
+            artifact_stored_path=artifact.artifact_path,
+            artifact_acquired_at=artifact.acquired_at,
+            artifact_media_type=adapter_result.media_type,
+            source_path=artifact.source_path,
+            source_url=artifact.source_url,
+            title=_resolve_document_title(artifact.metadata, artifact.source_path),
+            source_hash=artifact.content_hash,
+            normalized_path=adapter_result.derived_artifact_path,
+            metadata=document_metadata,
+            source_units=source_unit_rows,
+            pages=page_rows,
+            chunks=chunk_rows,
+            chunk_embeddings=chunk_embeddings,
+            passages=passage_rows,
+            passage_embeddings=passage_embeddings,
+            chunk_vectors=vector_rows,
+            passage_vectors=passage_vector_rows,
+            vector_store=self.vector_store,
+            passage_vector_store=self.passage_vector_store,
+        )
+
+    def _extract_source_units(self, artifact: PreparedSourceArtifact) -> AdapterResult:
+        adapter_input = AdapterInput(
+            artifact_path=artifact.artifact_path,
+            content_hash=artifact.content_hash,
+            media_type=artifact.media_type,
+            work_dir=artifact.work_dir,
+            options=artifact.adapter_options,
+        )
+        try:
+            result = self.adapter.extract(adapter_input)
+        except AdapterError as exc:
+            raise IngestError(f"Source adapter failed for {artifact.source_path}: {exc}") from exc
+        _validate_adapter_result(result, adapter=self.adapter)
+        return result
+
 
 class IngestionPipeline:
-    """End-to-end local PDF ingestion pipeline."""
+    """Current PDF job front end for the shared source-processing pipeline."""
 
     def __init__(
         self,
         *,
         storage_paths: StoragePaths,
         embedding_config: EmbeddingConfig,
+        adapter: SourceAdapter | None = None,
         ocr_runner: OcrRunner | None = None,
         text_extractor: TextExtractor | None = None,
         chunker: Chunker | None = None,
         embedding_provider: EmbeddingProvider | None = None,
         vector_store: VectorStore | None = None,
+        passage_vector_store: PassageVectorStore | None = None,
     ) -> None:
         self.storage_paths = storage_paths
-        self.ocr_runner = ocr_runner or SubprocessOcrRunner()
-        self.text_extractor = text_extractor
-        self.chunker = chunker or PageChunker()
-        self.embedding_provider = embedding_provider or build_embedding_provider(embedding_config)
-        self.vector_store = vector_store or LanceDbVectorStore(storage_paths.lancedb)
-        self.passage_vector_store = LanceDbPassageVectorStore(storage_paths.lancedb)
+        resolved_adapter = adapter or PdfSourceAdapter(
+            ocr_runner=ocr_runner or SubprocessOcrRunner(),
+            text_extractor=text_extractor,
+        )
+        self.processor = SourceProcessingPipeline(
+            storage_paths=storage_paths,
+            adapter=resolved_adapter,
+            chunker=chunker or PageChunker(),
+            embedding_provider=embedding_provider or build_embedding_provider(embedding_config),
+            vector_store=vector_store or LanceDbVectorStore(storage_paths.lancedb),
+            passage_vector_store=passage_vector_store
+            or LanceDbPassageVectorStore(storage_paths.lancedb),
+        )
 
     async def handle_job(self, job: Job) -> None:
         await asyncio.to_thread(self.process_job, job)
@@ -454,77 +536,18 @@ class IngestionPipeline:
                 return
 
             source_copy_path = _copy_source_pdf(self.storage_paths, source_path, source_hash)
-            normalized_path = self.storage_paths.ocr_pdfs / f"{source_hash}.pdf"
-            self.ocr_runner.normalize_pdf(source_copy_path, normalized_path)
-
-            text_extractor = self.text_extractor or build_pdf_text_extractor(
-                _payload_pdf_extractor_mode(job.payload)
-            )
-            try:
-                pages = text_extractor.extract_pages(normalized_path)
-            except IngestError as exc:
-                raise IngestError(
-                    f"Failed extracting text for {source_path} from {normalized_path}: {exc}"
-                ) from exc
-            chunks = self.chunker.chunk_pages(pages)
-            chunk_embeddings = self.embedding_provider.embed_chunks(
-                [chunk.text for chunk in chunks]
-            )
-            if len(chunk_embeddings) != len(chunks):
-                raise IngestError(
-                    f"Embedded {len(chunk_embeddings)} chunks for {len(chunks)} chunk drafts"
+            self.processor.process(
+                PreparedSourceArtifact(
+                    source_path=source_path,
+                    artifact_path=source_copy_path,
+                    content_hash=source_hash,
+                    media_type=PDF_MEDIA_TYPE,
+                    source_url=source_url,
+                    acquired_at=_metadata_retrieved_at(metadata) or _current_timestamp(),
+                    work_dir=self.storage_paths.ocr_pdfs,
+                    metadata=metadata,
+                    adapter_options={"pdf_extractor": _payload_pdf_extractor_mode(job.payload)},
                 )
-
-            document_id = f"document-{uuid.uuid4().hex[:8]}"
-            artifact_id = artifact_id_for_hash(source_hash)
-            source_identity = build_source_identity(
-                source_path=source_path,
-                source_url=source_url,
-            )
-            document_metadata = _build_document_metadata(metadata, source_path, source_copy_path)
-            page_rows, source_unit_rows, page_unit_ids = _build_page_and_source_unit_rows(
-                document_id,
-                artifact_id,
-                pages,
-            )
-            chunk_rows, vector_rows = _build_chunk_and_vector_rows(
-                document_id,
-                chunks,
-                chunk_embeddings,
-                page_unit_ids=page_unit_ids,
-            )
-            passage_rows = _build_passage_rows_from_chunks(chunk_rows)
-            passage_embeddings = self.embedding_provider.embed_chunks(
-                [passage_row[8] for passage_row in passage_rows]
-            )
-            if len(passage_embeddings) != len(passage_rows):
-                raise IngestError(
-                    f"Embedded {len(passage_embeddings)} passages for {len(passage_rows)} passage rows"
-                )
-            passage_vector_rows = _build_passage_vector_rows(passage_rows, passage_embeddings)
-
-            self.vector_store.add_chunks(vector_rows)
-            self.passage_vector_store.add_passages(passage_vector_rows)
-            _persist_document_bundle(
-                self.storage_paths.database,
-                document_id=document_id,
-                source_identity=source_identity,
-                artifact_id=artifact_id,
-                artifact_byte_size=source_copy_path.stat().st_size,
-                artifact_stored_path=source_copy_path,
-                artifact_acquired_at=_metadata_retrieved_at(metadata) or _current_timestamp(),
-                source_path=source_path,
-                source_url=source_url,
-                title=_resolve_document_title(metadata, source_path),
-                source_hash=source_hash,
-                normalized_path=normalized_path,
-                metadata=document_metadata,
-                source_units=source_unit_rows,
-                pages=page_rows,
-                chunks=chunk_rows,
-                chunk_embeddings=chunk_embeddings,
-                passages=passage_rows,
-                passage_embeddings=passage_embeddings,
             )
         except IngestError:
             raise
@@ -597,22 +620,26 @@ def build_ingest_handler(
     *,
     data_dir: Path,
     embedding_config: EmbeddingConfig,
+    adapter: SourceAdapter | None = None,
     ocr_runner: OcrRunner | None = None,
     text_extractor: TextExtractor | None = None,
     chunker: Chunker | None = None,
     embedding_provider: EmbeddingProvider | None = None,
     vector_store: VectorStore | None = None,
+    passage_vector_store: PassageVectorStore | None = None,
 ) -> Callable[[Job], Awaitable[None]]:
     """Build an async handler for local-PDF ingest jobs."""
 
     pipeline = IngestionPipeline(
         storage_paths=initialize_storage(data_dir),
         embedding_config=embedding_config,
+        adapter=adapter,
         ocr_runner=ocr_runner,
         text_extractor=text_extractor,
         chunker=chunker,
         embedding_provider=embedding_provider,
         vector_store=vector_store,
+        passage_vector_store=passage_vector_store,
     )
     return pipeline.handle_job
 
@@ -758,34 +785,6 @@ def list_chunk_vectors(
     return [dict(row) for row in rows if isinstance(row, dict)]
 
 
-def _extract_with_stage_context(
-    extractor: TextExtractor,
-    pdf_path: Path,
-    *,
-    stage: str,
-) -> list[ExtractedPage]:
-    extractor_name = _extractor_name(extractor)
-    try:
-        return extractor.extract_pages(pdf_path)
-    except IngestError as exc:
-        raise IngestError(
-            f"{stage} PDF text extraction with {extractor_name} failed for {pdf_path}: {exc}"
-        ) from exc
-    except Exception as exc:
-        raise IngestError(
-            f"{stage} PDF text extraction with {extractor_name} failed for {pdf_path}: {exc}"
-        ) from exc
-
-
-def _extractor_name(extractor: TextExtractor) -> str:
-    name = getattr(extractor, "extractor_name", extractor.__class__.__name__)
-    return str(name)
-
-
-def _has_usable_page_text(pages: Sequence[ExtractedPage]) -> bool:
-    return any(page.text.strip() for page in pages)
-
-
 def _iter_pdf_inputs(source_path: Path) -> tuple[Path, ...]:
     resolved_path = source_path.expanduser().resolve()
     if not resolved_path.exists():
@@ -852,6 +851,45 @@ def _metadata_retrieved_at(metadata: dict[str, Any]) -> str | None:
     return None
 
 
+def _validate_adapter_result(result: AdapterResult, *, adapter: SourceAdapter) -> None:
+    if result.media_type not in adapter.media_types:
+        raise IngestError(f"Source adapter returned unsupported media type {result.media_type!r}")
+    if not result.extractor.name.strip():
+        raise IngestError("Source adapter returned no extractor identity")
+    ordinals = [unit.ordinal for unit in result.units]
+    if ordinals != list(range(1, len(result.units) + 1)):
+        raise IngestError("Source adapter units must use contiguous one-based ordinals")
+    for unit in result.units:
+        if not unit.location_type.strip():
+            raise IngestError(f"Source adapter unit {unit.ordinal} has no location type")
+        if not unit.human_label.strip():
+            raise IngestError(f"Source adapter unit {unit.ordinal} has no human label")
+        if not unit.extractor.name.strip():
+            raise IngestError(f"Source adapter unit {unit.ordinal} has no extractor identity")
+
+
+def _page_number(unit: CanonicalSourceUnit) -> int:
+    page_number = _optional_page_number(unit)
+    if page_number is None:
+        raise IngestError(
+            f"Page-first chunking cannot process source-unit type {unit.location_type!r}"
+        )
+    return page_number
+
+
+def _optional_page_number(unit: CanonicalSourceUnit) -> int | None:
+    if unit.location_type != PAGE_LOCATION_TYPE:
+        return None
+    page_number = unit.location.get("page_number")
+    if isinstance(page_number, bool) or not isinstance(page_number, int) or page_number < 1:
+        raise IngestError(f"Source adapter unit {unit.ordinal} has an invalid PDF page location")
+    return page_number
+
+
+def _extractor_identity(name: str) -> ExtractorIdentity:
+    return ExtractorIdentity(name=name)
+
+
 def _hash_bytes(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
@@ -911,10 +949,10 @@ def _resolve_document_title(metadata: dict[str, Any], source_path: Path) -> str:
     return source_path.stem
 
 
-def _build_page_and_source_unit_rows(
+def _build_source_unit_rows(
     document_id: str,
     artifact_id: str,
-    pages: Sequence[ExtractedPage],
+    units: Sequence[CanonicalSourceUnit],
 ) -> tuple[
     list[tuple[str, str, int, str, str, str]],
     list[tuple[str, str, str, int, str, str, str, str, str, str, str | None]],
@@ -922,32 +960,44 @@ def _build_page_and_source_unit_rows(
 ]:
     page_rows: list[tuple[str, str, int, str, str, str]] = []
     source_unit_rows: list[tuple[str, str, str, int, str, str, str, str, str, str, str | None]] = []
-    page_unit_ids: dict[int, str] = {}
+    source_unit_ids: dict[int, str] = {}
 
-    for page in pages:
-        page_id = f"page-{uuid.uuid4().hex[:8]}"
-        unit_id = source_unit_id_for_page(page_id)
-        page_unit_ids[page.page_number] = unit_id
-        page_rows.append(
-            (page_id, document_id, page.page_number, unit_id, page.text, page.extractor)
-        )
+    for unit in units:
+        page_number = _optional_page_number(unit)
+        if page_number is not None:
+            page_id = f"page-{uuid.uuid4().hex[:8]}"
+            unit_id = source_unit_id_for_page(page_id)
+            page_rows.append(
+                (
+                    page_id,
+                    document_id,
+                    page_number,
+                    unit_id,
+                    unit.normalized_text,
+                    unit.extractor.name,
+                )
+            )
+        else:
+            unit_id = source_unit_id_for_ordinal(document_id, unit.ordinal)
+
+        source_unit_ids[unit.ordinal] = unit_id
         source_unit_rows.append(
             (
                 unit_id,
                 artifact_id,
                 document_id,
-                page.page_number,
-                PAGE_LOCATION_TYPE,
-                json.dumps({"page_number": page.page_number}, sort_keys=True),
-                f"p. {page.page_number}",
-                page.text,
-                "{}",
-                page.extractor,
-                None,
+                unit.ordinal,
+                unit.location_type,
+                json.dumps(unit.location, sort_keys=True),
+                unit.human_label,
+                unit.normalized_text,
+                json.dumps(unit.structure, sort_keys=True),
+                unit.extractor.name,
+                unit.extractor.version,
             )
         )
 
-    return page_rows, source_unit_rows, page_unit_ids
+    return page_rows, source_unit_rows, source_unit_ids
 
 
 def _build_chunk_and_vector_rows(
@@ -955,19 +1005,21 @@ def _build_chunk_and_vector_rows(
     chunks: Sequence[ChunkDraft],
     embeddings: Sequence[ChunkEmbedding],
     *,
-    page_unit_ids: dict[int, str],
+    source_unit_ids: dict[int, str],
 ) -> tuple[list[tuple[str, str, int, int, str, str, str]], list[ChunkVectorRecord]]:
     chunk_rows: list[tuple[str, str, int, int, str, str, str]] = []
     vector_rows: list[ChunkVectorRecord] = []
 
     for chunk, embedding in zip(chunks, embeddings, strict=True):
         chunk_id = f"chunk-{uuid.uuid4().hex[:8]}"
+        start_ordinal = chunk.source_unit_start_ordinal or chunk.page_start
+        end_ordinal = chunk.source_unit_end_ordinal or chunk.page_end
         try:
-            source_unit_start_id = page_unit_ids[chunk.page_start]
-            source_unit_end_id = page_unit_ids[chunk.page_end]
+            source_unit_start_id = source_unit_ids[start_ordinal]
+            source_unit_end_id = source_unit_ids[end_ordinal]
         except KeyError as exc:
             raise IngestError(
-                f"Chunk references missing PDF page {exc.args[0]} for document {document_id}"
+                f"Chunk references missing source unit {exc.args[0]} for document {document_id}"
             ) from exc
         chunk_rows.append(
             (
@@ -1063,7 +1115,7 @@ def _build_passage_vector_rows(
     ]
 
 
-def _persist_document_bundle(
+def _publish_document_bundle(
     database_path: Path,
     *,
     document_id: str,
@@ -1072,11 +1124,12 @@ def _persist_document_bundle(
     artifact_byte_size: int,
     artifact_stored_path: Path,
     artifact_acquired_at: str,
+    artifact_media_type: str,
     source_path: Path,
     source_url: str | None,
     title: str,
     source_hash: str,
-    normalized_path: Path,
+    normalized_path: Path | None,
     metadata: dict[str, Any],
     source_units: Sequence[tuple[str, str, str, int, str, str, str, str, str, str, str | None]],
     pages: Sequence[tuple[str, str, int, str, str, str]],
@@ -1084,11 +1137,19 @@ def _persist_document_bundle(
     chunk_embeddings: Sequence[ChunkEmbedding],
     passages: Sequence[tuple[str, str, str, int, int, str, str, int, str]],
     passage_embeddings: Sequence[ChunkEmbedding],
+    chunk_vectors: Sequence[ChunkVectorRecord],
+    passage_vectors: Sequence[PassageVectorRecord],
+    vector_store: VectorStore,
+    passage_vector_store: PassageVectorStore,
 ) -> None:
     metadata_json = json.dumps(metadata, sort_keys=True)
 
-    with sqlite3.connect(database_path) as connection:
-        connection.execute("PRAGMA foreign_keys = ON")
+    with _publication_transaction(
+        database_path,
+        document_id=document_id,
+        vector_store=vector_store,
+        passage_vector_store=passage_vector_store,
+    ) as connection:
         connection.execute(
             """
             INSERT OR IGNORE INTO sources(
@@ -1124,7 +1185,7 @@ def _persist_document_bundle(
             (
                 artifact_id,
                 source_identity.id,
-                PDF_MEDIA_TYPE,
+                artifact_media_type,
                 artifact_byte_size,
                 source_hash,
                 str(artifact_stored_path),
@@ -1151,7 +1212,7 @@ def _persist_document_bundle(
                 source_url,
                 title,
                 source_hash,
-                str(normalized_path),
+                str(normalized_path) if normalized_path is not None else None,
                 metadata_json,
                 artifact_id,
             ),
@@ -1228,27 +1289,103 @@ def _persist_document_bundle(
             """,
             [(passage_id, text) for passage_id, _, _, _, _, _, _, _, text in passages],
         )
-        connection.commit()
-
-    for chunk_row, embedding in zip(chunks, chunk_embeddings, strict=True):
-        create_embedding_record(
-            database_path,
+        _insert_embedding_rows(
+            connection,
             source_kind="chunk",
-            source_key=chunk_row[0],
-            embedding=embedding,
-            source_unit_start_id=chunk_row[4],
-            source_unit_end_id=chunk_row[5],
+            source_rows=chunks,
+            embeddings=chunk_embeddings,
+            source_key_index=0,
+            source_unit_start_index=4,
+            source_unit_end_index=5,
         )
-
-    for passage_row, embedding in zip(passages, passage_embeddings, strict=True):
-        create_embedding_record(
-            database_path,
+        _insert_embedding_rows(
+            connection,
             source_kind="passage",
-            source_key=passage_row[0],
-            embedding=embedding,
-            source_unit_start_id=passage_row[5],
-            source_unit_end_id=passage_row[6],
+            source_rows=passages,
+            embeddings=passage_embeddings,
+            source_key_index=0,
+            source_unit_start_index=5,
+            source_unit_end_index=6,
         )
+        vector_store.add_chunks(chunk_vectors)
+        passage_vector_store.add_passages(passage_vectors)
+
+
+@contextmanager
+def _publication_transaction(
+    database_path: Path,
+    *,
+    document_id: str,
+    vector_store: VectorStore,
+    passage_vector_store: PassageVectorStore,
+) -> Iterator[sqlite3.Connection]:
+    connection = sqlite3.connect(database_path)
+    connection.execute("PRAGMA foreign_keys = ON")
+    try:
+        yield connection
+        connection.commit()
+    except Exception as exc:
+        connection.rollback()
+        cleanup_errors: list[str] = []
+        for name, store in (
+            ("chunk vectors", vector_store),
+            ("passage vectors", passage_vector_store),
+        ):
+            try:
+                store.delete_document(document_id)
+            except Exception as cleanup_exc:
+                cleanup_errors.append(f"{name}: {cleanup_exc}")
+        if cleanup_errors:
+            detail = "; ".join(cleanup_errors)
+            raise IngestError(
+                f"Document publication failed for {document_id}: {exc}; "
+                f"vector cleanup also failed: {detail}"
+            ) from exc
+        raise
+    finally:
+        connection.close()
+
+
+def _insert_embedding_rows(
+    connection: sqlite3.Connection,
+    *,
+    source_kind: str,
+    source_rows: Sequence[tuple[object, ...]],
+    embeddings: Sequence[ChunkEmbedding],
+    source_key_index: int,
+    source_unit_start_index: int,
+    source_unit_end_index: int,
+) -> None:
+    connection.executemany(
+        """
+        INSERT INTO embedding_records(
+            id,
+            source_kind,
+            source_key,
+            provider,
+            model,
+            version,
+            dimensions,
+            source_unit_start_id,
+            source_unit_end_id
+        )
+        VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                f"embedding-{uuid.uuid4().hex[:8]}",
+                source_kind,
+                str(source_row[source_key_index]),
+                embedding.metadata.provider,
+                embedding.metadata.model,
+                embedding.metadata.version,
+                len(embedding.vector),
+                str(source_row[source_unit_start_index]),
+                str(source_row[source_unit_end_index]),
+            )
+            for source_row, embedding in zip(source_rows, embeddings, strict=True)
+        ],
+    )
 
 
 def _row_to_document(row: sqlite3.Row) -> DocumentRecord:

--- a/newsrag/pdf_adapter.py
+++ b/newsrag/pdf_adapter.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal, Protocol
+
+import fitz  # type: ignore[import-untyped]
+import pdfplumber
+
+from newsrag.adapters import (
+    AdapterError,
+    AdapterInput,
+    AdapterResult,
+    CanonicalSourceUnit,
+    ExtractorIdentity,
+)
+from newsrag.sources import PAGE_LOCATION_TYPE, PDF_MEDIA_TYPE
+
+PDF_EXTRACTOR_AUTO: Literal["auto"] = "auto"
+PDF_EXTRACTOR_PYMUPDF: Literal["pymupdf"] = "pymupdf"
+PDF_EXTRACTOR_PDFPLUMBER: Literal["pdfplumber"] = "pdfplumber"
+PDF_EXTRACTOR_TABLE: Literal["table"] = "table"
+PDF_EXTRACTOR_MODES = frozenset(
+    {
+        PDF_EXTRACTOR_AUTO,
+        PDF_EXTRACTOR_PYMUPDF,
+        PDF_EXTRACTOR_PDFPLUMBER,
+        PDF_EXTRACTOR_TABLE,
+    }
+)
+PdfExtractorMode = Literal["auto", "pymupdf", "pdfplumber", "table"]
+
+
+@dataclass(frozen=True)
+class ExtractedPage:
+    """Canonical page text extracted from one PDF page."""
+
+    page_number: int
+    text: str
+    extractor: str = "unknown"
+
+
+class OcrRunner(Protocol):
+    """Protocol for PDF OCR normalization."""
+
+    def normalize_pdf(self, source_path: Path, output_path: Path) -> None:
+        """Create an OCR-normalized PDF artifact."""
+
+
+class TextExtractor(Protocol):
+    """Protocol for page-text extraction."""
+
+    def extract_pages(self, pdf_path: Path) -> list[ExtractedPage]:
+        """Extract canonical page text from one PDF."""
+
+
+@dataclass(frozen=True)
+class SubprocessOcrRunner:
+    """OCR normalization backed by the `ocrmypdf` CLI."""
+
+    def normalize_pdf(self, source_path: Path, output_path: Path) -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            subprocess.run(
+                [
+                    "ocrmypdf",
+                    "--skip-text",
+                    "--quiet",
+                    str(source_path),
+                    str(output_path),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            detail = (exc.stderr or exc.stdout or str(exc)).strip()
+            raise AdapterError(f"ocrmypdf failed for {source_path}: {detail}") from exc
+
+
+@dataclass(frozen=True)
+class PyMuPdfTextExtractor:
+    """Text extraction backed by PyMuPDF."""
+
+    extractor_name: str = PDF_EXTRACTOR_PYMUPDF
+
+    def extract_pages(self, pdf_path: Path) -> list[ExtractedPage]:
+        try:
+            pages: list[ExtractedPage] = []
+            with fitz.open(pdf_path) as document:
+                for index, page in enumerate(document, start=1):
+                    pages.append(
+                        ExtractedPage(
+                            page_number=index,
+                            text=page.get_text().strip(),
+                            extractor=self.extractor_name,
+                        )
+                    )
+            return pages
+        except Exception as exc:
+            raise AdapterError(f"PyMuPDF extraction failed for {pdf_path}: {exc}") from exc
+
+
+@dataclass(frozen=True)
+class PdfPlumberTextExtractor:
+    """Text extraction backed by pdfplumber."""
+
+    extractor_name: str = PDF_EXTRACTOR_PDFPLUMBER
+
+    def extract_pages(self, pdf_path: Path) -> list[ExtractedPage]:
+        try:
+            pages: list[ExtractedPage] = []
+            with pdfplumber.open(pdf_path) as document:
+                for index, page in enumerate(document.pages, start=1):
+                    text = page.extract_text() or ""
+                    pages.append(
+                        ExtractedPage(
+                            page_number=index,
+                            text=text.strip(),
+                            extractor=self.extractor_name,
+                        )
+                    )
+            return pages
+        except Exception as exc:
+            raise AdapterError(f"pdfplumber extraction failed for {pdf_path}: {exc}") from exc
+
+
+@dataclass(frozen=True)
+class FallbackTextExtractor:
+    """Run a primary extractor and fall back when page text quality is unusable."""
+
+    primary: TextExtractor = field(default_factory=PyMuPdfTextExtractor)
+    fallback: TextExtractor = field(default_factory=PdfPlumberTextExtractor)
+
+    @property
+    def extractor_name(self) -> str:
+        return f"{_extractor_name(self.primary)}+{_extractor_name(self.fallback)}"
+
+    def extract_pages(self, pdf_path: Path) -> list[ExtractedPage]:
+        primary_pages = _extract_with_stage_context(
+            self.primary,
+            pdf_path,
+            stage="primary",
+        )
+        if not _has_usable_page_text(primary_pages):
+            return _extract_with_stage_context(
+                self.fallback,
+                pdf_path,
+                stage="fallback",
+            )
+        return primary_pages
+
+
+def build_pdf_text_extractor(mode: PdfExtractorMode = PDF_EXTRACTOR_AUTO) -> TextExtractor:
+    """Build the configured PDF text extraction path."""
+
+    if mode == PDF_EXTRACTOR_AUTO:
+        return FallbackTextExtractor()
+    if mode == PDF_EXTRACTOR_PYMUPDF:
+        return PyMuPdfTextExtractor()
+    if mode in {PDF_EXTRACTOR_PDFPLUMBER, PDF_EXTRACTOR_TABLE}:
+        return PdfPlumberTextExtractor()
+    raise AdapterError(f"Unsupported PDF extractor mode: {mode}")
+
+
+def normalize_pdf_extractor_mode(value: str | None) -> PdfExtractorMode:
+    """Normalize and validate a PDF extractor mode option."""
+
+    if value is None or not value.strip():
+        return PDF_EXTRACTOR_AUTO
+
+    normalized = value.strip().lower()
+    if normalized == PDF_EXTRACTOR_AUTO:
+        return PDF_EXTRACTOR_AUTO
+    if normalized == PDF_EXTRACTOR_PYMUPDF:
+        return PDF_EXTRACTOR_PYMUPDF
+    if normalized == PDF_EXTRACTOR_PDFPLUMBER:
+        return PDF_EXTRACTOR_PDFPLUMBER
+    if normalized == PDF_EXTRACTOR_TABLE:
+        return PDF_EXTRACTOR_TABLE
+
+    allowed = ", ".join(sorted(PDF_EXTRACTOR_MODES))
+    raise AdapterError(f"Unsupported PDF extractor mode: {value}; expected one of: {allowed}")
+
+
+@dataclass(frozen=True)
+class PdfSourceAdapter:
+    """Validate a raw PDF, normalize it through OCR, and emit page source units."""
+
+    ocr_runner: OcrRunner = field(default_factory=SubprocessOcrRunner)
+    text_extractor: TextExtractor | None = None
+
+    @property
+    def media_types(self) -> Sequence[str]:
+        return (PDF_MEDIA_TYPE,)
+
+    def extract(self, artifact: AdapterInput) -> AdapterResult:
+        _validate_pdf_artifact(artifact)
+        normalized_path = artifact.work_dir / f"{artifact.content_hash}.pdf"
+        try:
+            self.ocr_runner.normalize_pdf(artifact.artifact_path, normalized_path)
+        except AdapterError:
+            raise
+        except Exception as exc:
+            raise AdapterError(
+                f"PDF OCR normalization failed for {artifact.artifact_path}: {exc}"
+            ) from exc
+
+        extractor = self.text_extractor or build_pdf_text_extractor(
+            _extractor_mode_from_options(artifact.options)
+        )
+        try:
+            pages = extractor.extract_pages(normalized_path)
+        except AdapterError as exc:
+            raise AdapterError(f"Failed extracting PDF text from {normalized_path}: {exc}") from exc
+        except Exception as exc:
+            raise AdapterError(f"Failed extracting PDF text from {normalized_path}: {exc}") from exc
+
+        _validate_page_order(pages)
+        units = tuple(
+            CanonicalSourceUnit(
+                ordinal=page.page_number,
+                location_type=PAGE_LOCATION_TYPE,
+                location={"page_number": page.page_number},
+                human_label=f"p. {page.page_number}",
+                normalized_text=page.text,
+                structure={},
+                extractor=ExtractorIdentity(name=page.extractor),
+            )
+            for page in pages
+        )
+        return AdapterResult(
+            media_type=PDF_MEDIA_TYPE,
+            units=units,
+            extractor=ExtractorIdentity(name=_extractor_name(extractor)),
+            derived_artifact_path=normalized_path,
+        )
+
+
+def _validate_pdf_artifact(artifact: AdapterInput) -> None:
+    normalized_media_type = artifact.media_type.partition(";")[0].strip().lower()
+    if normalized_media_type != PDF_MEDIA_TYPE:
+        raise AdapterError(f"PDF adapter does not accept media type {artifact.media_type!r}")
+    try:
+        with artifact.artifact_path.open("rb") as artifact_file:
+            signature = artifact_file.read(5)
+    except OSError as exc:
+        raise AdapterError(f"Failed reading PDF artifact {artifact.artifact_path}: {exc}") from exc
+    if signature != b"%PDF-":
+        raise AdapterError(f"PDF artifact has an invalid signature: {artifact.artifact_path}")
+
+
+def _extractor_mode_from_options(options: Mapping[str, object]) -> PdfExtractorMode:
+    value = options.get("pdf_extractor")
+    if value is None:
+        return PDF_EXTRACTOR_AUTO
+    if not isinstance(value, str):
+        raise AdapterError("PDF adapter option pdf_extractor must be a string")
+    return normalize_pdf_extractor_mode(value)
+
+
+def _extract_with_stage_context(
+    extractor: TextExtractor,
+    pdf_path: Path,
+    *,
+    stage: str,
+) -> list[ExtractedPage]:
+    extractor_name = _extractor_name(extractor)
+    try:
+        return extractor.extract_pages(pdf_path)
+    except AdapterError as exc:
+        raise AdapterError(
+            f"{stage} PDF text extraction with {extractor_name} failed for {pdf_path}: {exc}"
+        ) from exc
+    except Exception as exc:
+        raise AdapterError(
+            f"{stage} PDF text extraction with {extractor_name} failed for {pdf_path}: {exc}"
+        ) from exc
+
+
+def _extractor_name(extractor: TextExtractor) -> str:
+    name = getattr(extractor, "extractor_name", extractor.__class__.__name__)
+    return str(name)
+
+
+def _has_usable_page_text(pages: Sequence[ExtractedPage]) -> bool:
+    return any(page.text.strip() for page in pages)
+
+
+def _validate_page_order(pages: Sequence[ExtractedPage]) -> None:
+    page_numbers = [page.page_number for page in pages]
+    if page_numbers != list(range(1, len(pages) + 1)):
+        raise AdapterError("PDF adapter returned pages outside contiguous source order")

--- a/newsrag/search.py
+++ b/newsrag/search.py
@@ -205,6 +205,15 @@ class LanceDbPassageVectorStore:
 
         table.add(records)
 
+    def delete_document(self, document_id: str) -> None:
+        database = lancedb.connect(self.lancedb_path)
+        try:
+            table = database.open_table(self.table_name)
+        except ValueError:
+            return
+        escaped_document_id = document_id.replace("'", "''")
+        table.delete(f"document_id = '{escaped_document_id}'")
+
 
 @dataclass(frozen=True)
 class LanceDbPassageVectorSearcher:
@@ -777,7 +786,9 @@ def _load_passage_context(
             )
 
     for candidate in vector_candidates:
-        existing = merged[candidate.passage_id]
+        existing = merged.get(candidate.passage_id)
+        if existing is None:
+            continue
         merged[candidate.passage_id] = SearchCandidate(
             passage_id=existing.passage_id,
             document_id=existing.document_id,

--- a/newsrag/sources.py
+++ b/newsrag/sources.py
@@ -84,6 +84,12 @@ def source_unit_id_for_page(page_id: str) -> str:
     return _stable_id("source-unit", page_id)
 
 
+def source_unit_id_for_ordinal(document_id: str, ordinal: int) -> str:
+    """Return a stable source-unit ID for a non-page canonical unit."""
+
+    return _stable_id("source-unit", document_id, str(ordinal))
+
+
 def _stable_id(prefix: str, *parts: str) -> str:
     identity = "\0".join(parts).encode("utf-8")
     return f"{prefix}-{hashlib.sha256(identity).hexdigest()}"

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from newsrag.adapters import AdapterError, AdapterInput
+from newsrag.pdf_adapter import ExtractedPage, PdfSourceAdapter
+
+
+@dataclass(frozen=True)
+class FakeOcrRunner:
+    def normalize_pdf(self, source_path: Path, output_path: Path) -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(source_path.read_bytes())
+
+
+@dataclass(frozen=True)
+class FakeTextExtractor:
+    pages: tuple[ExtractedPage, ...]
+    extractor_name: str = "fake-pdf"
+
+    def extract_pages(self, pdf_path: Path) -> list[ExtractedPage]:
+        assert pdf_path.read_bytes().startswith(b"%PDF-")
+        return list(self.pages)
+
+
+def test_pdf_adapter_emits_ordered_page_source_units(tmp_path: Path) -> None:
+    artifact_path = tmp_path / "packet.pdf"
+    artifact_path.write_bytes(b"%PDF-1.4\nmock")
+    adapter = PdfSourceAdapter(
+        ocr_runner=FakeOcrRunner(),
+        text_extractor=FakeTextExtractor(
+            pages=(
+                ExtractedPage(page_number=1, text="Agenda", extractor="pymupdf"),
+                ExtractedPage(page_number=2, text="Public comment", extractor="pdfplumber"),
+            )
+        ),
+    )
+
+    result = adapter.extract(
+        AdapterInput(
+            artifact_path=artifact_path,
+            content_hash="hash-1",
+            media_type="application/pdf",
+            work_dir=tmp_path / "normalized",
+            options={"pdf_extractor": "auto"},
+        )
+    )
+
+    assert result.media_type == "application/pdf"
+    assert result.derived_artifact_path == tmp_path / "normalized" / "hash-1.pdf"
+    assert result.extractor.name == "fake-pdf"
+    assert result.extractor.version is None
+    assert [unit.ordinal for unit in result.units] == [1, 2]
+    assert [unit.location_type for unit in result.units] == ["page", "page"]
+    assert [unit.location for unit in result.units] == [
+        {"page_number": 1},
+        {"page_number": 2},
+    ]
+    assert [unit.human_label for unit in result.units] == ["p. 1", "p. 2"]
+    assert [unit.normalized_text for unit in result.units] == ["Agenda", "Public comment"]
+    assert [unit.extractor.name for unit in result.units] == ["pymupdf", "pdfplumber"]
+
+
+@pytest.mark.parametrize(
+    ("media_type", "content"),
+    [
+        ("text/html", b"%PDF-1.4\nmock"),
+        ("application/pdf", b"not a pdf"),
+    ],
+)
+def test_pdf_adapter_rejects_invalid_artifacts(
+    tmp_path: Path,
+    media_type: str,
+    content: bytes,
+) -> None:
+    artifact_path = tmp_path / "input.bin"
+    artifact_path.write_bytes(content)
+    adapter = PdfSourceAdapter(
+        ocr_runner=FakeOcrRunner(),
+        text_extractor=FakeTextExtractor(pages=()),
+    )
+
+    with pytest.raises(AdapterError, match="PDF"):
+        adapter.extract(
+            AdapterInput(
+                artifact_path=artifact_path,
+                content_hash="hash-1",
+                media_type=media_type,
+                work_dir=tmp_path / "normalized",
+                options=_empty_options(),
+            )
+        )
+
+
+def _empty_options() -> Mapping[str, object]:
+    return {}

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import sqlite3
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import httpx
@@ -12,6 +12,12 @@ import lancedb  # type: ignore[import-untyped]
 import pytest
 from typer.testing import CliRunner
 
+from newsrag.adapters import (
+    AdapterInput,
+    AdapterResult,
+    CanonicalSourceUnit,
+    ExtractorIdentity,
+)
 from newsrag.cli import app
 from newsrag.config import EmbeddingConfig
 from newsrag.daemon import DaemonRunner
@@ -436,6 +442,102 @@ def test_ingest_url_download_failures_fail_clearly(
         enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
 
 
+def test_ingestion_pipeline_processes_an_injected_source_adapter(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    source_pdf = tmp_path / "packet.pdf"
+    source_pdf.write_bytes(b"%PDF-1.4\nmock")
+    paths = initialize_storage(data_dir)
+    job = create_job(
+        paths.database,
+        kind=INGEST_JOB_KIND,
+        payload={"path": str(source_pdf.resolve()), "metadata": {}},
+    )
+    adapter = FakeSourceAdapter()
+
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        adapter=adapter,
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+
+    asyncio.run(
+        DaemonRunner(
+            database_path=paths.database,
+            handlers={INGEST_JOB_KIND: handler},
+            poll_interval=0,
+        ).run_cycle()
+    )
+
+    assert get_job(paths.database, job.id).status == "done"
+    assert len(adapter.inputs) == 1
+    assert adapter.inputs[0].artifact_path.parent == paths.source_pdfs
+    assert adapter.inputs[0].media_type == "application/pdf"
+    with sqlite3.connect(paths.database) as connection:
+        unit = connection.execute(
+            """
+            SELECT location_type, location_json, human_label, normalized_text, extractor
+            FROM source_units
+            """
+        ).fetchone()
+    assert unit is not None
+    assert unit == ("page", '{"page_number": 1}', "p. 1", "Adapter agenda", "fake-adapter")
+
+
+def test_failed_vector_publication_leaves_no_searchable_document(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    source_pdf = tmp_path / "packet.pdf"
+    source_pdf.write_bytes(b"%PDF-1.4\nmock")
+    paths = initialize_storage(data_dir)
+    job = create_job(
+        paths.database,
+        kind=INGEST_JOB_KIND,
+        payload={"path": str(source_pdf.resolve()), "metadata": {}},
+    )
+    chunk_vector_store = RecordingChunkVectorStore()
+    passage_vector_store = FailingPassageVectorStore()
+
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        adapter=FakeSourceAdapter(),
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=chunk_vector_store,
+        passage_vector_store=passage_vector_store,
+    )
+
+    asyncio.run(
+        DaemonRunner(
+            database_path=paths.database,
+            handlers={INGEST_JOB_KIND: handler},
+            poll_interval=0,
+        ).run_cycle()
+    )
+
+    updated_job = get_job(paths.database, job.id)
+    assert updated_job.status == FAILED
+    assert "passage vector boom" in (updated_job.error or "")
+    with sqlite3.connect(paths.database) as connection:
+        for table_name in (
+            "sources",
+            "source_artifacts",
+            "documents",
+            "source_units",
+            "pages",
+            "chunks",
+            "passages",
+            "embedding_records",
+            "chunks_fts",
+            "passages_fts",
+        ):
+            count = connection.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()
+            assert count == (0,)
+    assert len(chunk_vector_store.added) == 1
+    assert len(chunk_vector_store.removed_document_ids) == 1
+    assert passage_vector_store.removed_document_ids == chunk_vector_store.removed_document_ids
+
+
 def test_mocked_local_pdf_job_creates_document_pages_chunks_and_vector_records(
     tmp_path: Path,
 ) -> None:
@@ -771,6 +873,58 @@ def test_ingest_failures_are_recorded_with_context(tmp_path: Path) -> None:
     assert list_documents(paths.database) == []
     assert list_chunks(paths.database) == []
     assert list_chunk_vectors(paths.lancedb) == []
+
+
+@dataclass
+class FakeSourceAdapter:
+    inputs: list[AdapterInput] = field(default_factory=list)
+
+    @property
+    def media_types(self) -> tuple[str, ...]:
+        return ("application/pdf",)
+
+    def extract(self, artifact: AdapterInput) -> AdapterResult:
+        self.inputs.append(artifact)
+        return AdapterResult(
+            media_type="application/pdf",
+            units=(
+                CanonicalSourceUnit(
+                    ordinal=1,
+                    location_type="page",
+                    location={"page_number": 1},
+                    human_label="p. 1",
+                    normalized_text="Adapter agenda",
+                    structure={},
+                    extractor=ExtractorIdentity(name="fake-adapter"),
+                ),
+            ),
+            extractor=ExtractorIdentity(name="fake-adapter"),
+            derived_artifact_path=artifact.artifact_path,
+        )
+
+
+@dataclass
+class RecordingChunkVectorStore:
+    added: list[object] = field(default_factory=list)
+    removed_document_ids: list[str] = field(default_factory=list)
+
+    def add_chunks(self, chunks: Sequence[object]) -> None:
+        self.added.extend(chunks)
+
+    def delete_document(self, document_id: str) -> None:
+        self.removed_document_ids.append(document_id)
+
+
+@dataclass
+class FailingPassageVectorStore:
+    removed_document_ids: list[str] = field(default_factory=list)
+
+    def add_passages(self, passages: Sequence[object]) -> None:
+        del passages
+        raise RuntimeError("passage vector boom")
+
+    def delete_document(self, document_id: str) -> None:
+        self.removed_document_ids.append(document_id)
 
 
 @dataclass(frozen=True)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -394,6 +394,35 @@ def test_search_uses_vector_candidates_when_keyword_search_is_empty(tmp_path: Pa
     assert results[0].citation == "Zoning Packet — 2026-03-15 — p. 2"
 
 
+def test_search_ignores_orphan_vectors_from_failed_publication(tmp_path: Path) -> None:
+    database_path = _seed_search_corpus(tmp_path)
+    engine = build_search_engine(
+        database_path=database_path,
+        lancedb_path=tmp_path / ".newsrag" / "lancedb",
+        embedding_config=EmbeddingConfig(),
+        embedding_provider=FakeQueryEmbeddingProvider(),
+        vector_searcher=FakeVectorSearcher(
+            {
+                "banana telescope": [
+                    SearchCandidate(
+                        passage_id="passage-orphan",
+                        document_id="document-orphan",
+                        page_start=1,
+                        page_end=1,
+                        text="uncommitted vector",
+                        title=None,
+                        meeting_date=None,
+                        vector_score=0.1,
+                    )
+                ]
+            }
+        ),
+        vector_store=FakeVectorStore(),
+    )
+
+    assert engine.search("banana telescope") == []
+
+
 def test_search_keeps_strong_semantic_passage_when_keyword_hits_exist(tmp_path: Path) -> None:
     database_path = _seed_search_corpus(tmp_path)
 


### PR DESCRIPTION
## Summary

Introduce a common source-adapter contract and shared processing/publication pipeline, then migrate existing PDF ingestion onto it without changing PDF-facing behavior.

## Task

- `task-9de42124`

## Changes

- Add canonical adapter input/result/source-unit contracts.
- Move PDF OCR, extractor selection, fallback, validation, and typed page-unit emission into `PdfSourceAdapter`.
- Route chunking, passages, embeddings, FTS/vector indexing, and document publication through `SourceProcessingPipeline`.
- Publish SQLite state transactionally, compensate failed vector writes, and ignore orphan passage vectors during search.
- Preserve existing PDF compatibility exports, page records, metadata, inventory, discovery, search, and packet citations.
- Document adapter and pipeline responsibilities and add adapter, migration, failure-atomicity, and orphan-vector tests.

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] `./scripts/pre-pr.sh` (162 tests)

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
