### PR TITLE
Use repo-local corpus for development daemon

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,1 +1,1 @@
-newsrag: uv run newsrag daemon run
+newsrag: uv run newsrag --data-dir "${NEWSRAG_DATA_DIR:-.newsrag}" daemon run

--- a/README.md
+++ b/README.md
@@ -97,7 +97,14 @@ uv run newsrag --help
 make dev
 ```
 
-This starts all processes defined in `Procfile.dev`, including the foreground `newsrag daemon run` process managed by Overmind.
+This starts all processes defined in `Procfile.dev`, including the foreground `newsrag daemon run` process managed by Overmind. The development daemon stores its corpus under the repository's gitignored `.newsrag` directory by default; set `NEWSRAG_DATA_DIR` to override it.
+
+Target the same development corpus from another terminal by passing the development data directory explicitly:
+
+```bash
+uv run newsrag --data-dir "${NEWSRAG_DATA_DIR:-.newsrag}" status
+uv run newsrag --data-dir "${NEWSRAG_DATA_DIR:-.newsrag}" jobs list
+```
 
 ### View and manage the development environment
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -63,6 +63,19 @@ Start the development environment:
 make dev
 ```
 
+The development daemon uses the repository's gitignored `.newsrag` directory by default instead of the installed corpus under `~/.local/share/newsrag`. Override the development location through the environment when needed:
+
+```bash
+NEWSRAG_DATA_DIR=/path/to/dev-corpus make dev
+```
+
+Use the same data directory explicitly for development CLI commands run outside Overmind:
+
+```bash
+uv run newsrag --data-dir "${NEWSRAG_DATA_DIR:-.newsrag}" status
+uv run newsrag --data-dir "${NEWSRAG_DATA_DIR:-.newsrag}" jobs list
+```
+
 Attach to one service terminal:
 
 ```bash
@@ -85,7 +98,9 @@ make dev-stop
 
 Current behavior:
 - `Procfile.dev` is present and wired into `make dev`.
-- The long-running process is `uv run newsrag daemon run` managed by Overmind.
+- The long-running process is `uv run newsrag --data-dir "${NEWSRAG_DATA_DIR:-.newsrag}" daemon run` managed by Overmind.
+- Development runtime data stays under `.newsrag` unless `NEWSRAG_DATA_DIR` overrides it.
+- Installed commands continue to use the configured data directory or `${XDG_DATA_HOME:-~/.local/share}/newsrag`.
 
 ## Verification commands
 

--- a/tests/test_dev_environment.py
+++ b/tests/test_dev_environment.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_dev_process_uses_repo_local_data_dir_by_default(tmp_path: Path) -> None:
+    invocation = _run_dev_process(tmp_path)
+
+    assert invocation == "run newsrag --data-dir .newsrag daemon run"
+
+
+def test_dev_process_honors_data_dir_override(tmp_path: Path) -> None:
+    override = tmp_path / "custom-corpus"
+
+    invocation = _run_dev_process(tmp_path, data_dir=override)
+
+    assert invocation == f"run newsrag --data-dir {override} daemon run"
+
+
+def test_repo_local_dev_data_is_gitignored() -> None:
+    ignored_paths = Path(".gitignore").read_text(encoding="utf-8").splitlines()
+
+    assert ".newsrag/" in ignored_paths
+
+
+def _run_dev_process(tmp_path: Path, *, data_dir: Path | None = None) -> str:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    invocation_path = tmp_path / "uv-invocation"
+    uv = bin_dir / "uv"
+    uv.write_text(
+        '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" > "$UV_INVOCATION_PATH"\n',
+        encoding="utf-8",
+    )
+    uv.chmod(0o755)
+
+    process_line = Path("Procfile.dev").read_text(encoding="utf-8").strip()
+    _, command = process_line.split(": ", maxsplit=1)
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}/usr/bin{os.pathsep}/bin",
+            "UV_INVOCATION_PATH": str(invocation_path),
+        }
+    )
+    if data_dir is None:
+        env.pop("NEWSRAG_DATA_DIR", None)
+    else:
+        env["NEWSRAG_DATA_DIR"] = str(data_dir)
+
+    result = subprocess.run(
+        ["/bin/bash", "-c", command],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    return invocation_path.read_text(encoding="utf-8").strip()


### PR DESCRIPTION
## Summary

Keep the development daemon isolated from the installed NewsRAG corpus by defaulting `make dev` to the repository's gitignored `.newsrag` directory.

## Task

- `task-dac960a8`

## Changes

- Pass `.newsrag` to the development daemon through `--data-dir` by default.
- Allow `NEWSRAG_DATA_DIR` to override the development corpus location.
- Document how commands outside Overmind target the same development corpus.
- Add regression coverage for the default, override, and gitignore behavior.
- Preserve the installed CLI's existing user-global data-directory resolution.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] `./scripts/pre-pr.sh` (159 tests)
- [x] Restarted `make dev` and verified the running command and status report use `<repo>/.newsrag`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
