### PR TITLE
Add daemon and ingestion progress logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ make dev-status
 make dev-stop
 ```
 
+`make dev-logs` streams daemon startup, job lifecycle, ingestion stage, completion, and failure messages. Set `NEWSRAG_LOG_LEVEL` in `.env` to `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`; the default is `INFO`.
+
 ### Run verification
 
 ```bash

--- a/docs/development.md
+++ b/docs/development.md
@@ -96,6 +96,18 @@ Stop the development environment:
 make dev-stop
 ```
 
+## Runtime logs
+
+Stream daemon output through Overmind:
+
+```bash
+make dev-logs
+```
+
+Use `make dev-tail` for a non-streaming snapshot of recent output. At the default `INFO` level, the daemon logs startup, job start and completion, failures, elapsed time, and ingestion stages including artifact preparation, adapter extraction, chunking, embeddings, and publication. Idle polling cycles are not logged.
+
+Set `NEWSRAG_LOG_LEVEL` in `.env` to one of `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`. The default is `INFO`. Logs include operational identifiers and source paths but not document text, embedding payloads, or credentials.
+
 Current behavior:
 - `Procfile.dev` is present and wired into `make dev`.
 - The long-running process is `uv run newsrag --data-dir "${NEWSRAG_DATA_DIR:-.newsrag}" daemon run` managed by Overmind.

--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -237,9 +237,15 @@ def daemon_run(
 
     from newsrag.daemon import DaemonConfig, run_daemon
     from newsrag.embeddings import EmbeddingError
+    from newsrag.logging_config import LoggingConfigError, configure_logging
 
     settings, _ = _resolve_runtime_settings(ctx)
-    typer.echo(f"NewsRAG daemon running for {settings.data_dir}")
+    try:
+        configure_logging()
+    except LoggingConfigError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
+
     try:
         asyncio.run(
             run_daemon(

--- a/newsrag/daemon.py
+++ b/newsrag/daemon.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from time import perf_counter
 
 from watchfiles import awatch
 
@@ -14,6 +16,7 @@ from newsrag.storage import initialize_storage
 from newsrag.watches import DEFAULT_WATCH_STABILITY_SECONDS, WatchDebouncer, list_watches
 
 JobHandler = Callable[[Job], Awaitable[None]]
+LOGGER = logging.getLogger(__name__)
 
 
 class UnknownJobKindError(Exception):
@@ -59,12 +62,26 @@ class DaemonRunner:
         if job is None:
             return False
 
+        started_at = perf_counter()
+        log_context = _job_log_context(job)
+        LOGGER.info("job_started %s", log_context)
         try:
             await self._handle_job(job)
         except Exception as exc:
             await asyncio.to_thread(mark_job_failed, self.database_path, job.id, error=str(exc))
+            LOGGER.error(
+                "job_failed %s elapsed_ms=%d error=%r",
+                log_context,
+                _elapsed_milliseconds(started_at),
+                str(exc),
+            )
         else:
             await asyncio.to_thread(mark_job_done, self.database_path, job.id)
+            LOGGER.info(
+                "job_completed %s elapsed_ms=%d",
+                log_context,
+                _elapsed_milliseconds(started_at),
+            )
         return True
 
     async def _handle_job(self, job: Job) -> None:
@@ -99,6 +116,12 @@ async def run_daemon(
         poll_interval=config.poll_interval,
     )
     watches = list_watches(storage_paths.database)
+    LOGGER.info(
+        "daemon_started data_dir=%r poll_interval_seconds=%s watches=%d",
+        str(config.data_dir),
+        config.poll_interval,
+        len(watches),
+    )
     if not watches:
         await runner.run(max_loops=config.max_loops)
         return
@@ -140,3 +163,15 @@ async def _run_watch_loop(
 async def _default_watch_stream(paths: tuple[str, ...]) -> AsyncIterator[set[tuple[object, str]]]:
     async for changes in awatch(*paths):
         yield {(change, str(path)) for change, path in changes}
+
+
+def _job_log_context(job: Job) -> str:
+    context = f"job_id={job.id} kind={job.kind}"
+    source_path = job.payload.get("path")
+    if isinstance(source_path, str):
+        context += f" source_path={source_path!r}"
+    return context
+
+
+def _elapsed_milliseconds(started_at: float) -> int:
+    return round((perf_counter() - started_at) * 1000)

--- a/newsrag/ingest.py
+++ b/newsrag/ingest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 import shutil
 import sqlite3
 import uuid
@@ -11,6 +12,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from time import perf_counter
 from typing import Any, Protocol
 from urllib.parse import unquote, urlparse
 
@@ -88,6 +90,7 @@ DEFAULT_CHUNK_MAX_CHARS = 2000
 DEFAULT_CHUNK_OVERLAP_CHARS = 200
 DEFAULT_DOWNLOAD_TIMEOUT_SECONDS = 30.0
 VECTOR_TABLE_NAME = "chunk_embeddings"
+LOGGER = logging.getLogger(__name__)
 
 
 class IngestError(Exception):
@@ -401,14 +404,34 @@ class SourceProcessingPipeline:
         self.vector_store = vector_store
         self.passage_vector_store = passage_vector_store
 
-    def process(self, artifact: PreparedSourceArtifact) -> None:
-        adapter_result = self._extract_source_units(artifact)
-        chunks = self.chunker.chunk_units(adapter_result.units)
-        chunk_embeddings = self.embedding_provider.embed_chunks([chunk.text for chunk in chunks])
-        if len(chunk_embeddings) != len(chunks):
-            raise IngestError(
-                f"Embedded {len(chunk_embeddings)} chunks for {len(chunks)} chunk drafts"
+    def process(self, artifact: PreparedSourceArtifact, *, job_id: str) -> None:
+        with _ingest_stage(job_id, "adapter_extraction", artifact.source_path):
+            adapter_result = self._extract_source_units(artifact)
+        LOGGER.info(
+            "ingest_units_ready job_id=%s source_path=%r units=%d extractor=%s",
+            job_id,
+            str(artifact.source_path),
+            len(adapter_result.units),
+            adapter_result.extractor.name,
+        )
+
+        with _ingest_stage(job_id, "chunking", artifact.source_path):
+            chunks = self.chunker.chunk_units(adapter_result.units)
+        LOGGER.info(
+            "ingest_chunks_ready job_id=%s source_path=%r chunks=%d",
+            job_id,
+            str(artifact.source_path),
+            len(chunks),
+        )
+
+        with _ingest_stage(job_id, "chunk_embeddings", artifact.source_path):
+            chunk_embeddings = self.embedding_provider.embed_chunks(
+                [chunk.text for chunk in chunks]
             )
+            if len(chunk_embeddings) != len(chunks):
+                raise IngestError(
+                    f"Embedded {len(chunk_embeddings)} chunks for {len(chunks)} chunk drafts"
+                )
 
         document_id = f"document-{uuid.uuid4().hex[:8]}"
         artifact_id = artifact_id_for_hash(artifact.content_hash)
@@ -433,43 +456,56 @@ class SourceProcessingPipeline:
             source_unit_ids=source_unit_ids,
         )
         passage_rows = _build_passage_rows_from_chunks(chunk_rows)
-        passage_embeddings = self.embedding_provider.embed_chunks(
-            [passage_row[8] for passage_row in passage_rows]
-        )
-        if len(passage_embeddings) != len(passage_rows):
-            raise IngestError(
-                f"Embedded {len(passage_embeddings)} passages for {len(passage_rows)} passage rows"
+        with _ingest_stage(job_id, "passage_embeddings", artifact.source_path):
+            passage_embeddings = self.embedding_provider.embed_chunks(
+                [passage_row[8] for passage_row in passage_rows]
             )
+            if len(passage_embeddings) != len(passage_rows):
+                raise IngestError(
+                    f"Embedded {len(passage_embeddings)} passages for "
+                    f"{len(passage_rows)} passage rows"
+                )
         passage_vector_rows = _build_passage_vector_rows(
             passage_rows,
             passage_embeddings,
         )
 
-        _publish_document_bundle(
-            self.storage_paths.database,
-            document_id=document_id,
-            source_identity=source_identity,
-            artifact_id=artifact_id,
-            artifact_byte_size=artifact.artifact_path.stat().st_size,
-            artifact_stored_path=artifact.artifact_path,
-            artifact_acquired_at=artifact.acquired_at,
-            artifact_media_type=adapter_result.media_type,
-            source_path=artifact.source_path,
-            source_url=artifact.source_url,
-            title=_resolve_document_title(artifact.metadata, artifact.source_path),
-            source_hash=artifact.content_hash,
-            normalized_path=adapter_result.derived_artifact_path,
-            metadata=document_metadata,
-            source_units=source_unit_rows,
-            pages=page_rows,
-            chunks=chunk_rows,
-            chunk_embeddings=chunk_embeddings,
-            passages=passage_rows,
-            passage_embeddings=passage_embeddings,
-            chunk_vectors=vector_rows,
-            passage_vectors=passage_vector_rows,
-            vector_store=self.vector_store,
-            passage_vector_store=self.passage_vector_store,
+        with _ingest_stage(job_id, "publication", artifact.source_path):
+            _publish_document_bundle(
+                self.storage_paths.database,
+                document_id=document_id,
+                source_identity=source_identity,
+                artifact_id=artifact_id,
+                artifact_byte_size=artifact.artifact_path.stat().st_size,
+                artifact_stored_path=artifact.artifact_path,
+                artifact_acquired_at=artifact.acquired_at,
+                artifact_media_type=adapter_result.media_type,
+                source_path=artifact.source_path,
+                source_url=artifact.source_url,
+                title=_resolve_document_title(artifact.metadata, artifact.source_path),
+                source_hash=artifact.content_hash,
+                normalized_path=adapter_result.derived_artifact_path,
+                metadata=document_metadata,
+                source_units=source_unit_rows,
+                pages=page_rows,
+                chunks=chunk_rows,
+                chunk_embeddings=chunk_embeddings,
+                passages=passage_rows,
+                passage_embeddings=passage_embeddings,
+                chunk_vectors=vector_rows,
+                passage_vectors=passage_vector_rows,
+                vector_store=self.vector_store,
+                passage_vector_store=self.passage_vector_store,
+            )
+        LOGGER.info(
+            "ingest_published job_id=%s source_path=%r document_id=%s pages=%d chunks=%d "
+            "passages=%d",
+            job_id,
+            str(artifact.source_path),
+            document_id,
+            len(page_rows),
+            len(chunk_rows),
+            len(passage_rows),
         )
 
     def _extract_source_units(self, artifact: PreparedSourceArtifact) -> AdapterResult:
@@ -528,14 +564,25 @@ class IngestionPipeline:
         source_url = _metadata_source_url(metadata)
 
         try:
-            source_hash = _hash_file(source_path)
-            existing_document = get_document_by_source_hash(
-                self.storage_paths.database, source_hash
-            )
-            if existing_document is not None:
-                return
+            with _ingest_stage(job.id, "artifact_preparation", source_path):
+                source_hash = _hash_file(source_path)
+                existing_document = get_document_by_source_hash(
+                    self.storage_paths.database, source_hash
+                )
+                if existing_document is not None:
+                    LOGGER.info(
+                        "ingest_duplicate_skipped job_id=%s source_path=%r document_id=%s",
+                        job.id,
+                        str(source_path),
+                        existing_document.id,
+                    )
+                    return
 
-            source_copy_path = _copy_source_pdf(self.storage_paths, source_path, source_hash)
+                source_copy_path = _copy_source_pdf(
+                    self.storage_paths,
+                    source_path,
+                    source_hash,
+                )
             self.processor.process(
                 PreparedSourceArtifact(
                     source_path=source_path,
@@ -547,7 +594,8 @@ class IngestionPipeline:
                     work_dir=self.storage_paths.ocr_pdfs,
                     metadata=metadata,
                     adapter_options={"pdf_extractor": _payload_pdf_extractor_mode(job.payload)},
-                )
+                ),
+                job_id=job.id,
             )
         except IngestError:
             raise
@@ -849,6 +897,35 @@ def _metadata_retrieved_at(metadata: dict[str, Any]) -> str | None:
     if isinstance(retrieved_at, str) and retrieved_at.strip():
         return retrieved_at.strip()
     return None
+
+
+@contextmanager
+def _ingest_stage(job_id: str, stage: str, source_path: Path) -> Iterator[None]:
+    started_at = perf_counter()
+    LOGGER.info(
+        "ingest_stage_started job_id=%s stage=%s source_path=%r",
+        job_id,
+        stage,
+        str(source_path),
+    )
+    try:
+        yield
+    except Exception:
+        LOGGER.error(
+            "ingest_stage_failed job_id=%s stage=%s source_path=%r elapsed_ms=%d",
+            job_id,
+            stage,
+            str(source_path),
+            round((perf_counter() - started_at) * 1000),
+        )
+        raise
+    LOGGER.info(
+        "ingest_stage_completed job_id=%s stage=%s source_path=%r elapsed_ms=%d",
+        job_id,
+        stage,
+        str(source_path),
+        round((perf_counter() - started_at) * 1000),
+    )
 
 
 def _validate_adapter_result(result: AdapterResult, *, adapter: SourceAdapter) -> None:

--- a/newsrag/logging_config.py
+++ b/newsrag/logging_config.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import logging
+import os
+
+DEFAULT_LOG_LEVEL = "INFO"
+LOG_LEVEL_ENV = "NEWSRAG_LOG_LEVEL"
+LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
+LOG_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+_ALLOWED_LOG_LEVELS = {
+    "CRITICAL": logging.CRITICAL,
+    "ERROR": logging.ERROR,
+    "WARNING": logging.WARNING,
+    "INFO": logging.INFO,
+    "DEBUG": logging.DEBUG,
+}
+
+
+class LoggingConfigError(ValueError):
+    """Raised when runtime logging configuration is invalid."""
+
+
+def resolve_log_level(value: str | None = None) -> int:
+    """Resolve a standard logging level from an explicit or environment value."""
+
+    configured = value if value is not None else os.environ.get(LOG_LEVEL_ENV, DEFAULT_LOG_LEVEL)
+    normalized = configured.strip().upper()
+    try:
+        return _ALLOWED_LOG_LEVELS[normalized]
+    except KeyError as exc:
+        allowed = ", ".join(_ALLOWED_LOG_LEVELS)
+        raise LoggingConfigError(
+            f"Invalid {LOG_LEVEL_ENV} value {configured!r}; expected one of: {allowed}"
+        ) from exc
+
+
+def configure_logging(value: str | None = None) -> int:
+    """Configure application console logging and return the resolved level."""
+
+    level = resolve_log_level(value)
+    logging.basicConfig(
+        level=level,
+        format=LOG_FORMAT,
+        datefmt=LOG_DATE_FORMAT,
+        force=True,
+    )
+    return level

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from newsrag.cli import app
@@ -44,7 +46,43 @@ embedding:
     )
 
     assert result.exit_code == 0
-    assert "NewsRAG daemon running" in result.stdout
+    assert "daemon_started" in result.stderr
+    assert str(data_dir) in result.stderr
+
+
+def test_daemon_run_command_honors_error_log_level(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+embedding:
+  provider: openai_compatible
+  base_url: http://127.0.0.1:8080/v1
+  model: nomic-embed-text-v1.5
+""".strip(),
+        encoding="utf-8",
+    )
+    initialize_storage(data_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            "--config-path",
+            str(config_path),
+            "--data-dir",
+            str(data_dir),
+            "daemon",
+            "run",
+            "--poll-interval",
+            "0",
+            "--max-loops",
+            "1",
+        ],
+        env={"NEWSRAG_LOG_LEVEL": "ERROR"},
+    )
+
+    assert result.exit_code == 0
+    assert "daemon_started" not in result.stderr
 
 
 def test_daemon_run_command_requires_embedding_configuration(tmp_path: Path) -> None:
@@ -73,12 +111,15 @@ def test_daemon_run_command_requires_embedding_configuration(tmp_path: Path) -> 
     assert "embedding.provider=openai_compatible" in result.stdout
 
 
-def test_mocked_job_moves_from_pending_to_running_to_done(tmp_path: Path) -> None:
+def test_mocked_job_moves_from_pending_to_running_to_done(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     data_dir = tmp_path / ".newsrag"
     paths = initialize_storage(data_dir)
     seen_running_statuses: list[str] = []
-
-    job = create_job(paths.database, kind="mock")
+    source_path = tmp_path / "packet.pdf"
+    job = create_job(paths.database, kind="mock", payload={"path": str(source_path)})
 
     async def handler(_: Job) -> None:
         current = get_job(paths.database, job.id)
@@ -90,17 +131,26 @@ def test_mocked_job_moves_from_pending_to_running_to_done(tmp_path: Path) -> Non
         poll_interval=0,
     )
 
-    processed = asyncio.run(runner_instance.run_cycle())
+    with caplog.at_level(logging.INFO, logger="newsrag.daemon"):
+        processed = asyncio.run(runner_instance.run_cycle())
 
     assert processed is True
     assert seen_running_statuses == [RUNNING]
     assert get_job(paths.database, job.id).status == DONE
+    assert f"job_started job_id={job.id} kind=mock" in caplog.text
+    assert f"job_completed job_id={job.id} kind=mock" in caplog.text
+    assert f"source_path='{source_path}'" in caplog.text
+    assert "elapsed_ms=" in caplog.text
 
 
-def test_failing_mocked_job_records_failed_state_and_error(tmp_path: Path) -> None:
+def test_failing_mocked_job_records_failed_state_and_error(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     data_dir = tmp_path / ".newsrag"
     paths = initialize_storage(data_dir)
-    job = create_job(paths.database, kind="mock")
+    source_path = tmp_path / "packet.pdf"
+    job = create_job(paths.database, kind="mock", payload={"path": str(source_path)})
 
     async def handler(_: Job) -> None:
         raise RuntimeError("boom")
@@ -111,12 +161,30 @@ def test_failing_mocked_job_records_failed_state_and_error(tmp_path: Path) -> No
         poll_interval=0,
     )
 
-    processed = asyncio.run(runner_instance.run_cycle())
+    with caplog.at_level(logging.INFO, logger="newsrag.daemon"):
+        processed = asyncio.run(runner_instance.run_cycle())
     updated_job = get_job(paths.database, job.id)
 
     assert processed is True
     assert updated_job.status == FAILED
     assert updated_job.error == "boom"
+    assert f"job_failed job_id={job.id} kind=mock" in caplog.text
+    assert f"source_path='{source_path}'" in caplog.text
+    assert "error='boom'" in caplog.text
+
+
+def test_idle_daemon_cycle_does_not_log(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    paths = initialize_storage(tmp_path / ".newsrag")
+    runner_instance = DaemonRunner(database_path=paths.database, poll_interval=0)
+
+    with caplog.at_level(logging.INFO, logger="newsrag.daemon"):
+        processed = asyncio.run(runner_instance.run_cycle())
+
+    assert processed is False
+    assert caplog.records == []
 
 
 def test_jobs_list_shows_all_job_statuses(tmp_path: Path) -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import sqlite3
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
@@ -442,7 +443,10 @@ def test_ingest_url_download_failures_fail_clearly(
         enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
 
 
-def test_ingestion_pipeline_processes_an_injected_source_adapter(tmp_path: Path) -> None:
+def test_ingestion_pipeline_processes_an_injected_source_adapter(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     data_dir = tmp_path / ".newsrag"
     source_pdf = tmp_path / "packet.pdf"
     source_pdf.write_bytes(b"%PDF-1.4\nmock")
@@ -462,15 +466,26 @@ def test_ingestion_pipeline_processes_an_injected_source_adapter(tmp_path: Path)
         vector_store=LanceDbVectorStore(paths.lancedb),
     )
 
-    asyncio.run(
-        DaemonRunner(
-            database_path=paths.database,
-            handlers={INGEST_JOB_KIND: handler},
-            poll_interval=0,
-        ).run_cycle()
-    )
+    with caplog.at_level(logging.INFO):
+        asyncio.run(
+            DaemonRunner(
+                database_path=paths.database,
+                handlers={INGEST_JOB_KIND: handler},
+                poll_interval=0,
+            ).run_cycle()
+        )
 
     assert get_job(paths.database, job.id).status == "done"
+    for stage in (
+        "artifact_preparation",
+        "adapter_extraction",
+        "chunking",
+        "chunk_embeddings",
+        "passage_embeddings",
+        "publication",
+    ):
+        assert f"stage={stage}" in caplog.text
+    assert "Adapter agenda" not in caplog.text
     assert len(adapter.inputs) == 1
     assert adapter.inputs[0].artifact_path.parent == paths.source_pdfs
     assert adapter.inputs[0].media_type == "application/pdf"

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from newsrag.logging_config import LoggingConfigError, resolve_log_level
+
+
+def test_log_level_defaults_to_info(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NEWSRAG_LOG_LEVEL", raising=False)
+
+    assert resolve_log_level() == logging.INFO
+
+
+def test_log_level_honors_environment_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEWSRAG_LOG_LEVEL", "debug")
+
+    assert resolve_log_level() == logging.DEBUG
+
+
+def test_log_level_rejects_invalid_environment_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEWSRAG_LOG_LEVEL", "verbose-ish")
+
+    with pytest.raises(LoggingConfigError, match="NEWSRAG_LOG_LEVEL"):
+        resolve_log_level()


### PR DESCRIPTION
## Summary

Add visible, structured daemon and ingestion progress logs so Overmind shows active work instead of only the startup line.

## Task

- `task-245750ba`

## Changes

- Configure timestamped console logging with `NEWSRAG_LOG_LEVEL`, defaulting to `INFO`.
- Log daemon startup and job start, completion, failure, safe source context, and elapsed time.
- Log ingestion stage start, completion, and failure for artifact preparation, adapter extraction, chunking, embeddings, and atomic publication.
- Report unit, chunk, page, passage, and published-document counts without logging document contents or embedding payloads.
- Keep idle polling silent.
- Document log viewing and level configuration.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] `./scripts/pre-pr.sh` (170 tests)
- [x] Ingested two generated PDFs and observed complete job/stage lifecycle output through `overmind echo`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
