### PR TITLE
Enforce exact-byte duplicate ingestion

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,7 @@ NewsRAG is organized around a small set of durable entities rather than a server
 - **Page**: the PDF-specific compatibility record linked one-to-one to a page source unit. Existing page numbers and page citations remain the source of citation truth for PDFs.
 - **Chunk**: searchable text derived from source units. Chunks retain both the existing PDF page span and a source-unit range for source-neutral retrieval.
 - **Embedding**: a vector representation of a chunk or passage stored in LanceDB, linked back to its source record, source-unit range, and embedding provider/model/version.
-- **Job**: durable processing work tracked through pending, running, done, and failed states, with error details and retry support.
+- **Job**: durable processing work tracked through pending, running, done, and failed states, with structured completion outcomes, error details, and retry support.
 - **Watch**: a configured folder watcher with default metadata used when new PDFs appear.
 - **Packet**: a generated Markdown evidence file assembled from retrieved chunks and source metadata.
 
@@ -67,7 +67,11 @@ documents:
     jurisdiction: Example City
 ```
 
-Processing is idempotent. The system hashes source content to avoid duplicate indexing and to detect changed documents. Raw bytes are retained as an immutable source artifact. Each PDF is normalized through OCR, then text is extracted from the normalized PDF. This makes scanned and born-digital PDFs follow the same downstream path.
+Processing uses exact raw-byte SHA-256 identity within one corpus. It does not compare normalized or extracted text and does not use fuzzy or semantic duplicate detection. A published exact duplicate completes with `duplicate_ignored`; it creates no new source, artifact, document, alias, or metadata and discards the repeated submission payload. The job result retains the existing artifact and document IDs. Artifacts retained after a failed attempt can be reused by a retry.
+
+When a known source returns different bytes, NewsRAG preserves the new artifact with `change_detected_artifact_saved` but does not replace the source's current document. Repeating those changed bytes reports `change_already_detected`. New publications report `created`. A unique document-to-artifact constraint and transactional cleanup make concurrent duplicate processing converge without exposing partial document records or vectors. The complete policy is recorded in [Source identity and repeated ingestion](research/source-identity-and-repeated-ingestion.md).
+
+Raw bytes are retained as immutable, content-addressed source artifacts. Each PDF is normalized through OCR, then text is extracted from the normalized PDF. This makes scanned and born-digital PDFs follow the same downstream path.
 
 The OCR stage uses `ocrmypdf` with Tesseract and its required supporting tools. Text extraction uses PyMuPDF as the primary extractor and pdfplumber as a fallback or table-oriented extraction path. Each extracted page is stored as an ordered page source unit before chunking, and source-unit ranges propagate through chunks, passages, embeddings, and search results while existing page citations remain stable.
 

--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -1093,6 +1093,11 @@ def _format_job_line(job: Job) -> str:
     source_path = job.payload.get("path")
     if isinstance(source_path, str) and source_path.strip():
         parts.append(f"path={source_path}")
+    if job.result is not None:
+        for key in ("outcome", "source_id", "artifact_id", "document_id"):
+            value = job.result.get(key)
+            if isinstance(value, str) and value:
+                parts.append(f"{key}={value}")
     if job.status == FAILED and job.error is not None:
         parts.append(f"failed_at={job.updated_at}")
         parts.append(f"error={job.error}")

--- a/newsrag/daemon.py
+++ b/newsrag/daemon.py
@@ -15,7 +15,8 @@ from newsrag.jobs import Job, claim_next_job, mark_job_done, mark_job_failed
 from newsrag.storage import initialize_storage
 from newsrag.watches import DEFAULT_WATCH_STABILITY_SECONDS, WatchDebouncer, list_watches
 
-JobHandler = Callable[[Job], Awaitable[None]]
+JobResult = dict[str, object]
+JobHandler = Callable[[Job], Awaitable[JobResult | None]]
 LOGGER = logging.getLogger(__name__)
 
 
@@ -66,7 +67,7 @@ class DaemonRunner:
         log_context = _job_log_context(job)
         LOGGER.info("job_started %s", log_context)
         try:
-            await self._handle_job(job)
+            result = await self._handle_job(job)
         except Exception as exc:
             await asyncio.to_thread(mark_job_failed, self.database_path, job.id, error=str(exc))
             LOGGER.error(
@@ -76,7 +77,12 @@ class DaemonRunner:
                 str(exc),
             )
         else:
-            await asyncio.to_thread(mark_job_done, self.database_path, job.id)
+            await asyncio.to_thread(
+                mark_job_done,
+                self.database_path,
+                job.id,
+                result=result,
+            )
             LOGGER.info(
                 "job_completed %s elapsed_ms=%d",
                 log_context,
@@ -84,11 +90,11 @@ class DaemonRunner:
             )
         return True
 
-    async def _handle_job(self, job: Job) -> None:
+    async def _handle_job(self, job: Job) -> JobResult | None:
         handler = self.handlers.get(job.kind)
         if handler is None:
             raise UnknownJobKindError(f"No handler registered for job kind '{job.kind}'")
-        await handler(job)
+        return await handler(job)
 
 
 WatchStreamFactory = Callable[[tuple[str, ...]], AsyncIterator[set[tuple[object, str]]]]

--- a/newsrag/ingest.py
+++ b/newsrag/ingest.py
@@ -14,7 +14,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from time import perf_counter
 from typing import Any, Protocol
-from urllib.parse import unquote, urlparse
 
 import httpx
 import lancedb  # type: ignore[import-untyped]
@@ -33,6 +32,13 @@ from newsrag.embeddings import (
     EmbeddingMetadata,
     EmbeddingProvider,
     build_embedding_provider,
+)
+from newsrag.ingestion_identity import (
+    OUTCOME_CREATED,
+    OUTCOME_DUPLICATE_IGNORED,
+    find_document_for_artifact,
+    find_published_duplicate,
+    register_acquired_artifact,
 )
 from newsrag.jobs import Job, create_job
 from newsrag.passages import build_passage_rows
@@ -61,7 +67,6 @@ from newsrag.search import LanceDbPassageVectorStore, PassageVectorRecord
 from newsrag.sources import (
     PAGE_LOCATION_TYPE,
     PDF_MEDIA_TYPE,
-    SourceIdentity,
     artifact_id_for_hash,
     build_source_identity,
     source_unit_id_for_ordinal,
@@ -226,11 +231,15 @@ class HttpxPdfDownloader:
             raise IngestError(f"URL did not return a PDF-like response: {url}")
 
         content_hash = _hash_bytes(content)
-        filename = _download_filename(response.url)
         destination_dir.mkdir(parents=True, exist_ok=True)
-        destination_path = destination_dir / f"{content_hash}-{filename}"
-        if not destination_path.exists():
-            destination_path.write_bytes(content)
+        destination_path = destination_dir / f"{content_hash}.pdf"
+        if not destination_path.exists() or _hash_file(destination_path) != content_hash:
+            temporary_path = destination_path.with_name(f".{content_hash}-{uuid.uuid4().hex}.tmp")
+            try:
+                temporary_path.write_bytes(content)
+                temporary_path.replace(destination_path)
+            finally:
+                temporary_path.unlink(missing_ok=True)
 
         return DownloadedPdf(
             path=destination_path,
@@ -404,7 +413,7 @@ class SourceProcessingPipeline:
         self.vector_store = vector_store
         self.passage_vector_store = passage_vector_store
 
-    def process(self, artifact: PreparedSourceArtifact, *, job_id: str) -> None:
+    def process(self, artifact: PreparedSourceArtifact, *, job_id: str) -> str:
         with _ingest_stage(job_id, "adapter_extraction", artifact.source_path):
             adapter_result = self._extract_source_units(artifact)
         LOGGER.info(
@@ -435,10 +444,6 @@ class SourceProcessingPipeline:
 
         document_id = f"document-{uuid.uuid4().hex[:8]}"
         artifact_id = artifact_id_for_hash(artifact.content_hash)
-        source_identity = build_source_identity(
-            source_path=artifact.source_path,
-            source_url=artifact.source_url,
-        )
         document_metadata = _build_document_metadata(
             artifact.metadata,
             artifact.source_path,
@@ -474,12 +479,7 @@ class SourceProcessingPipeline:
             _publish_document_bundle(
                 self.storage_paths.database,
                 document_id=document_id,
-                source_identity=source_identity,
                 artifact_id=artifact_id,
-                artifact_byte_size=artifact.artifact_path.stat().st_size,
-                artifact_stored_path=artifact.artifact_path,
-                artifact_acquired_at=artifact.acquired_at,
-                artifact_media_type=adapter_result.media_type,
                 source_path=artifact.source_path,
                 source_url=artifact.source_url,
                 title=_resolve_document_title(artifact.metadata, artifact.source_path),
@@ -507,6 +507,7 @@ class SourceProcessingPipeline:
             len(chunk_rows),
             len(passage_rows),
         )
+        return document_id
 
     def _extract_source_units(self, artifact: PreparedSourceArtifact) -> AdapterResult:
         adapter_input = AdapterInput(
@@ -555,10 +556,10 @@ class IngestionPipeline:
             or LanceDbPassageVectorStore(storage_paths.lancedb),
         )
 
-    async def handle_job(self, job: Job) -> None:
-        await asyncio.to_thread(self.process_job, job)
+    async def handle_job(self, job: Job) -> dict[str, object]:
+        return await asyncio.to_thread(self.process_job, job)
 
-    def process_job(self, job: Job) -> None:
+    def process_job(self, job: Job) -> dict[str, object]:
         source_path = _payload_path(job.payload)
         metadata = _payload_metadata(job.payload)
         source_url = _metadata_source_url(metadata)
@@ -566,41 +567,81 @@ class IngestionPipeline:
         try:
             with _ingest_stage(job.id, "artifact_preparation", source_path):
                 source_hash = _hash_file(source_path)
-                existing_document = get_document_by_source_hash(
-                    self.storage_paths.database, source_hash
+                duplicate = find_published_duplicate(
+                    self.storage_paths.database,
+                    source_hash,
                 )
-                if existing_document is not None:
-                    LOGGER.info(
-                        "ingest_duplicate_skipped job_id=%s source_path=%r document_id=%s",
-                        job.id,
-                        str(source_path),
-                        existing_document.id,
-                    )
-                    return
+                if duplicate is not None:
+                    return self._completed_identity_result(job, duplicate.result())
 
                 source_copy_path = _copy_source_pdf(
                     self.storage_paths,
                     source_path,
                     source_hash,
                 )
-            self.processor.process(
-                PreparedSourceArtifact(
-                    source_path=source_path,
-                    artifact_path=source_copy_path,
+                decision = register_acquired_artifact(
+                    self.storage_paths.database,
+                    source_identity=build_source_identity(
+                        source_path=source_path,
+                        source_url=source_url,
+                    ),
                     content_hash=source_hash,
                     media_type=PDF_MEDIA_TYPE,
-                    source_url=source_url,
+                    byte_size=source_copy_path.stat().st_size,
+                    stored_path=source_copy_path,
                     acquired_at=_metadata_retrieved_at(metadata) or _current_timestamp(),
-                    work_dir=self.storage_paths.ocr_pdfs,
-                    metadata=metadata,
-                    adapter_options={"pdf_extractor": _payload_pdf_extractor_mode(job.payload)},
-                ),
-                job_id=job.id,
-            )
+                )
+                if decision.action == "complete":
+                    return self._completed_identity_result(job, decision.result())
+
+            try:
+                document_id = self.processor.process(
+                    PreparedSourceArtifact(
+                        source_path=decision.document_source_path,
+                        artifact_path=decision.artifact_path,
+                        content_hash=source_hash,
+                        media_type=PDF_MEDIA_TYPE,
+                        source_url=decision.document_source_url,
+                        acquired_at=decision.acquired_at,
+                        work_dir=self.storage_paths.ocr_pdfs,
+                        metadata=metadata,
+                        adapter_options={"pdf_extractor": _payload_pdf_extractor_mode(job.payload)},
+                    ),
+                    job_id=job.id,
+                )
+            except sqlite3.IntegrityError as exc:
+                published_document_id = find_document_for_artifact(
+                    self.storage_paths.database,
+                    decision.artifact_id,
+                )
+                if "documents.artifact_id" in str(exc) and published_document_id is not None:
+                    return self._completed_identity_result(
+                        job,
+                        decision.result(
+                            outcome=OUTCOME_DUPLICATE_IGNORED,
+                            document_id=published_document_id,
+                        ),
+                    )
+                raise
+            return decision.result(outcome=OUTCOME_CREATED, document_id=document_id)
         except IngestError:
             raise
         except Exception as exc:
             raise IngestError(f"Failed ingesting {source_path}: {exc}") from exc
+
+    def _completed_identity_result(
+        self,
+        job: Job,
+        result: dict[str, object],
+    ) -> dict[str, object]:
+        LOGGER.info(
+            "ingest_identity_decided job_id=%s outcome=%s artifact_id=%s document_id=%s",
+            job.id,
+            result["outcome"],
+            result["artifact_id"],
+            result.get("document_id", "-"),
+        )
+        return result
 
 
 def enqueue_ingest_jobs(
@@ -675,7 +716,7 @@ def build_ingest_handler(
     embedding_provider: EmbeddingProvider | None = None,
     vector_store: VectorStore | None = None,
     passage_vector_store: PassageVectorStore | None = None,
-) -> Callable[[Job], Awaitable[None]]:
+) -> Callable[[Job], Awaitable[dict[str, object]]]:
     """Build an async handler for local-PDF ingest jobs."""
 
     pipeline = IngestionPipeline(
@@ -988,20 +1029,23 @@ def _looks_like_pdf(content_type: str | None, content: bytes) -> bool:
     return "application/pdf" in normalized_content_type or content.startswith(b"%PDF-")
 
 
-def _download_filename(final_url: httpx.URL) -> str:
-    parsed_path = urlparse(str(final_url)).path
-    candidate_name = Path(unquote(parsed_path)).name or "downloaded.pdf"
-    if not candidate_name.lower().endswith(".pdf"):
-        return f"{candidate_name}.pdf"
-    return candidate_name
-
-
 def _copy_source_pdf(storage_paths: StoragePaths, source_path: Path, source_hash: str) -> Path:
-    destination = storage_paths.source_pdfs / f"{source_hash}-{source_path.name}"
+    destination = storage_paths.source_pdfs / f"{source_hash}.pdf"
     if source_path.resolve() == destination.resolve():
-        return source_path
+        return destination
+    if destination.exists():
+        if _hash_file(destination) != source_hash:
+            raise IngestError(f"Stored artifact failed integrity check: {destination}")
+        return destination
 
-    shutil.copy2(source_path, destination)
+    temporary_path = destination.with_name(f".{source_hash}-{uuid.uuid4().hex}.tmp")
+    try:
+        shutil.copy2(source_path, temporary_path)
+        if _hash_file(temporary_path) != source_hash:
+            raise IngestError(f"Source changed while acquiring artifact: {source_path}")
+        temporary_path.replace(destination)
+    finally:
+        temporary_path.unlink(missing_ok=True)
     return destination
 
 
@@ -1196,12 +1240,7 @@ def _publish_document_bundle(
     database_path: Path,
     *,
     document_id: str,
-    source_identity: SourceIdentity,
     artifact_id: str,
-    artifact_byte_size: int,
-    artifact_stored_path: Path,
-    artifact_acquired_at: str,
-    artifact_media_type: str,
     source_path: Path,
     source_url: str | None,
     title: str,
@@ -1229,48 +1268,6 @@ def _publish_document_bundle(
     ) as connection:
         connection.execute(
             """
-            INSERT OR IGNORE INTO sources(
-                id,
-                kind,
-                submitted_reference,
-                normalized_reference,
-                resolved_reference
-            )
-            VALUES(?, ?, ?, ?, ?)
-            """,
-            (
-                source_identity.id,
-                source_identity.kind,
-                source_identity.submitted_reference,
-                source_identity.normalized_reference,
-                source_identity.resolved_reference,
-            ),
-        )
-        connection.execute(
-            """
-            INSERT INTO source_artifacts(
-                id,
-                source_id,
-                media_type,
-                byte_size,
-                content_hash,
-                stored_path,
-                acquired_at
-            )
-            VALUES(?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                artifact_id,
-                source_identity.id,
-                artifact_media_type,
-                artifact_byte_size,
-                source_hash,
-                str(artifact_stored_path),
-                artifact_acquired_at,
-            ),
-        )
-        connection.execute(
-            """
             INSERT INTO documents(
                 id,
                 source_path,
@@ -1293,6 +1290,10 @@ def _publish_document_bundle(
                 metadata_json,
                 artifact_id,
             ),
+        )
+        connection.execute(
+            "UPDATE source_artifacts SET state = 'published' WHERE id = ?",
+            (artifact_id,),
         )
         connection.executemany(
             """
@@ -1396,8 +1397,9 @@ def _publication_transaction(
     vector_store: VectorStore,
     passage_vector_store: PassageVectorStore,
 ) -> Iterator[sqlite3.Connection]:
-    connection = sqlite3.connect(database_path)
+    connection = sqlite3.connect(database_path, timeout=30)
     connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute("BEGIN IMMEDIATE")
     try:
         yield connection
         connection.commit()

--- a/newsrag/ingestion_identity.py
+++ b/newsrag/ingestion_identity.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from newsrag.sources import SOURCE_KIND_URL, SourceIdentity, artifact_id_for_hash
+
+ARTIFACT_STATE_PROCESSING = "processing"
+ARTIFACT_STATE_CHANGE_DETECTED = "change_detected"
+ARTIFACT_STATE_PUBLISHED = "published"
+
+OUTCOME_CREATED = "created"
+OUTCOME_DUPLICATE_IGNORED = "duplicate_ignored"
+OUTCOME_CHANGE_DETECTED = "change_detected_artifact_saved"
+OUTCOME_CHANGE_ALREADY_DETECTED = "change_already_detected"
+
+DecisionAction = Literal["process", "complete"]
+
+
+@dataclass(frozen=True)
+class IngestionIdentityDecision:
+    """Identity decision made after exact artifact acquisition."""
+
+    action: DecisionAction
+    source_id: str
+    artifact_id: str
+    artifact_path: Path
+    acquired_at: str
+    document_source_path: Path
+    document_source_url: str | None
+    outcome: str | None = None
+    document_id: str | None = None
+
+    def result(
+        self, *, outcome: str | None = None, document_id: str | None = None
+    ) -> dict[str, object]:
+        """Build the structured job result for this identity decision."""
+
+        resolved_outcome = outcome or self.outcome
+        if resolved_outcome is None:
+            raise ValueError("An ingestion outcome is required")
+        result: dict[str, object] = {
+            "outcome": resolved_outcome,
+            "source_id": self.source_id,
+            "artifact_id": self.artifact_id,
+        }
+        resolved_document_id = document_id or self.document_id
+        if resolved_document_id is not None:
+            result["document_id"] = resolved_document_id
+        return result
+
+
+def find_published_duplicate(
+    database_path: Path,
+    content_hash: str,
+) -> IngestionIdentityDecision | None:
+    """Return an exact published-artifact match without modifying the corpus."""
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        row = _artifact_row(connection, content_hash)
+    if row is None or row["document_id"] is None:
+        return None
+    return _decision_from_row(
+        row,
+        action="complete",
+        outcome=OUTCOME_DUPLICATE_IGNORED,
+    )
+
+
+def register_acquired_artifact(
+    database_path: Path,
+    *,
+    source_identity: SourceIdentity,
+    content_hash: str,
+    media_type: str,
+    byte_size: int,
+    stored_path: Path,
+    acquired_at: str,
+) -> IngestionIdentityDecision:
+    """Register exact bytes and decide whether ordinary processing may continue."""
+
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute("BEGIN IMMEDIATE")
+
+        artifact_row = _artifact_row(connection, content_hash)
+        if artifact_row is not None:
+            decision = _decision_for_existing_artifact(connection, artifact_row)
+            connection.commit()
+            return decision
+
+        current_document_id = _published_document_for_source(connection, source_identity.id)
+        _insert_source(connection, source_identity)
+        artifact_id = artifact_id_for_hash(content_hash)
+        state = (
+            ARTIFACT_STATE_CHANGE_DETECTED
+            if current_document_id is not None
+            else ARTIFACT_STATE_PROCESSING
+        )
+        connection.execute(
+            """
+            INSERT INTO source_artifacts(
+                id,
+                source_id,
+                media_type,
+                byte_size,
+                content_hash,
+                stored_path,
+                acquired_at,
+                state
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                artifact_id,
+                source_identity.id,
+                media_type,
+                byte_size,
+                content_hash,
+                str(stored_path),
+                acquired_at,
+                state,
+            ),
+        )
+        connection.commit()
+
+    action: DecisionAction = "complete" if current_document_id is not None else "process"
+    outcome = OUTCOME_CHANGE_DETECTED if current_document_id is not None else None
+    return IngestionIdentityDecision(
+        action=action,
+        source_id=source_identity.id,
+        artifact_id=artifact_id,
+        artifact_path=stored_path,
+        acquired_at=acquired_at,
+        document_source_path=_document_source_path(
+            source_kind=source_identity.kind,
+            submitted_reference=source_identity.submitted_reference,
+            stored_path=stored_path,
+        ),
+        document_source_url=(
+            source_identity.submitted_reference if source_identity.kind == SOURCE_KIND_URL else None
+        ),
+        outcome=outcome,
+        document_id=current_document_id,
+    )
+
+
+def find_document_for_artifact(database_path: Path, artifact_id: str) -> str | None:
+    """Return the published document ID for an artifact, if one exists."""
+
+    with sqlite3.connect(database_path) as connection:
+        row = connection.execute(
+            """
+            SELECT id
+            FROM documents
+            WHERE artifact_id = ?
+            ORDER BY created_at ASC, id ASC
+            LIMIT 1
+            """,
+            (artifact_id,),
+        ).fetchone()
+    return str(row[0]) if row is not None else None
+
+
+def _decision_for_existing_artifact(
+    connection: sqlite3.Connection,
+    row: sqlite3.Row,
+) -> IngestionIdentityDecision:
+    if row["document_id"] is not None:
+        return _decision_from_row(
+            row,
+            action="complete",
+            outcome=OUTCOME_DUPLICATE_IGNORED,
+        )
+
+    if str(row["state"]) == ARTIFACT_STATE_CHANGE_DETECTED:
+        current_document_id = _published_document_for_source(
+            connection,
+            str(row["source_id"]),
+        )
+        return _decision_from_row(
+            row,
+            action="complete",
+            outcome=OUTCOME_CHANGE_ALREADY_DETECTED,
+            document_id=current_document_id,
+        )
+
+    return _decision_from_row(row, action="process")
+
+
+def _decision_from_row(
+    row: sqlite3.Row,
+    *,
+    action: DecisionAction,
+    outcome: str | None = None,
+    document_id: str | None = None,
+) -> IngestionIdentityDecision:
+    stored_path = Path(str(row["stored_path"]))
+    source_kind = str(row["source_kind"])
+    submitted_reference = str(row["submitted_reference"])
+    return IngestionIdentityDecision(
+        action=action,
+        source_id=str(row["source_id"]),
+        artifact_id=str(row["artifact_id"]),
+        artifact_path=stored_path,
+        acquired_at=str(row["acquired_at"]),
+        document_source_path=_document_source_path(
+            source_kind=source_kind,
+            submitted_reference=submitted_reference,
+            stored_path=stored_path,
+        ),
+        document_source_url=(submitted_reference if source_kind == SOURCE_KIND_URL else None),
+        outcome=outcome,
+        document_id=(
+            document_id
+            if document_id is not None
+            else str(row["document_id"])
+            if row["document_id"] is not None
+            else None
+        ),
+    )
+
+
+def _artifact_row(connection: sqlite3.Connection, content_hash: str) -> sqlite3.Row | None:
+    row = connection.execute(
+        """
+        SELECT
+            source_artifacts.id AS artifact_id,
+            source_artifacts.source_id,
+            source_artifacts.stored_path,
+            source_artifacts.acquired_at,
+            source_artifacts.state,
+            sources.kind AS source_kind,
+            sources.submitted_reference,
+            documents.id AS document_id
+        FROM source_artifacts
+        JOIN sources ON sources.id = source_artifacts.source_id
+        LEFT JOIN documents ON documents.artifact_id = source_artifacts.id
+        WHERE source_artifacts.content_hash = ?
+        ORDER BY documents.created_at ASC, documents.id ASC
+        LIMIT 1
+        """,
+        (content_hash,),
+    ).fetchone()
+    return row if isinstance(row, sqlite3.Row) else None
+
+
+def _published_document_for_source(
+    connection: sqlite3.Connection,
+    source_id: str,
+) -> str | None:
+    row = connection.execute(
+        """
+        SELECT documents.id
+        FROM source_artifacts
+        JOIN documents ON documents.artifact_id = source_artifacts.id
+        WHERE source_artifacts.source_id = ?
+        ORDER BY documents.created_at ASC, documents.id ASC
+        LIMIT 1
+        """,
+        (source_id,),
+    ).fetchone()
+    return str(row[0]) if row is not None else None
+
+
+def _insert_source(connection: sqlite3.Connection, source_identity: SourceIdentity) -> None:
+    connection.execute(
+        """
+        INSERT OR IGNORE INTO sources(
+            id,
+            kind,
+            submitted_reference,
+            normalized_reference,
+            resolved_reference
+        )
+        VALUES(?, ?, ?, ?, ?)
+        """,
+        (
+            source_identity.id,
+            source_identity.kind,
+            source_identity.submitted_reference,
+            source_identity.normalized_reference,
+            source_identity.resolved_reference,
+        ),
+    )
+
+
+def _document_source_path(
+    *,
+    source_kind: str,
+    submitted_reference: str,
+    stored_path: Path,
+) -> Path:
+    if source_kind == SOURCE_KIND_URL:
+        return stored_path
+    return Path(submitted_reference)

--- a/newsrag/jobs.py
+++ b/newsrag/jobs.py
@@ -13,6 +13,8 @@ RUNNING: JobStatus = "running"
 DONE: JobStatus = "done"
 FAILED: JobStatus = "failed"
 
+_DUPLICATE_IGNORED_OUTCOME = "duplicate_ignored"
+
 
 class JobRetryError(Exception):
     """Raised when a durable job cannot be retried."""
@@ -26,6 +28,7 @@ class Job:
     kind: str
     status: JobStatus
     payload: dict[str, Any]
+    result: dict[str, Any] | None
     error: str | None
     created_at: str
     updated_at: str
@@ -63,7 +66,7 @@ def get_job(database_path: Path, job_id: str) -> Job:
         connection.row_factory = sqlite3.Row
         row = connection.execute(
             """
-            SELECT id, kind, status, payload_json, error, created_at, updated_at
+            SELECT id, kind, status, payload_json, result_json, error, created_at, updated_at
             FROM jobs
             WHERE id = ?
             """,
@@ -82,7 +85,7 @@ def list_jobs(database_path: Path) -> list[Job]:
         connection.row_factory = sqlite3.Row
         rows = connection.execute(
             """
-            SELECT id, kind, status, payload_json, error, created_at, updated_at
+            SELECT id, kind, status, payload_json, result_json, error, created_at, updated_at
             FROM jobs
             ORDER BY created_at ASC, id ASC
             """
@@ -116,7 +119,7 @@ def claim_next_job(database_path: Path) -> Job | None:
         connection.execute(
             """
             UPDATE jobs
-            SET status = ?, error = NULL, updated_at = CURRENT_TIMESTAMP
+            SET status = ?, result_json = NULL, error = NULL, updated_at = CURRENT_TIMESTAMP
             WHERE id = ?
             """,
             (RUNNING, job_id),
@@ -126,16 +129,37 @@ def claim_next_job(database_path: Path) -> Job | None:
     return get_job(database_path, job_id)
 
 
-def mark_job_done(database_path: Path, job_id: str) -> Job:
-    """Mark a running job done."""
+def mark_job_done(
+    database_path: Path,
+    job_id: str,
+    *,
+    result: dict[str, Any] | None = None,
+) -> Job:
+    """Mark a running job done with an optional structured result."""
 
-    return _set_job_status(database_path, job_id, status=DONE, error=None)
+    return _set_job_status(
+        database_path,
+        job_id,
+        status=DONE,
+        result=result,
+        error=None,
+        discard_payload=(
+            result is not None and result.get("outcome") == _DUPLICATE_IGNORED_OUTCOME
+        ),
+    )
 
 
 def mark_job_failed(database_path: Path, job_id: str, *, error: str) -> Job:
     """Mark a running job failed with context."""
 
-    return _set_job_status(database_path, job_id, status=FAILED, error=error)
+    return _set_job_status(
+        database_path,
+        job_id,
+        status=FAILED,
+        result=None,
+        error=error,
+        discard_payload=False,
+    )
 
 
 def retry_failed_job(database_path: Path, job_id: str) -> Job:
@@ -149,7 +173,14 @@ def retry_failed_job(database_path: Path, job_id: str) -> Job:
     if job.status != FAILED:
         raise JobRetryError(f"Job {job_id} is {job.status}; only failed jobs can be retried")
 
-    return _set_job_status(database_path, job_id, status=PENDING, error=None)
+    return _set_job_status(
+        database_path,
+        job_id,
+        status=PENDING,
+        result=None,
+        error=None,
+        discard_payload=False,
+    )
 
 
 def set_job_status(
@@ -164,7 +195,14 @@ def set_job_status(
     This is primarily useful for deterministic tests and status shaping.
     """
 
-    return _set_job_status(database_path, job_id, status=status, error=error)
+    return _set_job_status(
+        database_path,
+        job_id,
+        status=status,
+        result=None,
+        error=error,
+        discard_payload=False,
+    )
 
 
 def _set_job_status(
@@ -172,16 +210,23 @@ def _set_job_status(
     job_id: str,
     *,
     status: JobStatus,
+    result: dict[str, Any] | None,
     error: str | None,
+    discard_payload: bool,
 ) -> Job:
+    result_json = json.dumps(result, sort_keys=True) if result is not None else None
     with sqlite3.connect(database_path) as connection:
         connection.execute(
             """
             UPDATE jobs
-            SET status = ?, error = ?, updated_at = CURRENT_TIMESTAMP
+            SET status = ?,
+                payload_json = CASE WHEN ? THEN '{}' ELSE payload_json END,
+                result_json = ?,
+                error = ?,
+                updated_at = CURRENT_TIMESTAMP
             WHERE id = ?
             """,
-            (status, error, job_id),
+            (status, discard_payload, result_json, error, job_id),
         )
         connection.commit()
 
@@ -189,15 +234,22 @@ def _set_job_status(
 
 
 def _row_to_job(row: sqlite3.Row) -> Job:
-    payload = json.loads(str(row["payload_json"]))
-    if not isinstance(payload, dict):
-        payload = {}
+    payload = _load_json_mapping(row["payload_json"]) or {}
+    result = _load_json_mapping(row["result_json"])
     return Job(
         id=str(row["id"]),
         kind=str(row["kind"]),
         status=str(row["status"]),
         payload=payload,
+        result=result,
         error=str(row["error"]) if row["error"] is not None else None,
         created_at=str(row["created_at"]),
         updated_at=str(row["updated_at"]),
     )
+
+
+def _load_json_mapping(raw_value: object) -> dict[str, Any] | None:
+    if raw_value is None:
+        return None
+    value = json.loads(str(raw_value))
+    return value if isinstance(value, dict) else None

--- a/newsrag/storage.py
+++ b/newsrag/storage.py
@@ -79,7 +79,7 @@ DIRECTORY_NAMES: tuple[tuple[str, str], ...] = (
     ("artifacts", "artifacts"),
 )
 DATABASE_FILENAME = "newsrag.sqlite3"
-SCHEMA_VERSION = "2"
+SCHEMA_VERSION = "3"
 REQUIRED_TABLES = {
     "sources",
     "source_artifacts",
@@ -129,6 +129,7 @@ SCHEMA_STATEMENTS = (
         content_hash TEXT NOT NULL UNIQUE,
         stored_path TEXT NOT NULL,
         acquired_at TEXT NOT NULL,
+        state TEXT NOT NULL DEFAULT 'processing',
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY(source_id) REFERENCES sources(id)
     )
@@ -231,6 +232,7 @@ SCHEMA_STATEMENTS = (
         kind TEXT NOT NULL,
         status TEXT NOT NULL,
         payload_json TEXT NOT NULL DEFAULT '{}',
+        result_json TEXT,
         error TEXT,
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
         updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
@@ -377,8 +379,11 @@ def initialize_storage(data_dir: Path) -> StoragePaths:
     for directory in _iter_directories(paths):
         directory.mkdir(parents=True, exist_ok=True)
 
-    vector_migration_required = _initialize_database(paths.database)
+    vector_migration_required, removed_document_ids = _initialize_database(paths.database)
+    if removed_document_ids:
+        _delete_document_vectors(paths.lancedb, removed_document_ids)
     if vector_migration_required:
+        _delete_orphan_document_vectors(paths.database, paths.lancedb)
         _backfill_vector_source_unit_ranges(paths.database, paths.lancedb)
     _set_schema_version(paths.database)
     return paths
@@ -530,7 +535,7 @@ def _iter_directories(paths: StoragePaths) -> tuple[Path, ...]:
     return tuple(directory for _, directory in _directory_checks(paths))
 
 
-def _initialize_database(database_path: Path) -> bool:
+def _initialize_database(database_path: Path) -> tuple[bool, tuple[str, ...]]:
     with sqlite3.connect(database_path) as connection:
         connection.execute("PRAGMA foreign_keys = ON")
         for statement in SCHEMA_STATEMENTS:
@@ -547,6 +552,13 @@ def _initialize_database(database_path: Path) -> bool:
             "artifact_id",
             "TEXT REFERENCES source_artifacts(id)",
         )
+        _ensure_column(
+            connection,
+            "source_artifacts",
+            "state",
+            "TEXT NOT NULL DEFAULT 'processing'",
+        )
+        _ensure_column(connection, "jobs", "result_json", "TEXT")
         _ensure_column(connection, "pages", "extractor", "TEXT NOT NULL DEFAULT 'unknown'")
         _ensure_column(
             connection,
@@ -590,6 +602,25 @@ def _initialize_database(database_path: Path) -> bool:
         )
         _backfill_passages(connection)
         _backfill_pdf_source_model(connection)
+        removed_document_ids = _consolidate_duplicate_documents(connection)
+        connection.execute(
+            """
+            UPDATE source_artifacts
+            SET state = 'published'
+            WHERE id IN (
+                SELECT artifact_id
+                FROM documents
+                WHERE artifact_id IS NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_documents_unique_artifact
+            ON documents(artifact_id)
+            WHERE artifact_id IS NOT NULL
+            """
+        )
         connection.execute(
             """
             INSERT INTO passages_fts(passage_id, text)
@@ -600,7 +631,10 @@ def _initialize_database(database_path: Path) -> bool:
         )
         connection.commit()
 
-    return previous_schema_version is None or str(previous_schema_version[0]) != SCHEMA_VERSION
+    migration_required = (
+        previous_schema_version is None or str(previous_schema_version[0]) != SCHEMA_VERSION
+    )
+    return migration_required, removed_document_ids
 
 
 def _set_schema_version(database_path: Path) -> None:
@@ -856,6 +890,131 @@ def _backfill_pdf_source_model(connection: sqlite3.Connection) -> None:
             """,
             (source_kind,),
         )
+
+
+def _consolidate_duplicate_documents(connection: sqlite3.Connection) -> tuple[str, ...]:
+    rows = connection.execute(
+        """
+        SELECT
+            documents.id,
+            COALESCE(source_artifacts.content_hash, documents.source_hash) AS content_hash
+        FROM documents
+        LEFT JOIN source_artifacts ON source_artifacts.id = documents.artifact_id
+        WHERE COALESCE(source_artifacts.content_hash, documents.source_hash) IS NOT NULL
+        ORDER BY documents.created_at ASC, documents.id ASC
+        """
+    ).fetchall()
+    seen_hashes: set[str] = set()
+    duplicate_ids: list[str] = []
+    for document_id, content_hash in rows:
+        normalized_hash = str(content_hash)
+        if normalized_hash in seen_hashes:
+            duplicate_ids.append(str(document_id))
+        else:
+            seen_hashes.add(normalized_hash)
+
+    for document_id in duplicate_ids:
+        _delete_duplicate_document(connection, document_id)
+
+    connection.execute(
+        """
+        DELETE FROM sources
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM source_artifacts
+            WHERE source_artifacts.source_id = sources.id
+        )
+        """
+    )
+    return tuple(duplicate_ids)
+
+
+def _delete_duplicate_document(connection: sqlite3.Connection, document_id: str) -> None:
+    connection.execute(
+        """
+        DELETE FROM discovery_evidence
+        WHERE document_id = ?
+            OR item_id IN (SELECT id FROM discovery_items WHERE document_id = ?)
+        """,
+        (document_id, document_id),
+    )
+    connection.execute(
+        """
+        DELETE FROM discovery_items_fts
+        WHERE item_id IN (SELECT id FROM discovery_items WHERE document_id = ?)
+        """,
+        (document_id,),
+    )
+    connection.execute("DELETE FROM discovery_items WHERE document_id = ?", (document_id,))
+    connection.execute(
+        """
+        DELETE FROM document_briefs_fts
+        WHERE brief_id IN (SELECT id FROM document_briefs WHERE document_id = ?)
+        """,
+        (document_id,),
+    )
+    connection.execute("DELETE FROM document_briefs WHERE document_id = ?", (document_id,))
+    connection.execute("DELETE FROM document_profiles WHERE document_id = ?", (document_id,))
+    connection.execute(
+        """
+        DELETE FROM embedding_records
+        WHERE (source_kind = 'chunk' AND source_key IN (
+                SELECT id FROM chunks WHERE document_id = ?
+            ))
+            OR (source_kind = 'passage' AND source_key IN (
+                SELECT id FROM passages WHERE document_id = ?
+            ))
+        """,
+        (document_id, document_id),
+    )
+    connection.execute(
+        "DELETE FROM passages_fts WHERE passage_id IN "
+        "(SELECT id FROM passages WHERE document_id = ?)",
+        (document_id,),
+    )
+    connection.execute("DELETE FROM passages WHERE document_id = ?", (document_id,))
+    connection.execute(
+        "DELETE FROM chunks_fts WHERE chunk_id IN (SELECT id FROM chunks WHERE document_id = ?)",
+        (document_id,),
+    )
+    connection.execute("DELETE FROM chunks WHERE document_id = ?", (document_id,))
+    connection.execute("DELETE FROM pages WHERE document_id = ?", (document_id,))
+    connection.execute("DELETE FROM source_units WHERE document_id = ?", (document_id,))
+    connection.execute("DELETE FROM documents WHERE id = ?", (document_id,))
+
+
+def _delete_document_vectors(lancedb_path: Path, document_ids: tuple[str, ...]) -> None:
+    database = lancedb.connect(lancedb_path)
+    for table_name in ("chunk_embeddings", "passage_embeddings"):
+        try:
+            table = database.open_table(table_name)
+        except ValueError:
+            continue
+        for document_id in document_ids:
+            escaped_document_id = document_id.replace("'", "''")
+            table.delete(f"document_id = '{escaped_document_id}'")
+
+
+def _delete_orphan_document_vectors(database_path: Path, lancedb_path: Path) -> None:
+    with sqlite3.connect(database_path) as connection:
+        document_ids = {
+            str(row[0]) for row in connection.execute("SELECT id FROM documents").fetchall()
+        }
+
+    database = lancedb.connect(lancedb_path)
+    for table_name in ("chunk_embeddings", "passage_embeddings"):
+        try:
+            table = database.open_table(table_name)
+        except ValueError:
+            continue
+        orphan_ids = {
+            str(row["document_id"])
+            for row in table.to_arrow().to_pylist()
+            if str(row["document_id"]) not in document_ids
+        }
+        for document_id in orphan_ids:
+            escaped_document_id = document_id.replace("'", "''")
+            table.delete(f"document_id = '{escaped_document_id}'")
 
 
 def _load_metadata_json(raw_metadata: object) -> dict[str, object]:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -9,7 +9,17 @@ from typer.testing import CliRunner
 
 from newsrag.cli import app
 from newsrag.daemon import DaemonRunner
-from newsrag.jobs import DONE, FAILED, PENDING, RUNNING, Job, create_job, get_job, set_job_status
+from newsrag.jobs import (
+    DONE,
+    FAILED,
+    PENDING,
+    RUNNING,
+    Job,
+    create_job,
+    get_job,
+    mark_job_done,
+    set_job_status,
+)
 from newsrag.storage import initialize_storage
 
 runner = CliRunner()
@@ -143,6 +153,34 @@ def test_mocked_job_moves_from_pending_to_running_to_done(
     assert "elapsed_ms=" in caplog.text
 
 
+def test_successful_job_persists_structured_result(tmp_path: Path) -> None:
+    paths = initialize_storage(tmp_path / ".newsrag")
+    job = create_job(paths.database, kind="mock")
+
+    async def handler(_: Job) -> dict[str, object]:
+        return {
+            "outcome": "created",
+            "artifact_id": "artifact-1",
+            "document_id": "document-1",
+        }
+
+    asyncio.run(
+        DaemonRunner(
+            database_path=paths.database,
+            handlers={"mock": handler},
+            poll_interval=0,
+        ).run_cycle()
+    )
+
+    updated_job = get_job(paths.database, job.id)
+    assert updated_job.status == DONE
+    assert updated_job.result == {
+        "artifact_id": "artifact-1",
+        "document_id": "document-1",
+        "outcome": "created",
+    }
+
+
 def test_failing_mocked_job_records_failed_state_and_error(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
@@ -197,7 +235,11 @@ def test_jobs_list_shows_all_job_statuses(tmp_path: Path) -> None:
     failed_job = create_job(paths.database, kind="failed-job", job_id="job-failed")
 
     set_job_status(paths.database, running_job.id, status=RUNNING)
-    set_job_status(paths.database, done_job.id, status=DONE)
+    mark_job_done(
+        paths.database,
+        done_job.id,
+        result={"outcome": "created", "document_id": "document-1"},
+    )
     set_job_status(paths.database, failed_job.id, status=FAILED, error="boom")
 
     result = runner.invoke(app, ["--data-dir", str(data_dir), "jobs", "list"])
@@ -210,6 +252,8 @@ def test_jobs_list_shows_all_job_statuses(tmp_path: Path) -> None:
     assert "running" in result.stdout
     assert done_job.id in result.stdout
     assert "done" in result.stdout
+    assert "outcome=created" in result.stdout
+    assert "document_id=document-1" in result.stdout
     assert failed_job.id in result.stdout
     assert "failed" in result.stdout
     assert "failed_at=" in result.stdout

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -5,8 +5,10 @@ import json
 import logging
 import sqlite3
 from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
+from threading import Barrier
 
 import httpx
 import lancedb  # type: ignore[import-untyped]
@@ -14,6 +16,7 @@ import pytest
 from typer.testing import CliRunner
 
 from newsrag.adapters import (
+    AdapterError,
     AdapterInput,
     AdapterResult,
     CanonicalSourceUnit,
@@ -48,7 +51,14 @@ from newsrag.ingest import (
     list_documents,
     list_pages,
 )
-from newsrag.jobs import FAILED, create_job, get_job, list_jobs, set_job_status
+from newsrag.jobs import (
+    FAILED,
+    create_job,
+    get_job,
+    list_jobs,
+    retry_failed_job,
+    set_job_status,
+)
 from newsrag.manifests import ManifestError, load_manifest
 from newsrag.storage import initialize_storage
 
@@ -535,8 +545,6 @@ def test_failed_vector_publication_leaves_no_searchable_document(tmp_path: Path)
     assert "passage vector boom" in (updated_job.error or "")
     with sqlite3.connect(paths.database) as connection:
         for table_name in (
-            "sources",
-            "source_artifacts",
             "documents",
             "source_units",
             "pages",
@@ -548,6 +556,10 @@ def test_failed_vector_publication_leaves_no_searchable_document(tmp_path: Path)
         ):
             count = connection.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()
             assert count == (0,)
+        assert connection.execute("SELECT COUNT(*) FROM sources").fetchone() == (1,)
+        assert connection.execute("SELECT state FROM source_artifacts").fetchone() == (
+            "processing",
+        )
     assert len(chunk_vector_store.added) == 1
     assert len(chunk_vector_store.removed_document_ids) == 1
     assert passage_vector_store.removed_document_ids == chunk_vector_store.removed_document_ids
@@ -763,16 +775,16 @@ def test_reingesting_unchanged_pdf_does_not_duplicate_records(tmp_path: Path) ->
     source_pdf.write_bytes(b"%PDF-1.4\nmock")
     paths = initialize_storage(data_dir)
 
-    create_job(
+    first_job = create_job(
         paths.database,
         kind=INGEST_JOB_KIND,
         payload={"path": str(source_pdf.resolve()), "metadata": {"body": "City Council"}},
         job_id="job-first",
     )
-    create_job(
+    second_job = create_job(
         paths.database,
         kind=INGEST_JOB_KIND,
-        payload={"path": str(source_pdf.resolve()), "metadata": {"body": "City Council"}},
+        payload={"path": str(source_pdf.resolve()), "metadata": {"body": "Other Council"}},
         job_id="job-second",
     )
 
@@ -793,11 +805,339 @@ def test_reingesting_unchanged_pdf_does_not_duplicate_records(tmp_path: Path) ->
     asyncio.run(runner_instance.run_cycle())
     asyncio.run(runner_instance.run_cycle())
 
-    assert len(list_documents(paths.database)) == 1
+    documents = list_documents(paths.database)
+    first_result = get_job(paths.database, first_job.id).result
+    updated_second_job = get_job(paths.database, second_job.id)
+    second_result = updated_second_job.result
+
+    assert len(documents) == 1
+    assert documents[0].metadata["body"] == "City Council"
+    assert first_result is not None
+    assert first_result["outcome"] == "created"
+    assert second_result is not None
+    assert second_result["outcome"] == "duplicate_ignored"
+    assert second_result["document_id"] == first_result["document_id"]
+    assert second_result["artifact_id"] == first_result["artifact_id"]
+    assert updated_second_job.payload == {}
     assert len(list_pages(paths.database)) == 1
     assert len(list_chunks(paths.database)) == 1
     assert len(list_chunk_vectors(paths.lancedb)) == 1
     assert len(list_embedding_records(paths.database)) == 2
+
+
+def test_same_bytes_from_different_local_paths_ignore_the_second_source(
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / ".newsrag"
+    first_pdf = tmp_path / "first.pdf"
+    second_pdf = tmp_path / "renamed.pdf"
+    content = b"%PDF-1.4\nidentical"
+    first_pdf.write_bytes(content)
+    second_pdf.write_bytes(content)
+    paths = initialize_storage(data_dir)
+    first_job = create_job(
+        paths.database,
+        kind=INGEST_JOB_KIND,
+        payload={"path": str(first_pdf.resolve()), "metadata": {}},
+        job_id="job-a-first",
+    )
+    second_job = create_job(
+        paths.database,
+        kind=INGEST_JOB_KIND,
+        payload={"path": str(second_pdf.resolve()), "metadata": {}},
+        job_id="job-z-second",
+    )
+    adapter = FakeSourceAdapter()
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        adapter=adapter,
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+    runner_instance = DaemonRunner(
+        database_path=paths.database,
+        handlers={INGEST_JOB_KIND: handler},
+        poll_interval=0,
+    )
+
+    asyncio.run(runner_instance.run_cycle())
+    asyncio.run(runner_instance.run_cycle())
+
+    with sqlite3.connect(paths.database) as connection:
+        sources = connection.execute(
+            "SELECT submitted_reference FROM sources ORDER BY id"
+        ).fetchall()
+        artifact_count = connection.execute("SELECT COUNT(*) FROM source_artifacts").fetchone()
+    assert get_job(paths.database, first_job.id).result["outcome"] == "created"  # type: ignore[index]
+    updated_second_job = get_job(paths.database, second_job.id)
+    assert updated_second_job.result["outcome"] == "duplicate_ignored"  # type: ignore[index]
+    assert updated_second_job.payload == {}
+    assert sources == [(str(first_pdf.resolve()),)]
+    assert artifact_count == (1,)
+    assert len(adapter.inputs) == 1
+
+
+def test_same_bytes_from_different_urls_ignore_the_second_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_dir = tmp_path / ".newsrag"
+    paths = initialize_storage(data_dir)
+    first_url = "https://one.example.gov/packet.pdf"
+    second_url = "https://two.example.gov/renamed.pdf"
+    content = b"%PDF-1.4\nidentical-url"
+    monkeypatch.setattr(
+        "newsrag.ingest.httpx.get",
+        _fake_pdf_url_map_getter({first_url: content, second_url: content}),
+    )
+    first_job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=first_url)
+    adapter = FakeSourceAdapter()
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        adapter=adapter,
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+    runner_instance = DaemonRunner(
+        database_path=paths.database,
+        handlers={INGEST_JOB_KIND: handler},
+        poll_interval=0,
+    )
+
+    asyncio.run(runner_instance.run_cycle())
+    second_job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=second_url)
+    asyncio.run(runner_instance.run_cycle())
+
+    with sqlite3.connect(paths.database) as connection:
+        sources = connection.execute(
+            "SELECT submitted_reference FROM sources ORDER BY id"
+        ).fetchall()
+    first_result = get_job(paths.database, first_job.id).result
+    second_result = get_job(paths.database, second_job.id).result
+    assert first_result is not None and first_result["outcome"] == "created"
+    assert second_result is not None and second_result["outcome"] == "duplicate_ignored"
+    assert get_job(paths.database, second_job.id).payload == {}
+    assert sources == [(first_url,)]
+    assert len(list(paths.downloaded_pdfs.iterdir())) == 1
+    assert len(list(paths.source_pdfs.iterdir())) == 1
+    assert len(adapter.inputs) == 1
+
+
+def test_changed_source_bytes_are_preserved_without_replacing_document(
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / ".newsrag"
+    source_pdf = tmp_path / "packet.pdf"
+    source_pdf.write_bytes(b"%PDF-1.4\nfirst")
+    paths = initialize_storage(data_dir)
+    first_job = create_job(
+        paths.database,
+        kind=INGEST_JOB_KIND,
+        payload={"path": str(source_pdf.resolve()), "metadata": {"title": "First title"}},
+    )
+    adapter = FakeSourceAdapter()
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        adapter=adapter,
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+    runner_instance = DaemonRunner(
+        database_path=paths.database,
+        handlers={INGEST_JOB_KIND: handler},
+        poll_interval=0,
+    )
+    asyncio.run(runner_instance.run_cycle())
+
+    source_pdf.write_bytes(b"%PDF-1.4\nchanged")
+    changed_job = create_job(
+        paths.database,
+        kind=INGEST_JOB_KIND,
+        payload={"path": str(source_pdf.resolve()), "metadata": {"title": "Changed title"}},
+    )
+    asyncio.run(runner_instance.run_cycle())
+    repeated_path = tmp_path / "same-change-at-new-path.pdf"
+    repeated_path.write_bytes(b"%PDF-1.4\nchanged")
+    repeated_change_job = create_job(
+        paths.database,
+        kind=INGEST_JOB_KIND,
+        payload={"path": str(repeated_path.resolve()), "metadata": {}},
+    )
+    asyncio.run(runner_instance.run_cycle())
+
+    documents = list_documents(paths.database)
+    with sqlite3.connect(paths.database) as connection:
+        artifact_states = connection.execute(
+            "SELECT state FROM source_artifacts ORDER BY state"
+        ).fetchall()
+        source_count = connection.execute("SELECT COUNT(*) FROM sources").fetchone()
+    first_result = get_job(paths.database, first_job.id).result
+    changed_result = get_job(paths.database, changed_job.id).result
+    repeated_result = get_job(paths.database, repeated_change_job.id).result
+    assert first_result is not None and first_result["outcome"] == "created"
+    assert changed_result is not None
+    assert changed_result["outcome"] == "change_detected_artifact_saved"
+    assert changed_result["document_id"] == first_result["document_id"]
+    assert repeated_result is not None
+    assert repeated_result["outcome"] == "change_already_detected"
+    assert len(documents) == 1
+    assert documents[0].title == "First title"
+    assert artifact_states == [("change_detected",), ("published",)]
+    assert source_count == (1,)
+    assert len(adapter.inputs) == 1
+
+
+def test_different_raw_bytes_with_same_extracted_text_create_distinct_documents(
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / ".newsrag"
+    first_pdf = tmp_path / "first.pdf"
+    second_pdf = tmp_path / "second.pdf"
+    first_pdf.write_bytes(b"%PDF-1.4\nraw-a")
+    second_pdf.write_bytes(b"%PDF-1.4\nraw-b")
+    paths = initialize_storage(data_dir)
+    jobs = [
+        create_job(
+            paths.database,
+            kind=INGEST_JOB_KIND,
+            payload={"path": str(path.resolve()), "metadata": {}},
+        )
+        for path in (first_pdf, second_pdf)
+    ]
+    adapter = FakeSourceAdapter()
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        adapter=adapter,
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+    runner_instance = DaemonRunner(
+        database_path=paths.database,
+        handlers={INGEST_JOB_KIND: handler},
+        poll_interval=0,
+    )
+
+    asyncio.run(runner_instance.run_cycle())
+    asyncio.run(runner_instance.run_cycle())
+
+    assert [get_job(paths.database, job.id).result["outcome"] for job in jobs] == [  # type: ignore[index]
+        "created",
+        "created",
+    ]
+    assert len(list_documents(paths.database)) == 2
+    assert len(adapter.inputs) == 2
+
+
+def test_failed_unpublished_artifact_is_reused_on_retry(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    source_pdf = tmp_path / "packet.pdf"
+    source_pdf.write_bytes(b"%PDF-1.4\nretry")
+    paths = initialize_storage(data_dir)
+    job = create_job(
+        paths.database,
+        kind=INGEST_JOB_KIND,
+        payload={"path": str(source_pdf.resolve()), "metadata": {}},
+    )
+    failing_handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        adapter=FailingSourceAdapter(),
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+    asyncio.run(
+        DaemonRunner(
+            database_path=paths.database,
+            handlers={INGEST_JOB_KIND: failing_handler},
+            poll_interval=0,
+        ).run_cycle()
+    )
+
+    with sqlite3.connect(paths.database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM sources").fetchone() == (1,)
+        assert connection.execute("SELECT COUNT(*) FROM source_artifacts").fetchone() == (1,)
+        assert connection.execute("SELECT COUNT(*) FROM documents").fetchone() == (0,)
+    retry_failed_job(paths.database, job.id)
+    successful_handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        adapter=FakeSourceAdapter(),
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+    asyncio.run(
+        DaemonRunner(
+            database_path=paths.database,
+            handlers={INGEST_JOB_KIND: successful_handler},
+            poll_interval=0,
+        ).run_cycle()
+    )
+
+    updated_job = get_job(paths.database, job.id)
+    assert updated_job.status == "done"
+    assert updated_job.result is not None and updated_job.result["outcome"] == "created"
+    assert len(list_documents(paths.database)) == 1
+    with sqlite3.connect(paths.database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM sources").fetchone() == (1,)
+        assert connection.execute("SELECT COUNT(*) FROM source_artifacts").fetchone() == (1,)
+        assert connection.execute("SELECT state FROM source_artifacts").fetchone() == ("published",)
+
+
+def test_concurrent_exact_duplicates_converge_on_one_document(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    first_pdf = tmp_path / "first.pdf"
+    second_pdf = tmp_path / "second.pdf"
+    content = b"%PDF-1.4\nconcurrent"
+    first_pdf.write_bytes(content)
+    second_pdf.write_bytes(content)
+    paths = initialize_storage(data_dir)
+    jobs = [
+        create_job(
+            paths.database,
+            kind=INGEST_JOB_KIND,
+            payload={"path": str(path.resolve()), "metadata": {}},
+        )
+        for path in (first_pdf, second_pdf)
+    ]
+    adapter = BarrierSourceAdapter(Barrier(2))
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        adapter=adapter,
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+
+    def run_one_cycle() -> bool:
+        return asyncio.run(
+            DaemonRunner(
+                database_path=paths.database,
+                handlers={INGEST_JOB_KIND: handler},
+                poll_interval=0,
+            ).run_cycle()
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        processed = list(executor.map(lambda _: run_one_cycle(), range(2)))
+
+    outcomes = sorted(
+        str(get_job(paths.database, job.id).result["outcome"])  # type: ignore[index]
+        for job in jobs
+    )
+    assert processed == [True, True]
+    assert outcomes == ["created", "duplicate_ignored"]
+    assert len(list_documents(paths.database)) == 1
+    assert len(list_pages(paths.database)) == 1
+    assert len(list_chunks(paths.database)) == 1
+    assert len(list_chunk_vectors(paths.lancedb)) == 1
+    assert len(list(paths.source_pdfs.iterdir())) == 1
+    with sqlite3.connect(paths.database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM sources").fetchone() == (1,)
+        assert connection.execute("SELECT COUNT(*) FROM source_artifacts").fetchone() == (1,)
 
 
 def test_retried_ingest_job_keeps_duplicate_detection_idempotent(tmp_path: Path) -> None:
@@ -914,6 +1254,44 @@ class FakeSourceAdapter:
                 ),
             ),
             extractor=ExtractorIdentity(name="fake-adapter"),
+            derived_artifact_path=artifact.artifact_path,
+        )
+
+
+@dataclass(frozen=True)
+class FailingSourceAdapter:
+    @property
+    def media_types(self) -> tuple[str, ...]:
+        return ("application/pdf",)
+
+    def extract(self, artifact: AdapterInput) -> AdapterResult:
+        raise AdapterError(f"extract failed for {artifact.artifact_path}")
+
+
+@dataclass(frozen=True)
+class BarrierSourceAdapter:
+    barrier: Barrier
+
+    @property
+    def media_types(self) -> tuple[str, ...]:
+        return ("application/pdf",)
+
+    def extract(self, artifact: AdapterInput) -> AdapterResult:
+        self.barrier.wait(timeout=5)
+        return AdapterResult(
+            media_type="application/pdf",
+            units=(
+                CanonicalSourceUnit(
+                    ordinal=1,
+                    location_type="page",
+                    location={"page_number": 1},
+                    human_label="p. 1",
+                    normalized_text="Concurrent agenda",
+                    structure={},
+                    extractor=ExtractorIdentity(name="barrier-adapter"),
+                ),
+            ),
+            extractor=ExtractorIdentity(name="barrier-adapter"),
             derived_artifact_path=artifact.artifact_path,
         )
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -295,6 +295,7 @@ def test_initialize_storage_migrates_pdf_records_to_source_units(tmp_path: Path)
     assert artifact["byte_size"] == len(source_bytes)
     assert artifact["content_hash"] == source_hash
     assert artifact["stored_path"] == str(source_pdf)
+    assert artifact["state"] == "published"
     assert document is not None
     assert document["artifact_id"] == artifact["id"]
     assert unit is not None
@@ -318,6 +319,149 @@ def test_initialize_storage_migrates_pdf_records_to_source_units(tmp_path: Path)
     assert chunk_vector["source_unit_end_id"] == unit["id"]
     assert passage_vector["source_unit_start_id"] == unit["id"]
     assert passage_vector["source_unit_end_id"] == unit["id"]
+
+
+def test_initialize_storage_consolidates_legacy_exact_hash_documents(
+    tmp_path: Path,
+) -> None:
+    paths = initialize_storage(tmp_path / ".newsrag")
+    with sqlite3.connect(paths.database) as connection:
+        connection.execute("DROP INDEX idx_documents_unique_artifact")
+        connection.execute("UPDATE metadata SET value = '2' WHERE key = 'schema_version'")
+        connection.execute(
+            """
+            INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+            VALUES('source-1', 'local_path', '/tmp/packet.pdf', '/tmp/packet.pdf')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, byte_size, content_hash, stored_path, acquired_at
+            )
+            VALUES(
+                'artifact-1', 'source-1', 'application/pdf', 10, 'same-hash',
+                '/tmp/packet.pdf', CURRENT_TIMESTAMP
+            )
+            """
+        )
+        for suffix in ("a", "b"):
+            document_id = f"document-{suffix}"
+            unit_id = f"unit-{suffix}"
+            chunk_id = f"chunk-{suffix}"
+            passage_id = f"passage-{suffix}"
+            connection.execute(
+                """
+                INSERT INTO documents(id, source_path, title, source_hash, metadata_json, artifact_id)
+                VALUES(?, '/tmp/packet.pdf', ?, 'same-hash', '{}', 'artifact-1')
+                """,
+                (document_id, f"Packet {suffix.upper()}"),
+            )
+            connection.execute(
+                """
+                INSERT INTO source_units(
+                    id, artifact_id, document_id, ordinal, location_type, location_json,
+                    human_label, normalized_text, structure_json, extractor
+                )
+                VALUES(?, 'artifact-1', ?, 1, 'page', '{"page_number": 1}', 'p. 1', ?, '{}', 'test')
+                """,
+                (unit_id, document_id, f"Agenda {suffix}"),
+            )
+            connection.execute(
+                """
+                INSERT INTO pages(id, document_id, page_number, source_unit_id, text, extractor)
+                VALUES(?, ?, 1, ?, ?, 'test')
+                """,
+                (f"page-{suffix}", document_id, unit_id, f"Agenda {suffix}"),
+            )
+            connection.execute(
+                """
+                INSERT INTO chunks(
+                    id, document_id, page_start, page_end, source_unit_start_id,
+                    source_unit_end_id, text
+                )
+                VALUES(?, ?, 1, 1, ?, ?, ?)
+                """,
+                (chunk_id, document_id, unit_id, unit_id, f"Agenda {suffix}"),
+            )
+            connection.execute(
+                "INSERT INTO chunks_fts(chunk_id, text) VALUES(?, ?)",
+                (chunk_id, f"Agenda {suffix}"),
+            )
+            connection.execute(
+                """
+                INSERT INTO passages(
+                    id, chunk_id, document_id, page_start, page_end, source_unit_start_id,
+                    source_unit_end_id, ordinal, text
+                )
+                VALUES(?, ?, ?, 1, 1, ?, ?, 1, ?)
+                """,
+                (passage_id, chunk_id, document_id, unit_id, unit_id, f"Agenda {suffix}"),
+            )
+            connection.execute(
+                "INSERT INTO passages_fts(passage_id, text) VALUES(?, ?)",
+                (passage_id, f"Agenda {suffix}"),
+            )
+            connection.execute(
+                """
+                INSERT INTO embedding_records(
+                    id, source_kind, source_key, provider, model, version, dimensions,
+                    source_unit_start_id, source_unit_end_id
+                )
+                VALUES(?, 'passage', ?, 'test', 'test', 'v1', 2, ?, ?)
+                """,
+                (f"embedding-{suffix}", passage_id, unit_id, unit_id),
+            )
+        connection.commit()
+
+    lance_database = lancedb.connect(paths.lancedb)
+    for table_name, key_name, key_prefix in (
+        ("chunk_embeddings", "chunk_id", "chunk"),
+        ("passage_embeddings", "passage_id", "passage"),
+    ):
+        lance_database.create_table(
+            table_name,
+            data=[
+                {
+                    key_name: f"{key_prefix}-{suffix}",
+                    "document_id": f"document-{suffix}",
+                    "vector": [0.1, 0.2],
+                }
+                for suffix in ("a", "b")
+            ],
+        )
+
+    initialize_storage(paths.data_dir)
+
+    with sqlite3.connect(paths.database) as connection:
+        documents = connection.execute("SELECT id FROM documents ORDER BY id").fetchall()
+        units = connection.execute("SELECT document_id FROM source_units").fetchall()
+        pages = connection.execute("SELECT document_id FROM pages").fetchall()
+        chunks = connection.execute("SELECT document_id FROM chunks").fetchall()
+        passages = connection.execute("SELECT document_id FROM passages").fetchall()
+        embeddings = connection.execute("SELECT source_key FROM embedding_records").fetchall()
+        chunk_fts = connection.execute("SELECT chunk_id FROM chunks_fts").fetchall()
+        passage_fts = connection.execute("SELECT passage_id FROM passages_fts").fetchall()
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute(
+                """
+                INSERT INTO documents(id, source_hash, metadata_json, artifact_id)
+                VALUES('document-c', 'same-hash', '{}', 'artifact-1')
+                """
+            )
+    chunk_vectors = lance_database.open_table("chunk_embeddings").to_arrow().to_pylist()
+    passage_vectors = lance_database.open_table("passage_embeddings").to_arrow().to_pylist()
+
+    assert documents == [("document-a",)]
+    assert units == [("document-a",)]
+    assert pages == [("document-a",)]
+    assert chunks == [("document-a",)]
+    assert passages == [("document-a",)]
+    assert embeddings == [("passage-a",)]
+    assert chunk_fts == [("chunk-a",)]
+    assert passage_fts == [("passage-a",)]
+    assert [row["document_id"] for row in chunk_vectors] == ["document-a"]
+    assert [row["document_id"] for row in passage_vectors] == ["document-a"]
 
 
 def test_source_unit_locations_can_represent_non_page_units(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add exact raw-byte artifact identity decisions and structured ingestion job outcomes
- ignore published duplicates without retaining repeated source metadata, while preserving changed and failed artifacts
- enforce one document per artifact and consolidate legacy duplicate PDF records and vectors
- make URL and local artifact storage content-addressed and add deterministic duplicate, retry, migration, and concurrency coverage

## Testing
- `./scripts/pre-pr.sh`
