### PR TITLE
Add safe source artifact acquisition

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ newsrag jobs retry <job-id>
 
 ## Storage and configuration
 
-NewsRAG uses configurable local storage with a data directory defaulting to the user data directory (`$XDG_DATA_HOME/newsrag`, or `~/.local/share/newsrag` when `XDG_DATA_HOME` is unset). A user can override the active data directory with a CLI flag or configured default for a separate corpus. The data directory contains the corpus-local SQLite database, LanceDB vector index directory, downloaded source PDFs, OCR-normalized PDFs, processing artifacts, and local logs relevant to that corpus.
+NewsRAG uses configurable local storage with a data directory defaulting to the user data directory (`$XDG_DATA_HOME/newsrag`, or `~/.local/share/newsrag` when `XDG_DATA_HOME` is unset). A user can override the active data directory with a CLI flag or configured default for a separate corpus. The data directory contains the corpus-local SQLite database, LanceDB vector index directory, immutable content-addressed source artifacts, OCR-normalized PDFs, processing artifacts, and local logs relevant to that corpus.
 
 Configuration is user-global, for example `~/.config/newsrag/config.yaml`. The global config stores daemon settings, embedding provider/model defaults, watched folder registrations, and user-level defaults. CLI flags can override config values for a specific command.
 
@@ -71,9 +71,15 @@ Processing uses exact raw-byte SHA-256 identity within one corpus. It does not c
 
 When a known source returns different bytes, NewsRAG preserves the new artifact with `change_detected_artifact_saved` but does not replace the source's current document. Repeating those changed bytes reports `change_already_detected`. New publications report `created`. A unique document-to-artifact constraint and transactional cleanup make concurrent duplicate processing converge without exposing partial document records or vectors. The complete policy is recorded in [Source identity and repeated ingestion](research/source-identity-and-repeated-ingestion.md).
 
-Raw bytes are retained as immutable, content-addressed source artifacts. Each PDF is normalized through OCR, then text is extracted from the normalized PDF. This makes scanned and born-digital PDFs follow the same downstream path.
+Raw bytes are retained as immutable, content-addressed source artifacts. Acquisition runs in the daemon before format extraction. One acquisition accepts either an explicitly submitted local regular file or a public HTTP(S) URL, stages bytes while hashing, applies the duplicate decision, and durably promotes bytes that must be retained before invoking an adapter.
 
-The OCR stage uses `ocrmypdf` with Tesseract and its required supporting tools. Text extraction uses PyMuPDF as the primary extractor and pdfplumber as a fallback or table-oriented extraction path. Each extracted page is stored as an ordered page source unit before chunking, and source-unit ranges propagate through chunks, passages, embeddings, and search results while existing page citations remain stable.
+Remote acquisition resolves and pins a validated public address for each request, revalidates every redirect destination, follows at most five redirects, and applies a 30-second request timeout. URL credentials, localhost, non-public addresses, unsafe redirects, ambient proxy or cookie state, and unsupported content encodings are rejected. HTTP bodies are streamed with separate 250 MiB compressed and decompressed limits. Only the submitted resource and required HTTP redirects are fetched; linked and embedded resources are not retrieved.
+
+Local acquisition has a 250 MiB limit and accepts only regular files. An explicitly submitted symlink is allowed only when its resolved regular-file target remains stable. Directory scans skip symlinks. Device/inode, size, modification time, resolved target, and bytes read are checked around the read so missing, special, changed, or oversized inputs fail without preserving a partial artifact.
+
+Acquisition provenance stores submitted and resolved references, redirects, retrieval or file-read timestamps, reported media type, exact byte size and SHA-256, and the durable artifact path. Diagnostics use stage-specific errors and omit URL credentials, query data, response bodies, and ambient secrets.
+
+Each PDF is normalized through OCR, then text is extracted from the normalized PDF. This makes scanned and born-digital PDFs follow the same downstream path. The OCR stage uses `ocrmypdf` with Tesseract and its required supporting tools. Text extraction uses PyMuPDF as the primary extractor and pdfplumber as a fallback or table-oriented extraction path. Each extracted page is stored as an ordered page source unit before chunking, and source-unit ranges propagate through chunks, passages, embeddings, and search results while existing page citations remain stable.
 
 ## Source adapter contract
 

--- a/newsrag/acquisition.py
+++ b/newsrag/acquisition.py
@@ -1,0 +1,884 @@
+from __future__ import annotations
+
+import hashlib
+import http.client
+import ipaddress
+import logging
+import mimetypes
+import os
+import socket
+import ssl
+import stat
+import tempfile
+import zlib
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal, Protocol
+from urllib.parse import SplitResult, urljoin, urlsplit, urlunsplit
+
+from newsrag.sources import normalize_url_reference
+
+SOURCE_KIND_LOCAL_PATH: Literal["local_path"] = "local_path"
+SOURCE_KIND_URL: Literal["url"] = "url"
+DEFAULT_MAX_SOURCE_BYTES = 250 * 1024 * 1024
+DEFAULT_MAX_REDIRECTS = 5
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 30.0
+_READ_CHUNK_BYTES = 64 * 1024
+_REDIRECT_STATUS_CODES = frozenset({301, 302, 303, 307, 308})
+_SUPPORTED_CONTENT_ENCODINGS = frozenset({"", "identity", "gzip"})
+LOGGER = logging.getLogger(__name__)
+
+SourceKind = Literal["local_path", "url"]
+Resolver = Callable[[str, int], tuple[str, ...]]
+
+
+class AcquisitionError(Exception):
+    """Raised when source acquisition fails safely."""
+
+    def __init__(self, stage: str, message: str) -> None:
+        self.stage = stage
+        super().__init__(f"Acquisition {stage} failed: {message}")
+
+
+@dataclass(frozen=True)
+class AcquisitionLimits:
+    """Resource limits applied while acquiring one source."""
+
+    max_local_bytes: int = DEFAULT_MAX_SOURCE_BYTES
+    max_compressed_bytes: int = DEFAULT_MAX_SOURCE_BYTES
+    max_decompressed_bytes: int = DEFAULT_MAX_SOURCE_BYTES
+    max_redirects: int = DEFAULT_MAX_REDIRECTS
+    timeout_seconds: float = DEFAULT_REQUEST_TIMEOUT_SECONDS
+
+
+@dataclass(frozen=True)
+class AcquisitionRequest:
+    """One explicit local path or public HTTP(S) URL to acquire."""
+
+    kind: SourceKind
+    reference: str
+
+
+@dataclass(frozen=True)
+class StagedSourceArtifact:
+    """Exact acquired bytes staged for an ingestion identity decision."""
+
+    source_kind: SourceKind
+    submitted_reference: str
+    normalized_reference: str
+    resolved_reference: str
+    staged_path: Path
+    content_hash: str
+    byte_size: int
+    acquired_at: str
+    reported_media_type: str | None
+    provenance: dict[str, object]
+
+    @property
+    def safe_reference(self) -> str:
+        """Return a log-safe source reference."""
+
+        if self.source_kind == SOURCE_KIND_URL:
+            return safe_url_reference(self.submitted_reference)
+        return self.submitted_reference
+
+
+class _ByteWriter(Protocol):
+    def write(self, value: bytes) -> int:
+        """Write bytes and return the number written."""
+
+
+class _Digest(Protocol):
+    def update(self, value: bytes) -> None:
+        """Add bytes to the digest."""
+
+
+class _Decompressor(Protocol):
+    @property
+    def unconsumed_tail(self) -> bytes:
+        """Return encoded input not consumed because of the output bound."""
+
+    @property
+    def eof(self) -> bool:
+        """Return whether the compressed stream reached its end marker."""
+
+    @property
+    def unused_data(self) -> bytes:
+        """Return encoded bytes found after the compressed stream."""
+
+    def decompress(self, data: bytes, max_length: int = 0) -> bytes:
+        """Decompress one encoded chunk."""
+
+    def flush(self, length: int = 0) -> bytes:
+        """Flush buffered decompressed bytes."""
+
+
+class HttpResponseStream(Protocol):
+    """Minimal streaming HTTP response used by safe acquisition."""
+
+    status_code: int
+    headers: Mapping[str, str]
+
+    def iter_raw(self) -> Iterator[bytes]:
+        """Yield encoded response-body bytes."""
+
+    def close(self) -> None:
+        """Close response and connection resources."""
+
+
+class HttpTransport(Protocol):
+    """Transport that connects to one prevalidated address."""
+
+    def get(
+        self,
+        *,
+        url: str,
+        connect_ip: str,
+        timeout_seconds: float,
+    ) -> HttpResponseStream:
+        """Open one streaming GET request without redirects or ambient credentials."""
+
+
+@dataclass
+class _StdlibHttpResponse:
+    status_code: int
+    headers: Mapping[str, str]
+    response: http.client.HTTPResponse
+    connection: http.client.HTTPConnection
+
+    def iter_raw(self) -> Iterator[bytes]:
+        while True:
+            chunk = self.response.read(_READ_CHUNK_BYTES)
+            if not chunk:
+                return
+            yield chunk
+
+    def close(self) -> None:
+        try:
+            self.response.close()
+        finally:
+            self.connection.close()
+
+
+class _PinnedHttpsConnection(http.client.HTTPSConnection):
+    def __init__(
+        self,
+        host: str,
+        connect_ip: str,
+        *,
+        port: int,
+        timeout: float,
+        context: ssl.SSLContext,
+    ) -> None:
+        super().__init__(host, port=port, timeout=timeout, context=context)
+        self._connect_ip = connect_ip
+        self._newsrag_context = context
+
+    def connect(self) -> None:
+        raw_socket = socket.create_connection(
+            (self._connect_ip, self.port),
+            self.timeout,
+        )
+        try:
+            self.sock = self._newsrag_context.wrap_socket(
+                raw_socket,
+                server_hostname=self.host,
+            )
+        except Exception:
+            raw_socket.close()
+            raise
+
+
+@dataclass(frozen=True)
+class PinnedHttpTransport:
+    """HTTP/1.1 transport pinned to a previously validated public address."""
+
+    ssl_context: ssl.SSLContext = field(default_factory=ssl.create_default_context)
+
+    def get(
+        self,
+        *,
+        url: str,
+        connect_ip: str,
+        timeout_seconds: float,
+    ) -> HttpResponseStream:
+        parsed = urlsplit(url)
+        host = parsed.hostname
+        if host is None:
+            raise AcquisitionError("validation", "URL must include a host")
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        if parsed.scheme == "https":
+            connection: http.client.HTTPConnection = _PinnedHttpsConnection(
+                host,
+                connect_ip,
+                port=port,
+                timeout=timeout_seconds,
+                context=self.ssl_context,
+            )
+        else:
+            connection = http.client.HTTPConnection(
+                connect_ip,
+                port=port,
+                timeout=timeout_seconds,
+            )
+
+        request_target = urlunsplit(("", "", parsed.path or "/", parsed.query, ""))
+        headers = {
+            "Accept-Encoding": "gzip",
+            "Host": _host_header(parsed),
+            "User-Agent": "NewsRAG",
+        }
+        try:
+            connection.request("GET", request_target, headers=headers)
+            response = connection.getresponse()
+        except Exception:
+            connection.close()
+            raise
+        return _StdlibHttpResponse(
+            status_code=response.status,
+            headers={key.lower(): value for key, value in response.getheaders()},
+            response=response,
+            connection=connection,
+        )
+
+
+class SourceArtifactAcquirer(Protocol):
+    """Acquire one explicit source into bounded temporary storage."""
+
+    def acquire(self, request: AcquisitionRequest, staging_dir: Path) -> StagedSourceArtifact:
+        """Acquire exact bytes without publishing an artifact record."""
+
+
+@dataclass(frozen=True)
+class SafeSourceArtifactAcquirer:
+    """Safely acquire local files and public HTTP(S) resources."""
+
+    limits: AcquisitionLimits = AcquisitionLimits()
+    resolver: Resolver = field(default_factory=lambda: _default_resolver)
+    transport: HttpTransport = field(default_factory=PinnedHttpTransport)
+
+    def acquire(self, request: AcquisitionRequest, staging_dir: Path) -> StagedSourceArtifact:
+        """Acquire one source into a staged exact-byte artifact."""
+
+        if request.kind == SOURCE_KIND_LOCAL_PATH:
+            return self._acquire_local(request.reference, staging_dir)
+        if request.kind == SOURCE_KIND_URL:
+            return self._acquire_url(request.reference, staging_dir)
+        raise AcquisitionError("validation", f"Unsupported source kind: {request.kind}")
+
+    def _acquire_local(self, reference: str, staging_dir: Path) -> StagedSourceArtifact:
+        submitted_path = _absolute_path(reference)
+        try:
+            supplied_state = os.lstat(submitted_path)
+            resolved_path = submitted_path.resolve(strict=True)
+            target_state = _file_state(resolved_path)
+        except (OSError, RuntimeError) as exc:
+            raise AcquisitionError(
+                "local_validation",
+                f"Cannot resolve local source {submitted_path} ({type(exc).__name__})",
+            ) from exc
+
+        if not stat.S_ISREG(target_state.mode):
+            raise AcquisitionError(
+                "local_validation",
+                f"Local source is not a regular file: {submitted_path}",
+            )
+        if target_state.size > self.limits.max_local_bytes:
+            raise AcquisitionError(
+                "local_size_limit",
+                f"Local source exceeds {self.limits.max_local_bytes} bytes: {submitted_path}",
+            )
+
+        staged_path = _new_staging_path(staging_dir)
+        read_started_at = _current_timestamp()
+        digest = hashlib.sha256()
+        byte_size = 0
+        try:
+            open_flags = (
+                os.O_RDONLY
+                | getattr(os, "O_NONBLOCK", 0)
+                | getattr(
+                    os,
+                    "O_NOFOLLOW",
+                    0,
+                )
+            )
+            source_fd = os.open(resolved_path, open_flags)
+            try:
+                opened_state = _file_state_from_fd(source_fd)
+                if opened_state != target_state:
+                    raise AcquisitionError(
+                        "local_integrity",
+                        f"Local source changed before reading: {submitted_path}",
+                    )
+                with staged_path.open("wb") as output:
+                    while True:
+                        chunk = os.read(source_fd, _READ_CHUNK_BYTES)
+                        if not chunk:
+                            break
+                        byte_size += len(chunk)
+                        if byte_size > self.limits.max_local_bytes:
+                            raise AcquisitionError(
+                                "local_size_limit",
+                                f"Local source exceeds {self.limits.max_local_bytes} bytes: "
+                                f"{submitted_path}",
+                            )
+                        output.write(chunk)
+                        digest.update(chunk)
+                    output.flush()
+                    os.fsync(output.fileno())
+                completed_state = _file_state_from_fd(source_fd)
+            finally:
+                os.close(source_fd)
+
+            current_state = _file_state(resolved_path)
+            if (
+                completed_state != opened_state
+                or current_state != opened_state
+                or byte_size != opened_state.size
+                or (
+                    stat.S_ISLNK(supplied_state.st_mode)
+                    and submitted_path.resolve(strict=True) != resolved_path
+                )
+            ):
+                raise AcquisitionError(
+                    "local_integrity",
+                    f"Local source changed while reading: {submitted_path}",
+                )
+        except AcquisitionError:
+            staged_path.unlink(missing_ok=True)
+            raise
+        except OSError as exc:
+            staged_path.unlink(missing_ok=True)
+            raise AcquisitionError(
+                "local_read",
+                f"Cannot read local source {submitted_path} ({type(exc).__name__})",
+            ) from exc
+
+        acquired_at = _current_timestamp()
+        reported_media_type, _ = mimetypes.guess_type(submitted_path.name)
+        return StagedSourceArtifact(
+            source_kind=SOURCE_KIND_LOCAL_PATH,
+            submitted_reference=str(submitted_path),
+            normalized_reference=str(submitted_path),
+            resolved_reference=str(resolved_path),
+            staged_path=staged_path,
+            content_hash=digest.hexdigest(),
+            byte_size=byte_size,
+            acquired_at=acquired_at,
+            reported_media_type=reported_media_type,
+            provenance={
+                "file_mtime_ns": opened_state.modified_at_ns,
+                "file_read_completed_at": acquired_at,
+                "file_read_started_at": read_started_at,
+                "resolved_path": str(resolved_path),
+                "submitted_path": str(submitted_path),
+            },
+        )
+
+    def _acquire_url(self, reference: str, staging_dir: Path) -> StagedSourceArtifact:
+        submitted_url = reference.strip()
+        current_url = _without_fragment(submitted_url)
+        redirects: list[str] = []
+
+        while True:
+            parsed, addresses = _validate_public_url(current_url, self.resolver)
+            safe_reference = safe_url_reference(current_url)
+            try:
+                response = self.transport.get(
+                    url=current_url,
+                    connect_ip=addresses[0],
+                    timeout_seconds=self.limits.timeout_seconds,
+                )
+            except TimeoutError as exc:
+                raise AcquisitionError(
+                    "remote_timeout",
+                    f"Request timed out for {safe_reference}",
+                ) from exc
+            except AcquisitionError:
+                raise
+            except Exception as exc:
+                raise AcquisitionError(
+                    "remote_request",
+                    f"Request failed for {safe_reference} ({type(exc).__name__})",
+                ) from exc
+
+            try:
+                if response.status_code in _REDIRECT_STATUS_CODES:
+                    location = response.headers.get("location")
+                    if location is None or not location.strip():
+                        raise AcquisitionError(
+                            "remote_redirect",
+                            f"Redirect is missing a destination for {safe_reference}",
+                        )
+                    if len(redirects) >= self.limits.max_redirects:
+                        raise AcquisitionError(
+                            "remote_redirect_limit",
+                            f"Source exceeded {self.limits.max_redirects} redirects",
+                        )
+                    next_url = _without_fragment(urljoin(current_url, location.strip()))
+                    if (
+                        parsed.scheme.lower() == "https"
+                        and urlsplit(next_url).scheme.lower() == "http"
+                    ):
+                        raise AcquisitionError(
+                            "remote_redirect",
+                            f"HTTPS downgrade redirect is not allowed for {safe_reference}",
+                        )
+                    redirects.append(next_url)
+                    current_url = next_url
+                    continue
+
+                if response.status_code != 200:
+                    raise AcquisitionError(
+                        "remote_status",
+                        f"HTTP status {response.status_code} for {safe_reference}",
+                    )
+
+                staged_path, content_hash, byte_size, compressed_byte_size = (
+                    self._stage_response_body(response, staging_dir, safe_reference)
+                )
+                acquired_at = _current_timestamp()
+                reported_media_type = _reported_media_type(response.headers)
+                return StagedSourceArtifact(
+                    source_kind=SOURCE_KIND_URL,
+                    submitted_reference=submitted_url,
+                    normalized_reference=normalize_url_reference(submitted_url),
+                    resolved_reference=current_url,
+                    staged_path=staged_path,
+                    content_hash=content_hash,
+                    byte_size=byte_size,
+                    acquired_at=acquired_at,
+                    reported_media_type=reported_media_type,
+                    provenance={
+                        "compressed_byte_size": compressed_byte_size,
+                        "content_encoding": _content_encoding(response.headers),
+                        "redirects": redirects,
+                        "reported_content_length": _content_length(response.headers),
+                        "resolved_url": current_url,
+                        "retrieved_at": acquired_at,
+                        "submitted_url": submitted_url,
+                    },
+                )
+            finally:
+                _close_response(response, safe_reference)
+
+    def _stage_response_body(
+        self,
+        response: HttpResponseStream,
+        staging_dir: Path,
+        safe_reference: str,
+    ) -> tuple[Path, str, int, int]:
+        content_length = _content_length(response.headers)
+        if content_length is not None and content_length > self.limits.max_compressed_bytes:
+            raise AcquisitionError(
+                "remote_compressed_size_limit",
+                f"Response exceeds {self.limits.max_compressed_bytes} compressed bytes for "
+                f"{safe_reference}",
+            )
+
+        encoding = _content_encoding(response.headers)
+        if encoding not in _SUPPORTED_CONTENT_ENCODINGS:
+            raise AcquisitionError(
+                "remote_content_encoding",
+                f"Unsupported Content-Encoding for {safe_reference}",
+            )
+        decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS) if encoding == "gzip" else None
+        staged_path = _new_staging_path(staging_dir)
+        digest = hashlib.sha256()
+        compressed_byte_size = 0
+        byte_size = 0
+        try:
+            with staged_path.open("wb") as output:
+                for chunk in response.iter_raw():
+                    compressed_byte_size += len(chunk)
+                    if compressed_byte_size > self.limits.max_compressed_bytes:
+                        raise AcquisitionError(
+                            "remote_compressed_size_limit",
+                            f"Response exceeds {self.limits.max_compressed_bytes} compressed "
+                            f"bytes for {safe_reference}",
+                        )
+                    decoded = _decode_chunk(
+                        decompressor,
+                        chunk,
+                        remaining=self.limits.max_decompressed_bytes - byte_size,
+                        safe_reference=safe_reference,
+                        limit=self.limits.max_decompressed_bytes,
+                    )
+                    byte_size = _write_decoded_chunk(
+                        output,
+                        digest,
+                        decoded,
+                        byte_size=byte_size,
+                        limit=self.limits.max_decompressed_bytes,
+                        safe_reference=safe_reference,
+                    )
+                if decompressor is not None:
+                    decoded = _flush_decoder(
+                        decompressor,
+                        remaining=self.limits.max_decompressed_bytes - byte_size,
+                        safe_reference=safe_reference,
+                        limit=self.limits.max_decompressed_bytes,
+                    )
+                    byte_size = _write_decoded_chunk(
+                        output,
+                        digest,
+                        decoded,
+                        byte_size=byte_size,
+                        limit=self.limits.max_decompressed_bytes,
+                        safe_reference=safe_reference,
+                    )
+                if content_length is not None and compressed_byte_size != content_length:
+                    raise AcquisitionError(
+                        "remote_transfer",
+                        f"Response length did not match Content-Length for {safe_reference}",
+                    )
+                output.flush()
+                os.fsync(output.fileno())
+        except AcquisitionError:
+            staged_path.unlink(missing_ok=True)
+            raise
+        except TimeoutError as exc:
+            staged_path.unlink(missing_ok=True)
+            raise AcquisitionError(
+                "remote_timeout",
+                f"Request timed out for {safe_reference}",
+            ) from exc
+        except (OSError, zlib.error) as exc:
+            staged_path.unlink(missing_ok=True)
+            raise AcquisitionError(
+                "remote_transfer",
+                f"Could not read response for {safe_reference} ({type(exc).__name__})",
+            ) from exc
+        return staged_path, digest.hexdigest(), byte_size, compressed_byte_size
+
+
+def _close_response(response: HttpResponseStream, safe_reference: str) -> None:
+    try:
+        response.close()
+    except Exception as exc:
+        LOGGER.warning(
+            "acquisition_response_close_failed source_reference=%r error_type=%s",
+            safe_reference,
+            type(exc).__name__,
+        )
+
+
+def preserve_staged_artifact(
+    artifact: StagedSourceArtifact,
+    artifact_dir: Path,
+) -> Path:
+    """Atomically promote staged bytes into durable content-addressed storage."""
+
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    destination = artifact_dir / artifact.content_hash
+    if destination.exists():
+        if (
+            destination.stat().st_size != artifact.byte_size
+            or _hash_file(destination) != artifact.content_hash
+        ):
+            raise AcquisitionError(
+                "artifact_integrity",
+                f"Stored artifact failed integrity check: {destination}",
+            )
+        artifact.staged_path.unlink(missing_ok=True)
+        return destination
+
+    try:
+        artifact.staged_path.replace(destination)
+        _fsync_directory(artifact_dir)
+    except OSError as exc:
+        raise AcquisitionError(
+            "artifact_storage",
+            f"Could not preserve acquired artifact ({type(exc).__name__})",
+        ) from exc
+    return destination
+
+
+def validate_url_submission(url: str) -> str:
+    """Validate fields that must never be persisted in a URL job payload."""
+
+    submitted_url = url.strip()
+    if not submitted_url or any(
+        ord(character) < 32 or ord(character) == 127 for character in submitted_url
+    ):
+        raise AcquisitionError(
+            "remote_validation",
+            "URL is empty or contains control characters",
+        )
+    try:
+        parsed = urlsplit(submitted_url)
+    except ValueError as exc:
+        raise AcquisitionError("remote_validation", "URL is malformed") from exc
+    if parsed.username is not None or parsed.password is not None:
+        raise AcquisitionError("remote_validation", "URL credentials are not allowed")
+    return submitted_url
+
+
+def safe_url_reference(url: str) -> str:
+    """Return a URL suitable for logs and errors without credentials or query data."""
+
+    try:
+        parsed = urlsplit(url)
+        host = parsed.hostname or "invalid-host"
+        port = parsed.port
+    except ValueError:
+        return "invalid-url"
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    default_port = (parsed.scheme == "http" and port == 80) or (
+        parsed.scheme == "https" and port == 443
+    )
+    authority = host if port is None or default_port else f"{host}:{port}"
+    return urlunsplit((parsed.scheme.lower(), authority, parsed.path or "/", "", ""))
+
+
+def _validate_public_url(url: str, resolver: Resolver) -> tuple[SplitResult, tuple[str, ...]]:
+    submitted_url = validate_url_submission(url)
+    try:
+        parsed = urlsplit(submitted_url)
+        port = parsed.port
+    except ValueError as exc:
+        raise AcquisitionError("remote_validation", "URL is malformed") from exc
+    if parsed.scheme.lower() not in {"http", "https"}:
+        raise AcquisitionError("remote_validation", "Only public HTTP(S) URLs are supported")
+    host = parsed.hostname
+    if host is None:
+        raise AcquisitionError("remote_validation", "URL must include a host")
+    normalized_host = host.rstrip(".").lower()
+    if normalized_host == "localhost" or normalized_host.endswith(".localhost"):
+        raise AcquisitionError("remote_destination", "Localhost destinations are not allowed")
+
+    resolved_port = port or (443 if parsed.scheme.lower() == "https" else 80)
+    try:
+        literal_address = ipaddress.ip_address(normalized_host)
+    except ValueError:
+        try:
+            addresses = resolver(normalized_host, resolved_port)
+        except AcquisitionError:
+            raise
+        except Exception as exc:
+            raise AcquisitionError(
+                "remote_resolution",
+                f"Could not resolve {safe_url_reference(url)} ({type(exc).__name__})",
+            ) from exc
+    else:
+        addresses = (str(literal_address),)
+
+    if not addresses:
+        raise AcquisitionError(
+            "remote_resolution",
+            f"No addresses resolved for {safe_url_reference(url)}",
+        )
+    for address in addresses:
+        try:
+            parsed_address = ipaddress.ip_address(address)
+        except ValueError as exc:
+            raise AcquisitionError(
+                "remote_resolution", "Resolver returned an invalid address"
+            ) from exc
+        if not _is_public_unicast(parsed_address):
+            raise AcquisitionError(
+                "remote_destination",
+                f"Non-public destination is not allowed for {safe_url_reference(url)}",
+            )
+    return parsed, tuple(dict.fromkeys(addresses))
+
+
+def _is_public_unicast(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return (
+        address.is_global
+        and not address.is_multicast
+        and not address.is_unspecified
+        and not address.is_reserved
+        and not address.is_loopback
+        and not address.is_link_local
+        and not address.is_private
+    )
+
+
+def _default_resolver(host: str, port: int) -> tuple[str, ...]:
+    records = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    return tuple(dict.fromkeys(str(record[4][0]) for record in records))
+
+
+def _absolute_path(reference: str) -> Path:
+    if not reference.strip():
+        raise AcquisitionError("local_validation", "Local source path is empty")
+    return Path(os.path.abspath(os.path.expanduser(reference)))
+
+
+@dataclass(frozen=True)
+class _FileState:
+    device: int
+    inode: int
+    mode: int
+    size: int
+    modified_at_ns: int
+
+
+def _file_state(path: Path) -> _FileState:
+    return _state_from_stat(os.stat(path))
+
+
+def _file_state_from_fd(file_descriptor: int) -> _FileState:
+    return _state_from_stat(os.fstat(file_descriptor))
+
+
+def _state_from_stat(value: os.stat_result) -> _FileState:
+    return _FileState(
+        device=value.st_dev,
+        inode=value.st_ino,
+        mode=value.st_mode,
+        size=value.st_size,
+        modified_at_ns=value.st_mtime_ns,
+    )
+
+
+def _new_staging_path(staging_dir: Path) -> Path:
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    descriptor, raw_path = tempfile.mkstemp(prefix="acquisition-", dir=staging_dir)
+    os.close(descriptor)
+    return Path(raw_path)
+
+
+def _decode_chunk(
+    decompressor: _Decompressor | None,
+    chunk: bytes,
+    *,
+    remaining: int,
+    safe_reference: str,
+    limit: int,
+) -> bytes:
+    if decompressor is None:
+        return chunk
+    if remaining < 0:
+        _raise_decompressed_limit(safe_reference, limit)
+    decoded = decompressor.decompress(chunk, remaining + 1)
+    if len(decoded) > remaining or decompressor.unconsumed_tail:
+        _raise_decompressed_limit(safe_reference, limit)
+    if decompressor.unused_data:
+        raise AcquisitionError(
+            "remote_transfer",
+            f"Compressed response contains trailing data for {safe_reference}",
+        )
+    return decoded
+
+
+def _flush_decoder(
+    decompressor: _Decompressor,
+    *,
+    remaining: int,
+    safe_reference: str,
+    limit: int,
+) -> bytes:
+    if remaining < 0:
+        _raise_decompressed_limit(safe_reference, limit)
+    decoded = decompressor.flush(remaining + 1)
+    if len(decoded) > remaining:
+        _raise_decompressed_limit(safe_reference, limit)
+    if not decompressor.eof:
+        raise AcquisitionError(
+            "remote_transfer",
+            f"Compressed response ended early for {safe_reference}",
+        )
+    if decompressor.unused_data:
+        raise AcquisitionError(
+            "remote_transfer",
+            f"Compressed response contains trailing data for {safe_reference}",
+        )
+    return decoded
+
+
+def _write_decoded_chunk(
+    output: _ByteWriter,
+    digest: _Digest,
+    decoded: bytes,
+    *,
+    byte_size: int,
+    limit: int,
+    safe_reference: str,
+) -> int:
+    next_size = byte_size + len(decoded)
+    if next_size > limit:
+        _raise_decompressed_limit(safe_reference, limit)
+    if decoded:
+        output.write(decoded)
+        digest.update(decoded)
+    return next_size
+
+
+def _raise_decompressed_limit(safe_reference: str, limit: int) -> None:
+    raise AcquisitionError(
+        "remote_decompressed_size_limit",
+        f"Response exceeds {limit} decompressed bytes for {safe_reference}",
+    )
+
+
+def _content_encoding(headers: Mapping[str, str]) -> str:
+    return headers.get("content-encoding", "").strip().lower()
+
+
+def _content_length(headers: Mapping[str, str]) -> int | None:
+    raw_value = headers.get("content-length")
+    if raw_value is None:
+        return None
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise AcquisitionError("remote_headers", "Content-Length is invalid") from exc
+    if value < 0:
+        raise AcquisitionError("remote_headers", "Content-Length is invalid")
+    return value
+
+
+def _reported_media_type(headers: Mapping[str, str]) -> str | None:
+    raw_value = headers.get("content-type")
+    if raw_value is None:
+        return None
+    media_type = raw_value.split(";", maxsplit=1)[0].strip().lower()
+    return media_type or None
+
+
+def _without_fragment(url: str) -> str:
+    try:
+        parsed = urlsplit(url)
+    except ValueError as exc:
+        raise AcquisitionError("remote_validation", "URL is malformed") from exc
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, parsed.query, ""))
+
+
+def _host_header(parsed: SplitResult) -> str:
+    host = parsed.hostname or ""
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    port = parsed.port
+    if (
+        port is None
+        or (parsed.scheme == "http" and port == 80)
+        or (parsed.scheme == "https" and port == 443)
+    ):
+        return host
+    return f"{host}:{port}"
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file_handle:
+        for chunk in iter(lambda: file_handle.read(_READ_CHUNK_BYTES), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _current_timestamp() -> str:
+    return datetime.now(UTC).isoformat()

--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -338,8 +338,9 @@ def ingest_url_command(
     ),
     pdf_extractor: str = PDF_EXTRACTOR_OPTION,
 ) -> None:
-    """Download one direct PDF URL and enqueue it for ingestion."""
+    """Enqueue one direct PDF URL for background acquisition and ingestion."""
 
+    from newsrag.acquisition import safe_url_reference
     from newsrag.ingest import IngestError, enqueue_ingest_url_job, normalize_pdf_extractor_mode
     from newsrag.storage import initialize_storage
 
@@ -367,13 +368,14 @@ def ingest_url_command(
         raise typer.Exit(code=1) from exc
 
     typer.echo("Enqueued 1 ingest job(s)")
-    typer.echo(f"{job.id} {job.payload['path']}")
+    typer.echo(f"{job.id} {safe_url_reference(str(job.payload['url']))}")
 
 
 @app.command("ingest-manifest")
 def ingest_manifest_command(ctx: typer.Context, path: Path) -> None:
     """Load a YAML manifest and enqueue one URL-ingest job per document."""
 
+    from newsrag.acquisition import safe_url_reference
     from newsrag.ingest import IngestError, enqueue_ingest_url_job
     from newsrag.manifests import ManifestError, load_manifest
     from newsrag.storage import initialize_storage
@@ -404,7 +406,7 @@ def ingest_manifest_command(ctx: typer.Context, path: Path) -> None:
 
     typer.echo(f"Enqueued {len(jobs)} ingest job(s)")
     for job in jobs:
-        typer.echo(f"{job.id} {job.payload['path']}")
+        typer.echo(f"{job.id} {safe_url_reference(str(job.payload['url']))}")
 
 
 @app.command("search")
@@ -1087,12 +1089,16 @@ def run() -> None:
 
 
 def _format_job_line(job: Job) -> str:
+    from newsrag.acquisition import safe_url_reference
     from newsrag.jobs import FAILED
 
     parts = [job.id, job.status, job.kind, f"updated_at={job.updated_at}"]
     source_path = job.payload.get("path")
     if isinstance(source_path, str) and source_path.strip():
         parts.append(f"path={source_path}")
+    source_url = job.payload.get("url")
+    if isinstance(source_url, str) and source_url.strip():
+        parts.append(f"url={safe_url_reference(source_url)}")
     if job.result is not None:
         for key in ("outcome", "source_id", "artifact_id", "document_id"):
             value = job.result.get(key)

--- a/newsrag/daemon.py
+++ b/newsrag/daemon.py
@@ -9,6 +9,7 @@ from time import perf_counter
 
 from watchfiles import awatch
 
+from newsrag.acquisition import safe_url_reference
 from newsrag.config import EmbeddingConfig
 from newsrag.ingest import INGEST_JOB_KIND, build_ingest_handler
 from newsrag.jobs import Job, claim_next_job, mark_job_done, mark_job_failed
@@ -176,6 +177,9 @@ def _job_log_context(job: Job) -> str:
     source_path = job.payload.get("path")
     if isinstance(source_path, str):
         context += f" source_path={source_path!r}"
+    source_url = job.payload.get("url")
+    if isinstance(source_url, str):
+        context += f" source_url={safe_url_reference(source_url)!r}"
     return context
 
 

--- a/newsrag/ingest.py
+++ b/newsrag/ingest.py
@@ -1,23 +1,30 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
 import logging
-import shutil
+import os
 import sqlite3
 import uuid
 from collections.abc import Awaitable, Callable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 from time import perf_counter
 from typing import Any, Protocol
 
-import httpx
 import lancedb  # type: ignore[import-untyped]
 
+from newsrag.acquisition import (
+    SOURCE_KIND_URL,
+    AcquisitionError,
+    AcquisitionRequest,
+    SafeSourceArtifactAcquirer,
+    SourceArtifactAcquirer,
+    preserve_staged_artifact,
+    safe_url_reference,
+    validate_url_submission,
+)
 from newsrag.adapters import (
     AdapterError,
     AdapterInput,
@@ -38,6 +45,7 @@ from newsrag.ingestion_identity import (
     OUTCOME_DUPLICATE_IGNORED,
     find_document_for_artifact,
     find_published_duplicate,
+    find_stored_artifact_path,
     register_acquired_artifact,
 )
 from newsrag.jobs import Job, create_job
@@ -93,13 +101,12 @@ __all__ = [
 INGEST_JOB_KIND = "ingest-file"
 DEFAULT_CHUNK_MAX_CHARS = 2000
 DEFAULT_CHUNK_OVERLAP_CHARS = 200
-DEFAULT_DOWNLOAD_TIMEOUT_SECONDS = 30.0
 VECTOR_TABLE_NAME = "chunk_embeddings"
 LOGGER = logging.getLogger(__name__)
 
 
 class IngestError(Exception):
-    """Raised when local PDF ingestion cannot complete."""
+    """Raised when source acquisition or PDF ingestion cannot complete."""
 
 
 @dataclass(frozen=True)
@@ -169,23 +176,6 @@ class ChunkVectorRecord:
     source_unit_end_id: str | None = None
 
 
-@dataclass(frozen=True)
-class DownloadedPdf:
-    """One downloaded direct-PDF artifact."""
-
-    path: Path
-    source_url: str
-    retrieved_at: str
-    content_hash: str
-
-
-class PdfDownloader(Protocol):
-    """Protocol for direct PDF downloads."""
-
-    def download_pdf(self, url: str, destination_dir: Path) -> DownloadedPdf:
-        """Download one direct PDF into the corpus data directory."""
-
-
 class Chunker(Protocol):
     """Protocol for canonical-source-unit chunking."""
 
@@ -211,42 +201,6 @@ class PassageVectorStore(Protocol):
 
     def delete_document(self, document_id: str) -> None:
         """Remove staged vectors for one failed document publication."""
-
-
-@dataclass(frozen=True)
-class HttpxPdfDownloader:
-    """Direct-PDF downloader backed by `httpx`."""
-
-    timeout_seconds: float = DEFAULT_DOWNLOAD_TIMEOUT_SECONDS
-
-    def download_pdf(self, url: str, destination_dir: Path) -> DownloadedPdf:
-        try:
-            response = httpx.get(url, follow_redirects=True, timeout=self.timeout_seconds)
-            response.raise_for_status()
-        except httpx.HTTPError as exc:
-            raise IngestError(f"Failed downloading {url}: {exc}") from exc
-
-        content = response.content
-        if not _looks_like_pdf(response.headers.get("Content-Type"), content):
-            raise IngestError(f"URL did not return a PDF-like response: {url}")
-
-        content_hash = _hash_bytes(content)
-        destination_dir.mkdir(parents=True, exist_ok=True)
-        destination_path = destination_dir / f"{content_hash}.pdf"
-        if not destination_path.exists() or _hash_file(destination_path) != content_hash:
-            temporary_path = destination_path.with_name(f".{content_hash}-{uuid.uuid4().hex}.tmp")
-            try:
-                temporary_path.write_bytes(content)
-                temporary_path.replace(destination_path)
-            finally:
-                temporary_path.unlink(missing_ok=True)
-
-        return DownloadedPdf(
-            path=destination_path,
-            source_url=url,
-            retrieved_at=_current_timestamp(),
-            content_hash=content_hash,
-        )
 
 
 def build_pdf_text_extractor(mode: PdfExtractorMode = PDF_EXTRACTOR_AUTO) -> TextExtractor:
@@ -533,6 +487,7 @@ class IngestionPipeline:
         *,
         storage_paths: StoragePaths,
         embedding_config: EmbeddingConfig,
+        acquirer: SourceArtifactAcquirer | None = None,
         adapter: SourceAdapter | None = None,
         ocr_runner: OcrRunner | None = None,
         text_extractor: TextExtractor | None = None,
@@ -542,6 +497,7 @@ class IngestionPipeline:
         passage_vector_store: PassageVectorStore | None = None,
     ) -> None:
         self.storage_paths = storage_paths
+        self.acquirer = acquirer or SafeSourceArtifactAcquirer()
         resolved_adapter = adapter or PdfSourceAdapter(
             ocr_runner=ocr_runner or SubprocessOcrRunner(),
             text_extractor=text_extractor,
@@ -560,51 +516,84 @@ class IngestionPipeline:
         return await asyncio.to_thread(self.process_job, job)
 
     def process_job(self, job: Job) -> dict[str, object]:
-        source_path = _payload_path(job.payload)
+        request = _payload_acquisition_request(job.payload)
+        safe_reference = _safe_acquisition_reference(request)
         metadata = _payload_metadata(job.payload)
-        source_url = _metadata_source_url(metadata)
+        staged_artifact = None
 
         try:
-            with _ingest_stage(job.id, "artifact_preparation", source_path):
-                source_hash = _hash_file(source_path)
+            with _ingest_stage(job.id, "artifact_acquisition", safe_reference):
+                staged_artifact = self.acquirer.acquire(
+                    request,
+                    self.storage_paths.artifact_staging,
+                )
+
+            with _ingest_stage(job.id, "artifact_preparation", safe_reference):
                 duplicate = find_published_duplicate(
                     self.storage_paths.database,
-                    source_hash,
+                    staged_artifact.content_hash,
                 )
                 if duplicate is not None:
                     return self._completed_identity_result(job, duplicate.result())
 
-                source_copy_path = _copy_source_pdf(
-                    self.storage_paths,
-                    source_path,
-                    source_hash,
+                stored_path = find_stored_artifact_path(
+                    self.storage_paths.database,
+                    staged_artifact.content_hash,
+                )
+                if stored_path is None:
+                    stored_path = preserve_staged_artifact(
+                        staged_artifact,
+                        self.storage_paths.source_artifacts,
+                    )
+
+                source_url = (
+                    staged_artifact.submitted_reference
+                    if staged_artifact.source_kind == SOURCE_KIND_URL
+                    else _metadata_source_url(metadata)
+                )
+                resolved_reference = (
+                    staged_artifact.resolved_reference
+                    if source_url is None or staged_artifact.source_kind == SOURCE_KIND_URL
+                    else source_url
                 )
                 decision = register_acquired_artifact(
                     self.storage_paths.database,
                     source_identity=build_source_identity(
-                        source_path=source_path,
+                        source_path=Path(staged_artifact.submitted_reference),
                         source_url=source_url,
+                        resolved_reference=resolved_reference,
                     ),
-                    content_hash=source_hash,
+                    content_hash=staged_artifact.content_hash,
                     media_type=PDF_MEDIA_TYPE,
-                    byte_size=source_copy_path.stat().st_size,
-                    stored_path=source_copy_path,
-                    acquired_at=_metadata_retrieved_at(metadata) or _current_timestamp(),
+                    byte_size=staged_artifact.byte_size,
+                    stored_path=stored_path,
+                    acquired_at=staged_artifact.acquired_at,
+                    reported_media_type=staged_artifact.reported_media_type,
+                    provenance=staged_artifact.provenance,
                 )
                 if decision.action == "complete":
                     return self._completed_identity_result(job, decision.result())
+
+            document_metadata = dict(metadata)
+            document_metadata["source_size_bytes"] = staged_artifact.byte_size
+            file_mtime_ns = staged_artifact.provenance.get("file_mtime_ns")
+            if isinstance(file_mtime_ns, int):
+                document_metadata["source_mtime_ns"] = file_mtime_ns
+            if staged_artifact.source_kind == SOURCE_KIND_URL:
+                document_metadata["source_url"] = staged_artifact.submitted_reference
+                document_metadata["retrieved_at"] = staged_artifact.acquired_at
 
             try:
                 document_id = self.processor.process(
                     PreparedSourceArtifact(
                         source_path=decision.document_source_path,
                         artifact_path=decision.artifact_path,
-                        content_hash=source_hash,
+                        content_hash=staged_artifact.content_hash,
                         media_type=PDF_MEDIA_TYPE,
                         source_url=decision.document_source_url,
                         acquired_at=decision.acquired_at,
                         work_dir=self.storage_paths.ocr_pdfs,
-                        metadata=metadata,
+                        metadata=document_metadata,
                         adapter_options={"pdf_extractor": _payload_pdf_extractor_mode(job.payload)},
                     ),
                     job_id=job.id,
@@ -624,10 +613,15 @@ class IngestionPipeline:
                     )
                 raise
             return decision.result(outcome=OUTCOME_CREATED, document_id=document_id)
+        except AcquisitionError as exc:
+            raise IngestError(str(exc)) from exc
         except IngestError:
             raise
         except Exception as exc:
-            raise IngestError(f"Failed ingesting {source_path}: {exc}") from exc
+            raise IngestError(f"Failed ingesting {safe_reference}: {exc}") from exc
+        finally:
+            if staged_artifact is not None:
+                staged_artifact.staged_path.unlink(missing_ok=True)
 
     def _completed_identity_result(
         self,
@@ -679,20 +673,18 @@ def enqueue_ingest_url_job(
     storage_paths: StoragePaths,
     url: str,
     metadata: dict[str, Any] | None = None,
-    downloader: PdfDownloader | None = None,
     pdf_extractor: str | None = None,
 ) -> Job:
-    """Download one direct PDF URL and enqueue it for ingestion."""
+    """Enqueue one direct URL for safe background acquisition and ingestion."""
 
-    resolved_downloader = downloader or HttpxPdfDownloader()
-    downloaded_pdf = resolved_downloader.download_pdf(url, storage_paths.downloaded_pdfs)
-    payload_metadata = dict(metadata or {})
-    payload_metadata["source_url"] = downloaded_pdf.source_url
-    payload_metadata["retrieved_at"] = downloaded_pdf.retrieved_at
-
+    del storage_paths
+    try:
+        submitted_url = validate_url_submission(url)
+    except AcquisitionError as exc:
+        raise IngestError(str(exc)) from exc
     payload: dict[str, Any] = {
-        "path": str(downloaded_pdf.path),
-        "metadata": payload_metadata,
+        "url": submitted_url,
+        "metadata": dict(metadata or {}),
         "source": "ingest-url",
     }
     if pdf_extractor is not None:
@@ -709,6 +701,7 @@ def build_ingest_handler(
     *,
     data_dir: Path,
     embedding_config: EmbeddingConfig,
+    acquirer: SourceArtifactAcquirer | None = None,
     adapter: SourceAdapter | None = None,
     ocr_runner: OcrRunner | None = None,
     text_extractor: TextExtractor | None = None,
@@ -717,11 +710,12 @@ def build_ingest_handler(
     vector_store: VectorStore | None = None,
     passage_vector_store: PassageVectorStore | None = None,
 ) -> Callable[[Job], Awaitable[dict[str, object]]]:
-    """Build an async handler for local-PDF ingest jobs."""
+    """Build an async handler for safely acquired PDF ingest jobs."""
 
     pipeline = IngestionPipeline(
         storage_paths=initialize_storage(data_dir),
         embedding_config=embedding_config,
+        acquirer=acquirer,
         adapter=adapter,
         ocr_runner=ocr_runner,
         text_extractor=text_extractor,
@@ -875,39 +869,42 @@ def list_chunk_vectors(
 
 
 def _iter_pdf_inputs(source_path: Path) -> tuple[Path, ...]:
-    resolved_path = source_path.expanduser().resolve()
-    if not resolved_path.exists():
-        raise IngestError(f"Input path does not exist: {resolved_path}")
-
-    if resolved_path.is_file():
-        if resolved_path.suffix.lower() != ".pdf":
-            raise IngestError(f"Input file is not a PDF: {resolved_path}")
-        return (resolved_path,)
-
-    pdf_paths = tuple(
-        sorted(
-            candidate.resolve()
-            for candidate in resolved_path.rglob("*")
-            if candidate.is_file() and candidate.suffix.lower() == ".pdf"
+    submitted_path = Path(os.path.abspath(source_path.expanduser()))
+    if submitted_path.is_dir() and not submitted_path.is_symlink():
+        pdf_paths = tuple(
+            sorted(
+                Path(os.path.abspath(candidate))
+                for candidate in submitted_path.rglob("*")
+                if not candidate.is_symlink()
+                and candidate.is_file()
+                and candidate.suffix.lower() == ".pdf"
+            )
         )
-    )
-    if pdf_paths:
-        return pdf_paths
+        if pdf_paths:
+            return pdf_paths
+        raise IngestError(f"No PDF files found under {submitted_path}")
 
-    raise IngestError(f"No PDF files found under {resolved_path}")
+    if submitted_path.suffix.lower() != ".pdf":
+        raise IngestError(f"Input file is not a PDF: {submitted_path}")
+    return (submitted_path,)
 
 
-def _payload_path(payload: dict[str, Any]) -> Path:
+def _payload_acquisition_request(payload: dict[str, Any]) -> AcquisitionRequest:
+    raw_url = payload.get("url")
     raw_path = payload.get("path")
-    if not isinstance(raw_path, str) or not raw_path.strip():
-        raise IngestError("Ingest job payload is missing a valid path")
+    if isinstance(raw_url, str) and raw_url.strip():
+        if isinstance(raw_path, str) and raw_path.strip():
+            raise IngestError("Ingest job payload cannot contain both a URL and path")
+        return AcquisitionRequest(kind=SOURCE_KIND_URL, reference=raw_url.strip())
+    if isinstance(raw_path, str) and raw_path.strip():
+        return AcquisitionRequest(kind="local_path", reference=raw_path)
+    raise IngestError("Ingest job payload is missing a valid URL or path")
 
-    source_path = Path(raw_path).expanduser().resolve()
-    if not source_path.exists() or not source_path.is_file():
-        raise IngestError(f"Source PDF not found: {source_path}")
-    if source_path.suffix.lower() != ".pdf":
-        raise IngestError(f"Source file is not a PDF: {source_path}")
-    return source_path
+
+def _safe_acquisition_reference(request: AcquisitionRequest) -> str:
+    if request.kind == SOURCE_KIND_URL:
+        return safe_url_reference(request.reference)
+    return str(Path(os.path.abspath(Path(request.reference).expanduser())))
 
 
 def _payload_metadata(payload: dict[str, Any]) -> dict[str, Any]:
@@ -933,38 +930,31 @@ def _metadata_source_url(metadata: dict[str, Any]) -> str | None:
     return None
 
 
-def _metadata_retrieved_at(metadata: dict[str, Any]) -> str | None:
-    retrieved_at = metadata.get("retrieved_at")
-    if isinstance(retrieved_at, str) and retrieved_at.strip():
-        return retrieved_at.strip()
-    return None
-
-
 @contextmanager
-def _ingest_stage(job_id: str, stage: str, source_path: Path) -> Iterator[None]:
+def _ingest_stage(job_id: str, stage: str, source_reference: Path | str) -> Iterator[None]:
     started_at = perf_counter()
     LOGGER.info(
-        "ingest_stage_started job_id=%s stage=%s source_path=%r",
+        "ingest_stage_started job_id=%s stage=%s source_reference=%r",
         job_id,
         stage,
-        str(source_path),
+        str(source_reference),
     )
     try:
         yield
     except Exception:
         LOGGER.error(
-            "ingest_stage_failed job_id=%s stage=%s source_path=%r elapsed_ms=%d",
+            "ingest_stage_failed job_id=%s stage=%s source_reference=%r elapsed_ms=%d",
             job_id,
             stage,
-            str(source_path),
+            str(source_reference),
             round((perf_counter() - started_at) * 1000),
         )
         raise
     LOGGER.info(
-        "ingest_stage_completed job_id=%s stage=%s source_path=%r elapsed_ms=%d",
+        "ingest_stage_completed job_id=%s stage=%s source_reference=%r elapsed_ms=%d",
         job_id,
         stage,
-        str(source_path),
+        str(source_reference),
         round((perf_counter() - started_at) * 1000),
     )
 
@@ -1008,53 +998,12 @@ def _extractor_identity(name: str) -> ExtractorIdentity:
     return ExtractorIdentity(name=name)
 
 
-def _hash_bytes(content: bytes) -> str:
-    return hashlib.sha256(content).hexdigest()
-
-
-def _hash_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as file_handle:
-        for chunk in iter(lambda: file_handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _current_timestamp() -> str:
-    return datetime.now(UTC).isoformat()
-
-
-def _looks_like_pdf(content_type: str | None, content: bytes) -> bool:
-    normalized_content_type = (content_type or "").lower()
-    return "application/pdf" in normalized_content_type or content.startswith(b"%PDF-")
-
-
-def _copy_source_pdf(storage_paths: StoragePaths, source_path: Path, source_hash: str) -> Path:
-    destination = storage_paths.source_pdfs / f"{source_hash}.pdf"
-    if source_path.resolve() == destination.resolve():
-        return destination
-    if destination.exists():
-        if _hash_file(destination) != source_hash:
-            raise IngestError(f"Stored artifact failed integrity check: {destination}")
-        return destination
-
-    temporary_path = destination.with_name(f".{source_hash}-{uuid.uuid4().hex}.tmp")
-    try:
-        shutil.copy2(source_path, temporary_path)
-        if _hash_file(temporary_path) != source_hash:
-            raise IngestError(f"Source changed while acquiring artifact: {source_path}")
-        temporary_path.replace(destination)
-    finally:
-        temporary_path.unlink(missing_ok=True)
-    return destination
-
-
 def _build_document_metadata(
     metadata: dict[str, Any],
     source_path: Path,
     stored_source_path: Path,
 ) -> dict[str, Any]:
-    source_stat = source_path.stat()
+    source_stat = stored_source_path.stat()
     combined = dict(metadata)
     combined.setdefault("source_filename", source_path.name)
     combined.setdefault("source_size_bytes", source_stat.st_size)

--- a/newsrag/ingestion_identity.py
+++ b/newsrag/ingestion_identity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
@@ -79,6 +80,8 @@ def register_acquired_artifact(
     byte_size: int,
     stored_path: Path,
     acquired_at: str,
+    reported_media_type: str | None,
+    provenance: dict[str, object],
 ) -> IngestionIdentityDecision:
     """Register exact bytes and decide whether ordinary processing may continue."""
 
@@ -111,9 +114,11 @@ def register_acquired_artifact(
                 content_hash,
                 stored_path,
                 acquired_at,
-                state
+                state,
+                reported_media_type,
+                provenance_json
             )
-            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 artifact_id,
@@ -124,6 +129,8 @@ def register_acquired_artifact(
                 str(stored_path),
                 acquired_at,
                 state,
+                reported_media_type,
+                json.dumps(provenance, sort_keys=True),
             ),
         )
         connection.commit()
@@ -147,6 +154,17 @@ def register_acquired_artifact(
         outcome=outcome,
         document_id=current_document_id,
     )
+
+
+def find_stored_artifact_path(database_path: Path, content_hash: str) -> Path | None:
+    """Return the durable path for previously registered exact bytes."""
+
+    with sqlite3.connect(database_path) as connection:
+        row = connection.execute(
+            "SELECT stored_path FROM source_artifacts WHERE content_hash = ?",
+            (content_hash,),
+        ).fetchone()
+    return Path(str(row[0])) if row is not None else None
 
 
 def find_document_for_artifact(database_path: Path, artifact_id: str) -> str | None:

--- a/newsrag/sources.py
+++ b/newsrag/sources.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import SplitResult, urlsplit, urlunsplit
@@ -22,7 +23,12 @@ class SourceIdentity:
     resolved_reference: str | None
 
 
-def build_source_identity(*, source_path: Path, source_url: str | None) -> SourceIdentity:
+def build_source_identity(
+    *,
+    source_path: Path,
+    source_url: str | None,
+    resolved_reference: str | None = None,
+) -> SourceIdentity:
     """Build the corpus-local identity fields for a URL or local path."""
 
     if source_url is not None:
@@ -33,17 +39,17 @@ def build_source_identity(*, source_path: Path, source_url: str | None) -> Sourc
             kind=SOURCE_KIND_URL,
             submitted_reference=submitted_reference,
             normalized_reference=normalized_reference,
-            resolved_reference=normalized_reference,
+            resolved_reference=resolved_reference or normalized_reference,
         )
 
     submitted_reference = str(source_path)
-    normalized_reference = str(source_path.expanduser().resolve())
+    normalized_reference = str(Path(os.path.abspath(os.path.expanduser(submitted_reference))))
     return SourceIdentity(
         id=_stable_id("source", SOURCE_KIND_LOCAL_PATH, normalized_reference),
         kind=SOURCE_KIND_LOCAL_PATH,
         submitted_reference=submitted_reference,
         normalized_reference=normalized_reference,
-        resolved_reference=normalized_reference,
+        resolved_reference=resolved_reference or str(Path(normalized_reference).resolve()),
     )
 
 

--- a/newsrag/storage.py
+++ b/newsrag/storage.py
@@ -35,6 +35,8 @@ class StoragePaths:
     lancedb: Path
     logs: Path
     artifacts: Path
+    source_artifacts: Path
+    artifact_staging: Path
     database: Path
 
 
@@ -77,9 +79,11 @@ DIRECTORY_NAMES: tuple[tuple[str, str], ...] = (
     ("lancedb", "lancedb"),
     ("logs", "logs"),
     ("artifacts", "artifacts"),
+    ("source_artifacts", "artifacts/sources"),
+    ("artifact_staging", "artifacts/staging"),
 )
 DATABASE_FILENAME = "newsrag.sqlite3"
-SCHEMA_VERSION = "3"
+SCHEMA_VERSION = "4"
 REQUIRED_TABLES = {
     "sources",
     "source_artifacts",
@@ -130,6 +134,8 @@ SCHEMA_STATEMENTS = (
         stored_path TEXT NOT NULL,
         acquired_at TEXT NOT NULL,
         state TEXT NOT NULL DEFAULT 'processing',
+        reported_media_type TEXT,
+        provenance_json TEXT NOT NULL DEFAULT '{}',
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY(source_id) REFERENCES sources(id)
     )
@@ -365,6 +371,8 @@ def build_storage_paths(data_dir: Path) -> StoragePaths:
         lancedb=directory_paths["lancedb"],
         logs=directory_paths["logs"],
         artifacts=directory_paths["artifacts"],
+        source_artifacts=directory_paths["source_artifacts"],
+        artifact_staging=directory_paths["artifact_staging"],
         database=data_dir / DATABASE_FILENAME,
     )
 
@@ -528,6 +536,8 @@ def _directory_checks(paths: StoragePaths) -> tuple[tuple[str, Path], ...]:
         ("lancedb", paths.lancedb),
         ("logs", paths.logs),
         ("artifacts", paths.artifacts),
+        ("source_artifacts", paths.source_artifacts),
+        ("artifact_staging", paths.artifact_staging),
     )
 
 
@@ -559,6 +569,13 @@ def _initialize_database(database_path: Path) -> tuple[bool, tuple[str, ...]]:
             "TEXT NOT NULL DEFAULT 'processing'",
         )
         _ensure_column(connection, "jobs", "result_json", "TEXT")
+        _ensure_column(connection, "source_artifacts", "reported_media_type", "TEXT")
+        _ensure_column(
+            connection,
+            "source_artifacts",
+            "provenance_json",
+            "TEXT NOT NULL DEFAULT '{}'",
+        )
         _ensure_column(connection, "pages", "extractor", "TEXT NOT NULL DEFAULT 'unknown'")
         _ensure_column(
             connection,

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import gzip
+import hashlib
+import os
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+
+import pytest
+
+import newsrag.acquisition as acquisition_module
+from newsrag.acquisition import (
+    SOURCE_KIND_LOCAL_PATH,
+    SOURCE_KIND_URL,
+    AcquisitionError,
+    AcquisitionLimits,
+    AcquisitionRequest,
+    SafeSourceArtifactAcquirer,
+    preserve_staged_artifact,
+)
+
+PUBLIC_IP = "93.184.216.34"
+
+
+def test_default_acquisition_limits_match_approved_policy() -> None:
+    limits = AcquisitionLimits()
+
+    assert limits.max_local_bytes == 250 * 1024 * 1024
+    assert limits.max_compressed_bytes == 250 * 1024 * 1024
+    assert limits.max_decompressed_bytes == 250 * 1024 * 1024
+    assert limits.max_redirects == 5
+    assert limits.timeout_seconds == 30.0
+
+
+def test_local_acquisition_stages_exact_bytes_and_provenance(tmp_path: Path) -> None:
+    source_path = tmp_path / "packet.pdf"
+    content = b"%PDF-1.4\nlocal"
+    source_path.write_bytes(content)
+    acquirer = SafeSourceArtifactAcquirer()
+
+    artifact = acquirer.acquire(
+        AcquisitionRequest(kind=SOURCE_KIND_LOCAL_PATH, reference=str(source_path)),
+        tmp_path / "staging",
+    )
+    stored_path = preserve_staged_artifact(artifact, tmp_path / "artifacts")
+
+    assert stored_path.read_bytes() == content
+    assert stored_path.name == hashlib.sha256(content).hexdigest()
+    assert not artifact.staged_path.exists()
+    assert artifact.submitted_reference == str(source_path)
+    assert artifact.normalized_reference == str(source_path)
+    assert artifact.resolved_reference == str(source_path.resolve())
+    assert artifact.byte_size == len(content)
+    assert artifact.reported_media_type == "application/pdf"
+    assert artifact.provenance["submitted_path"] == str(source_path)
+    assert artifact.provenance["resolved_path"] == str(source_path.resolve())
+    assert isinstance(artifact.provenance["file_mtime_ns"], int)
+    assert "file_read_started_at" in artifact.provenance
+    assert "file_read_completed_at" in artifact.provenance
+
+
+def test_explicit_local_symlink_records_submitted_and_resolved_paths(tmp_path: Path) -> None:
+    target_path = tmp_path / "target.pdf"
+    target_path.write_bytes(b"%PDF-1.4\nsymlink")
+    symlink_path = tmp_path / "submitted.pdf"
+    symlink_path.symlink_to(target_path)
+
+    artifact = SafeSourceArtifactAcquirer().acquire(
+        AcquisitionRequest(kind=SOURCE_KIND_LOCAL_PATH, reference=str(symlink_path)),
+        tmp_path / "staging",
+    )
+
+    assert artifact.submitted_reference == str(symlink_path)
+    assert artifact.normalized_reference == str(symlink_path)
+    assert artifact.resolved_reference == str(target_path.resolve())
+    assert artifact.staged_path.read_bytes() == target_path.read_bytes()
+
+
+def test_local_acquisition_rejects_missing_special_oversized_and_changed_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    missing_path = tmp_path / "missing.pdf"
+    with pytest.raises(AcquisitionError, match="Cannot resolve local source"):
+        SafeSourceArtifactAcquirer().acquire(
+            AcquisitionRequest(kind=SOURCE_KIND_LOCAL_PATH, reference=str(missing_path)),
+            tmp_path / "staging-missing",
+        )
+
+    fifo_path = tmp_path / "special.pdf"
+    os.mkfifo(fifo_path)
+    with pytest.raises(AcquisitionError, match="not a regular file"):
+        SafeSourceArtifactAcquirer().acquire(
+            AcquisitionRequest(kind=SOURCE_KIND_LOCAL_PATH, reference=str(fifo_path)),
+            tmp_path / "staging-special",
+        )
+
+    oversized_path = tmp_path / "oversized.pdf"
+    oversized_path.write_bytes(b"12345")
+    with pytest.raises(AcquisitionError, match="exceeds 4 bytes"):
+        SafeSourceArtifactAcquirer(limits=AcquisitionLimits(max_local_bytes=4)).acquire(
+            AcquisitionRequest(kind=SOURCE_KIND_LOCAL_PATH, reference=str(oversized_path)),
+            tmp_path / "staging-oversized",
+        )
+
+    changed_path = tmp_path / "changed.pdf"
+    changed_path.write_bytes(b"stable")
+    real_file_state_from_fd = acquisition_module._file_state_from_fd
+    calls = 0
+
+    def changed_file_state(file_descriptor: int) -> acquisition_module._FileState:
+        nonlocal calls
+        calls += 1
+        state = real_file_state_from_fd(file_descriptor)
+        return replace(state, modified_at_ns=state.modified_at_ns + 1) if calls == 2 else state
+
+    monkeypatch.setattr(acquisition_module, "_file_state_from_fd", changed_file_state)
+    with pytest.raises(AcquisitionError, match="changed while reading"):
+        SafeSourceArtifactAcquirer().acquire(
+            AcquisitionRequest(kind=SOURCE_KIND_LOCAL_PATH, reference=str(changed_path)),
+            tmp_path / "staging-changed",
+        )
+    assert list((tmp_path / "staging-changed").iterdir()) == []
+
+
+def test_remote_acquisition_revalidates_redirect_and_records_provenance(
+    tmp_path: Path,
+) -> None:
+    first_url = "https://example.gov/start?token=private"
+    final_url = "https://cdn.example.gov/packet.pdf"
+    content = b"%PDF-1.4\nremote"
+    compressed = gzip.compress(content)
+    transport = FakeHttpTransport(
+        responses={
+            first_url: [
+                FakeHttpResponse(
+                    status_code=302,
+                    headers={"location": final_url},
+                )
+            ],
+            final_url: [
+                FakeHttpResponse(
+                    status_code=200,
+                    headers={
+                        "content-encoding": "gzip",
+                        "content-length": str(len(compressed)),
+                        "content-type": "application/pdf; charset=binary",
+                    },
+                    chunks=(compressed,),
+                )
+            ],
+        }
+    )
+    resolver = RecordingResolver(
+        addresses={"example.gov": (PUBLIC_IP,), "cdn.example.gov": (PUBLIC_IP,)}
+    )
+
+    artifact = SafeSourceArtifactAcquirer(
+        resolver=resolver,
+        transport=transport,
+    ).acquire(
+        AcquisitionRequest(kind=SOURCE_KIND_URL, reference=first_url),
+        tmp_path / "staging",
+    )
+
+    assert artifact.staged_path.read_bytes() == content
+    assert artifact.content_hash == hashlib.sha256(content).hexdigest()
+    assert artifact.reported_media_type == "application/pdf"
+    assert artifact.resolved_reference == final_url
+    assert artifact.provenance["redirects"] == [final_url]
+    assert artifact.provenance["compressed_byte_size"] == len(compressed)
+    assert artifact.provenance["reported_content_length"] == len(compressed)
+    assert resolver.hosts == ["example.gov", "cdn.example.gov"]
+    assert transport.requests == [(first_url, PUBLIC_IP), (final_url, PUBLIC_IP)]
+    assert all(
+        response.closed for responses in transport.responses.values() for response in responses
+    )
+
+
+@pytest.mark.parametrize(
+    ("url", "addresses", "message"),
+    [
+        ("file:///tmp/packet.pdf", {}, "Only public HTTP"),
+        ("https://user:secret@example.gov/packet.pdf", {}, "credentials"),
+        ("https://localhost/packet.pdf", {}, "Localhost"),
+        ("https://127.0.0.1/packet.pdf", {}, "Non-public"),
+        ("https://169.254.1.2/packet.pdf", {}, "Non-public"),
+        ("https://224.0.0.1/packet.pdf", {}, "Non-public"),
+        ("https://0.0.0.0/packet.pdf", {}, "Non-public"),
+        ("https://[::1]/packet.pdf", {}, "Non-public"),
+        ("https://[fe80::1]/packet.pdf", {}, "Non-public"),
+        (
+            "https://internal.example.gov/packet.pdf",
+            {"internal.example.gov": ("10.0.0.2",)},
+            "Non-public",
+        ),
+    ],
+)
+def test_remote_acquisition_rejects_unsafe_destinations_before_request(
+    tmp_path: Path,
+    url: str,
+    addresses: dict[str, tuple[str, ...]],
+    message: str,
+) -> None:
+    transport = FakeHttpTransport()
+
+    with pytest.raises(AcquisitionError, match=message):
+        SafeSourceArtifactAcquirer(
+            resolver=RecordingResolver(addresses=addresses),
+            transport=transport,
+        ).acquire(
+            AcquisitionRequest(kind=SOURCE_KIND_URL, reference=url),
+            tmp_path / "staging",
+        )
+
+    assert transport.requests == []
+
+
+def test_remote_acquisition_rejects_private_redirect_before_following_it(
+    tmp_path: Path,
+) -> None:
+    first_url = "https://example.gov/packet.pdf"
+    private_url = "https://10.0.0.4/internal.pdf"
+    transport = FakeHttpTransport(
+        responses={
+            first_url: [FakeHttpResponse(status_code=302, headers={"location": private_url})]
+        }
+    )
+
+    with pytest.raises(AcquisitionError, match="Non-public"):
+        SafeSourceArtifactAcquirer(
+            resolver=RecordingResolver(addresses={"example.gov": (PUBLIC_IP,)}),
+            transport=transport,
+        ).acquire(
+            AcquisitionRequest(kind=SOURCE_KIND_URL, reference=first_url),
+            tmp_path / "staging",
+        )
+
+    assert transport.requests == [(first_url, PUBLIC_IP)]
+
+
+def test_remote_acquisition_rejects_https_downgrade_redirect(tmp_path: Path) -> None:
+    url = "https://example.gov/packet.pdf"
+    transport = FakeHttpTransport(
+        responses={
+            url: [
+                FakeHttpResponse(
+                    status_code=302,
+                    headers={"location": "http://example.gov/packet.pdf"},
+                )
+            ]
+        }
+    )
+
+    with pytest.raises(AcquisitionError, match="HTTPS downgrade"):
+        SafeSourceArtifactAcquirer(
+            resolver=RecordingResolver(addresses={"example.gov": (PUBLIC_IP,)}),
+            transport=transport,
+        ).acquire(
+            AcquisitionRequest(kind=SOURCE_KIND_URL, reference=url),
+            tmp_path / "staging",
+        )
+
+    assert transport.requests == [(url, PUBLIC_IP)]
+
+
+def test_remote_acquisition_enforces_redirect_limit(tmp_path: Path) -> None:
+    first_url = "https://example.gov/first"
+    second_url = "https://example.gov/second"
+    transport = FakeHttpTransport(
+        responses={
+            first_url: [FakeHttpResponse(302, {"location": second_url})],
+            second_url: [FakeHttpResponse(302, {"location": "/third"})],
+        }
+    )
+
+    with pytest.raises(AcquisitionError, match="exceeded 1 redirects"):
+        SafeSourceArtifactAcquirer(
+            limits=AcquisitionLimits(max_redirects=1),
+            resolver=RecordingResolver(addresses={"example.gov": (PUBLIC_IP,)}),
+            transport=transport,
+        ).acquire(
+            AcquisitionRequest(kind=SOURCE_KIND_URL, reference=first_url),
+            tmp_path / "staging",
+        )
+
+    assert transport.requests == [(first_url, PUBLIC_IP), (second_url, PUBLIC_IP)]
+
+
+def test_remote_acquisition_rejects_partial_response(tmp_path: Path) -> None:
+    url = "https://example.gov/packet.pdf"
+
+    with pytest.raises(AcquisitionError, match="HTTP status 206"):
+        SafeSourceArtifactAcquirer(
+            resolver=RecordingResolver(addresses={"example.gov": (PUBLIC_IP,)}),
+            transport=FakeHttpTransport(
+                responses={url: [FakeHttpResponse(206, {}, (b"partial",))]}
+            ),
+        ).acquire(
+            AcquisitionRequest(kind=SOURCE_KIND_URL, reference=url),
+            tmp_path / "staging",
+        )
+
+
+def test_remote_acquisition_rejects_unsupported_encoding_and_length_mismatch(
+    tmp_path: Path,
+) -> None:
+    url = "https://example.gov/packet.pdf"
+    resolver = RecordingResolver(addresses={"example.gov": (PUBLIC_IP,)})
+    with pytest.raises(AcquisitionError, match="Unsupported Content-Encoding"):
+        SafeSourceArtifactAcquirer(
+            resolver=resolver,
+            transport=FakeHttpTransport(
+                responses={
+                    url: [
+                        FakeHttpResponse(
+                            200,
+                            {"content-encoding": "br"},
+                            (b"encoded",),
+                        )
+                    ]
+                }
+            ),
+        ).acquire(
+            AcquisitionRequest(kind=SOURCE_KIND_URL, reference=url),
+            tmp_path / "encoding-staging",
+        )
+
+    with pytest.raises(AcquisitionError, match="did not match Content-Length"):
+        SafeSourceArtifactAcquirer(
+            resolver=resolver,
+            transport=FakeHttpTransport(
+                responses={url: [FakeHttpResponse(200, {"content-length": "10"}, (b"short",))]}
+            ),
+        ).acquire(
+            AcquisitionRequest(kind=SOURCE_KIND_URL, reference=url),
+            tmp_path / "length-staging",
+        )
+
+
+def test_remote_acquisition_enforces_compressed_and_decompressed_limits(
+    tmp_path: Path,
+) -> None:
+    url = "https://example.gov/packet.pdf"
+    resolver = RecordingResolver(addresses={"example.gov": (PUBLIC_IP,)})
+    compressed_transport = FakeHttpTransport(
+        responses={url: [FakeHttpResponse(status_code=200, headers={}, chunks=(b"12345",))]}
+    )
+    with pytest.raises(AcquisitionError, match="compressed bytes"):
+        SafeSourceArtifactAcquirer(
+            limits=AcquisitionLimits(max_compressed_bytes=4),
+            resolver=resolver,
+            transport=compressed_transport,
+        ).acquire(
+            AcquisitionRequest(kind=SOURCE_KIND_URL, reference=url),
+            tmp_path / "compressed-staging",
+        )
+
+    expanded = b"x" * 20
+    encoded = gzip.compress(expanded)
+    decompressed_transport = FakeHttpTransport(
+        responses={
+            url: [
+                FakeHttpResponse(
+                    status_code=200,
+                    headers={"content-encoding": "gzip"},
+                    chunks=(encoded,),
+                )
+            ]
+        }
+    )
+    with pytest.raises(AcquisitionError, match="decompressed bytes"):
+        SafeSourceArtifactAcquirer(
+            limits=AcquisitionLimits(max_decompressed_bytes=10),
+            resolver=resolver,
+            transport=decompressed_transport,
+        ).acquire(
+            AcquisitionRequest(kind=SOURCE_KIND_URL, reference=url),
+            tmp_path / "decompressed-staging",
+        )
+
+
+def test_remote_acquisition_does_not_fetch_secondary_resources(tmp_path: Path) -> None:
+    url = "https://example.gov/page"
+    content = b'<html><img src="https://other.example/image.png"></html>'
+    transport = FakeHttpTransport(
+        responses={
+            url: [
+                FakeHttpResponse(
+                    status_code=200,
+                    headers={"content-type": "text/html"},
+                    chunks=(content,),
+                )
+            ]
+        }
+    )
+
+    artifact = SafeSourceArtifactAcquirer(
+        resolver=RecordingResolver(addresses={"example.gov": (PUBLIC_IP,)}),
+        transport=transport,
+    ).acquire(
+        AcquisitionRequest(kind=SOURCE_KIND_URL, reference=url),
+        tmp_path / "staging",
+    )
+
+    assert artifact.staged_path.read_bytes() == content
+    assert transport.requests == [(url, PUBLIC_IP)]
+
+
+def test_remote_errors_do_not_expose_query_or_response_body(tmp_path: Path) -> None:
+    url = "https://example.gov/packet.pdf?token=secret"
+    transport = FakeHttpTransport(error=TimeoutError("response body secret"))
+
+    with pytest.raises(AcquisitionError) as raised:
+        SafeSourceArtifactAcquirer(
+            resolver=RecordingResolver(addresses={"example.gov": (PUBLIC_IP,)}),
+            transport=transport,
+        ).acquire(
+            AcquisitionRequest(kind=SOURCE_KIND_URL, reference=url),
+            tmp_path / "staging",
+        )
+
+    message = str(raised.value)
+    assert "token=secret" not in message
+    assert "response body secret" not in message
+    assert "https://example.gov/packet.pdf" in message
+
+
+@dataclass
+class FakeHttpResponse:
+    status_code: int
+    headers: Mapping[str, str]
+    chunks: tuple[bytes, ...] = ()
+    closed: bool = False
+
+    def iter_raw(self) -> Iterator[bytes]:
+        yield from self.chunks
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@dataclass
+class FakeHttpTransport:
+    responses: dict[str, list[FakeHttpResponse]] = field(default_factory=dict)
+    error: Exception | None = None
+    requests: list[tuple[str, str]] = field(default_factory=list)
+
+    def get(
+        self,
+        *,
+        url: str,
+        connect_ip: str,
+        timeout_seconds: float,
+    ) -> FakeHttpResponse:
+        del timeout_seconds
+        self.requests.append((url, connect_ip))
+        if self.error is not None:
+            raise self.error
+        return self.responses[url].pop(0)
+
+
+@dataclass
+class RecordingResolver:
+    addresses: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    hosts: list[str] = field(default_factory=list)
+
+    def __call__(self, host: str, port: int) -> tuple[str, ...]:
+        del port
+        self.hosts.append(host)
+        return self.addresses.get(host, (PUBLIC_IP,))

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -260,6 +260,23 @@ def test_jobs_list_shows_all_job_statuses(tmp_path: Path) -> None:
     assert "error=boom" in result.stdout
 
 
+def test_jobs_list_redacts_url_query_values(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    paths = initialize_storage(data_dir)
+    job = create_job(
+        paths.database,
+        kind="ingest-file",
+        payload={"url": "https://example.gov/packet.pdf?token=secret"},
+    )
+
+    result = runner.invoke(app, ["--data-dir", str(data_dir), "jobs", "list"])
+
+    assert result.exit_code == 0
+    assert job.id in result.stdout
+    assert "url=https://example.gov/packet.pdf" in result.stdout
+    assert "token=secret" not in result.stdout
+
+
 def test_failed_job_appears_in_status_with_error_count(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
     paths = initialize_storage(data_dir)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,20 +1,28 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import sqlite3
-from collections.abc import Callable, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
 from threading import Barrier
 
-import httpx
 import lancedb  # type: ignore[import-untyped]
 import pytest
 from typer.testing import CliRunner
 
+from newsrag.acquisition import (
+    SOURCE_KIND_URL,
+    AcquisitionError,
+    AcquisitionRequest,
+    HttpResponseStream,
+    SafeSourceArtifactAcquirer,
+    StagedSourceArtifact,
+)
 from newsrag.adapters import (
     AdapterError,
     AdapterInput,
@@ -39,12 +47,12 @@ from newsrag.ingest import (
     PDF_EXTRACTOR_TABLE,
     ExtractedPage,
     FallbackTextExtractor,
-    IngestError,
     LanceDbVectorStore,
     PdfPlumberTextExtractor,
     PyMuPdfTextExtractor,
     build_ingest_handler,
     build_pdf_text_extractor,
+    enqueue_ingest_jobs,
     enqueue_ingest_url_job,
     list_chunk_vectors,
     list_chunks,
@@ -60,6 +68,7 @@ from newsrag.jobs import (
     set_job_status,
 )
 from newsrag.manifests import ManifestError, load_manifest
+from newsrag.sources import normalize_url_reference
 from newsrag.storage import initialize_storage
 
 runner = CliRunner()
@@ -71,6 +80,7 @@ def test_ingest_command_enqueues_local_pdf_jobs(tmp_path: Path) -> None:
     source_dir.mkdir()
     (source_dir / "packet-a.pdf").write_bytes(b"%PDF-1.4\nA")
     (source_dir / "packet-b.PDF").write_bytes(b"%PDF-1.4\nB")
+    (source_dir / "alias.pdf").symlink_to(source_dir / "packet-a.pdf")
     (source_dir / "notes.txt").write_text("ignore me", encoding="utf-8")
 
     result = runner.invoke(
@@ -124,14 +134,9 @@ def test_ingest_command_records_pdf_extractor_mode(tmp_path: Path) -> None:
     assert jobs[0].payload["pdf_extractor"] == PDF_EXTRACTOR_TABLE
 
 
-def test_ingest_url_command_downloads_pdf_and_enqueues_job(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_ingest_url_command_enqueues_background_acquisition(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
-    url = "https://example.gov/packet.pdf"
-
-    monkeypatch.setattr("newsrag.ingest.httpx.get", _fake_pdf_getter(url, b"%PDF-1.4\nurl-pdf"))
+    url = "https://example.gov/packet.pdf?token=secret"
 
     result = runner.invoke(
         app,
@@ -152,48 +157,68 @@ def test_ingest_url_command_downloads_pdf_and_enqueues_job(
 
     assert result.exit_code == 0
     assert "Enqueued 1 ingest job(s)" in result.stdout
+    assert "token=secret" not in result.stdout
     assert len(jobs) == 1
     assert jobs[0].kind == INGEST_JOB_KIND
-    assert Path(jobs[0].payload["path"]).parent == paths.downloaded_pdfs
-    assert Path(jobs[0].payload["path"]).is_file()
+    assert jobs[0].payload["url"] == url
+    assert "path" not in jobs[0].payload
     assert jobs[0].payload["metadata"]["body"] == "City Council"
     assert jobs[0].payload["metadata"]["document_type"] == "agenda_packet"
-    assert jobs[0].payload["metadata"]["source_url"] == url
-    assert "retrieved_at" in jobs[0].payload["metadata"]
+    assert list(paths.downloaded_pdfs.iterdir()) == []
+    assert list(paths.source_artifacts.iterdir()) == []
 
 
-def test_enqueue_ingest_url_job_reuses_hash_named_download_for_unchanged_content(
+def test_ingest_url_rejects_credentials_without_persisting_or_displaying_them(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    data_dir = tmp_path / ".newsrag"
+
+    result = runner.invoke(
+        app,
+        [
+            "--data-dir",
+            str(data_dir),
+            "ingest-url",
+            "https://user:secret@example.gov/packet.pdf",
+        ],
+    )
+
+    paths = initialize_storage(data_dir)
+    assert result.exit_code == 1
+    assert "URL credentials are not allowed" in result.stdout
+    assert "user:secret" not in result.stdout
+    assert list_jobs(paths.database) == []
+
+
+def test_enqueue_ingest_url_job_does_not_fetch_before_daemon_processing(tmp_path: Path) -> None:
     paths = initialize_storage(tmp_path / ".newsrag")
     url = "https://example.gov/packet.pdf"
-
-    monkeypatch.setattr("newsrag.ingest.httpx.get", _fake_pdf_getter(url, b"%PDF-1.4\nunchanged"))
 
     first_job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
     second_job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
 
-    assert first_job.payload["path"] == second_job.payload["path"]
-    assert Path(first_job.payload["path"]).is_file()
+    assert first_job.payload["url"] == url
+    assert second_job.payload["url"] == url
+    assert list(paths.downloaded_pdfs.iterdir()) == []
+    assert list(paths.source_artifacts.iterdir()) == []
 
 
-def test_url_ingest_stores_source_url_and_retrieved_at(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_url_ingest_stores_source_url_and_acquisition_provenance(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
     paths = initialize_storage(data_dir)
     url = "https://example.gov/packet.pdf"
+    resolved_url = "https://cdn.example.gov/packet.pdf"
+    acquirer = FakeUrlAcquirer(
+        content_by_url={url: b"%PDF-1.4\nurl-pdf"},
+        resolved_url_by_url={url: resolved_url},
+    )
 
-    monkeypatch.setattr("newsrag.ingest.httpx.get", _fake_pdf_getter(url, b"%PDF-1.4\nurl-pdf"))
-
-    job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
-    retrieved_at = str(job.payload["metadata"]["retrieved_at"])
+    enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
 
     handler = build_ingest_handler(
         data_dir=data_dir,
         embedding_config=EmbeddingConfig(),
+        acquirer=acquirer,
         ocr_runner=FakeOcrRunner(),
         text_extractor=FakeTextExtractor(pages=[ExtractedPage(page_number=1, text="Agenda")]),
         embedding_provider=FakeEmbeddingProvider(),
@@ -216,43 +241,101 @@ def test_url_ingest_stores_source_url_and_retrieved_at(
 
     assert len(documents) == 1
     assert documents[0].source_url == url
-    assert documents[0].metadata["retrieved_at"] == retrieved_at
+    assert documents[0].metadata["retrieved_at"] == FakeUrlAcquirer.ACQUIRED_AT
     assert source is not None
     assert source["kind"] == "url"
     assert source["submitted_reference"] == url
     assert source["normalized_reference"] == url
+    assert source["resolved_reference"] == resolved_url
     assert artifact is not None
     assert artifact["source_id"] == source["id"]
-    assert artifact["acquired_at"] == retrieved_at
+    assert artifact["acquired_at"] == FakeUrlAcquirer.ACQUIRED_AT
+    assert artifact["reported_media_type"] == "application/pdf"
+    assert json.loads(artifact["provenance_json"]) == {
+        "redirects": [resolved_url],
+        "resolved_url": resolved_url,
+        "retrieved_at": FakeUrlAcquirer.ACQUIRED_AT,
+        "submitted_url": url,
+    }
+    assert Path(artifact["stored_path"]).parent == paths.source_artifacts
+    assert Path(artifact["stored_path"]).read_bytes() == b"%PDF-1.4\nurl-pdf"
 
 
-def test_ingest_url_rejects_non_pdf_responses(
+def test_safe_url_acquisition_runs_inside_daemon(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    paths = initialize_storage(data_dir)
+    url = "https://example.gov/packet.pdf"
+    response = PipelineHttpResponse(
+        status_code=200,
+        headers={"content-type": "application/pdf"},
+        chunks=(b"%PDF-1.4\nbackground",),
+    )
+    transport = PipelineHttpTransport(response=response)
+    job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        acquirer=SafeSourceArtifactAcquirer(
+            resolver=PublicResolver(),
+            transport=transport,
+        ),
+        adapter=FakeSourceAdapter(),
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+
+    asyncio.run(
+        DaemonRunner(
+            database_path=paths.database,
+            handlers={INGEST_JOB_KIND: handler},
+            poll_interval=0,
+        ).run_cycle()
+    )
+
+    assert get_job(paths.database, job.id).status == "done"
+    assert transport.requests == [(url, "93.184.216.34")]
+    assert response.closed is True
+    assert len(list(paths.source_artifacts.iterdir())) == 1
+
+
+def test_ingest_url_reports_non_pdf_validation_failure_from_background_job(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    paths = initialize_storage(tmp_path / ".newsrag")
+    data_dir = tmp_path / ".newsrag"
+    paths = initialize_storage(data_dir)
     url = "https://example.gov/not-a-pdf"
+    job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        acquirer=FakeUrlAcquirer(
+            content_by_url={url: b"<html>nope</html>"},
+            media_type_by_url={url: "text/html"},
+        ),
+        ocr_runner=FakeOcrRunner(),
+        text_extractor=FakeTextExtractor(pages=[]),
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
 
-    def fake_get(target_url: str, *, follow_redirects: bool, timeout: float) -> httpx.Response:
-        del follow_redirects, timeout
-        request = httpx.Request("GET", target_url)
-        return httpx.Response(
-            200,
-            request=request,
-            headers={"Content-Type": "text/html"},
-            content=b"<html>nope</html>",
-        )
+    asyncio.run(
+        DaemonRunner(
+            database_path=paths.database,
+            handlers={INGEST_JOB_KIND: handler},
+            poll_interval=0,
+        ).run_cycle()
+    )
 
-    monkeypatch.setattr("newsrag.ingest.httpx.get", fake_get)
+    updated_job = get_job(paths.database, job.id)
+    assert updated_job.status == FAILED
+    assert "invalid signature" in (updated_job.error or "")
+    with sqlite3.connect(paths.database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM sources").fetchone() == (1,)
+        assert connection.execute("SELECT COUNT(*) FROM source_artifacts").fetchone() == (1,)
+        assert connection.execute("SELECT COUNT(*) FROM documents").fetchone() == (0,)
 
-    with pytest.raises(IngestError, match="PDF-like response"):
-        enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
 
-
-def test_ingest_manifest_enqueues_one_job_per_document(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_ingest_manifest_enqueues_one_job_per_document(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
     manifest_path = tmp_path / "sources.yaml"
     manifest_path.write_text(
@@ -269,16 +352,6 @@ def test_ingest_manifest_enqueues_one_job_per_document(
         encoding="utf-8",
     )
 
-    monkeypatch.setattr(
-        "newsrag.ingest.httpx.get",
-        _fake_pdf_url_map_getter(
-            {
-                "https://example.gov/packet-1.pdf": b"%PDF-1.4\npacket-1",
-                "https://example.gov/packet-2.pdf": b"%PDF-1.4\npacket-2",
-            }
-        ),
-    )
-
     result = runner.invoke(
         app, ["--data-dir", str(data_dir), "ingest-manifest", str(manifest_path)]
     )
@@ -290,13 +363,14 @@ def test_ingest_manifest_enqueues_one_job_per_document(
     assert "Enqueued 2 ingest job(s)" in result.stdout
     assert len(jobs) == 2
 
-    jobs_by_url = {str(job.payload["metadata"]["source_url"]): job for job in jobs}
+    jobs_by_url = {str(job.payload["url"]): job for job in jobs}
     first_job = jobs_by_url["https://example.gov/packet-1.pdf"]
     second_job = jobs_by_url["https://example.gov/packet-2.pdf"]
 
     assert first_job.payload["metadata"]["title"] == "Packet One"
     assert first_job.payload["metadata"]["meeting_date"] == "2026-05-01"
     assert second_job.payload["metadata"]["jurisdiction"] == "Example City"
+    assert list(paths.source_artifacts.iterdir()) == []
 
 
 def test_invalid_manifest_missing_url_fails_without_enqueuing(tmp_path: Path) -> None:
@@ -379,10 +453,7 @@ def test_invalid_manifest_unsupported_fields_fail(tmp_path: Path) -> None:
         load_manifest(manifest_path)
 
 
-def test_manifest_metadata_is_preserved_on_created_documents(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_manifest_metadata_is_preserved_on_created_documents(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
     manifest_path = tmp_path / "sources.yaml"
     manifest_path.write_text(
@@ -398,11 +469,6 @@ def test_manifest_metadata_is_preserved_on_created_documents(
         encoding="utf-8",
     )
 
-    monkeypatch.setattr(
-        "newsrag.ingest.httpx.get",
-        _fake_pdf_getter("https://example.gov/packet.pdf", b"%PDF-1.4\nmanifest"),
-    )
-
     result = runner.invoke(
         app, ["--data-dir", str(data_dir), "ingest-manifest", str(manifest_path)]
     )
@@ -412,6 +478,9 @@ def test_manifest_metadata_is_preserved_on_created_documents(
     handler = build_ingest_handler(
         data_dir=data_dir,
         embedding_config=EmbeddingConfig(),
+        acquirer=FakeUrlAcquirer(
+            content_by_url={"https://example.gov/packet.pdf": b"%PDF-1.4\nmanifest"}
+        ),
         ocr_runner=FakeOcrRunner(),
         text_extractor=FakeTextExtractor(pages=[ExtractedPage(page_number=1, text="Agenda")]),
         embedding_provider=FakeEmbeddingProvider(),
@@ -435,22 +504,43 @@ def test_manifest_metadata_is_preserved_on_created_documents(
     assert documents[0].metadata["jurisdiction"] == "Example City"
 
 
-def test_ingest_url_download_failures_fail_clearly(
+def test_ingest_url_acquisition_failures_are_recorded_by_background_job(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    paths = initialize_storage(tmp_path / ".newsrag")
+    data_dir = tmp_path / ".newsrag"
+    paths = initialize_storage(data_dir)
     url = "https://example.gov/packet.pdf"
+    job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        acquirer=FakeUrlAcquirer(
+            content_by_url={},
+            error=AcquisitionError("remote_request", "Request failed safely"),
+        ),
+        adapter=FakeSourceAdapter(),
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
 
-    def fake_get(target_url: str, *, follow_redirects: bool, timeout: float) -> httpx.Response:
-        del follow_redirects, timeout
-        request = httpx.Request("GET", target_url)
-        raise httpx.ConnectError("boom", request=request)
+    with caplog.at_level(logging.INFO):
+        asyncio.run(
+            DaemonRunner(
+                database_path=paths.database,
+                handlers={INGEST_JOB_KIND: handler},
+                poll_interval=0,
+            ).run_cycle()
+        )
 
-    monkeypatch.setattr("newsrag.ingest.httpx.get", fake_get)
-
-    with pytest.raises(IngestError, match="Failed downloading"):
-        enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
+    updated_job = get_job(paths.database, job.id)
+    assert updated_job.status == FAILED
+    assert "Acquisition remote_request failed" in (updated_job.error or "")
+    assert "stage=artifact_acquisition" in caplog.text
+    assert "ingest_stage_failed" in caplog.text
+    with sqlite3.connect(paths.database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM sources").fetchone() == (0,)
+        assert connection.execute("SELECT COUNT(*) FROM source_artifacts").fetchone() == (0,)
 
 
 def test_ingestion_pipeline_processes_an_injected_source_adapter(
@@ -487,6 +577,7 @@ def test_ingestion_pipeline_processes_an_injected_source_adapter(
 
     assert get_job(paths.database, job.id).status == "done"
     for stage in (
+        "artifact_acquisition",
         "artifact_preparation",
         "adapter_extraction",
         "chunking",
@@ -497,7 +588,7 @@ def test_ingestion_pipeline_processes_an_injected_source_adapter(
         assert f"stage={stage}" in caplog.text
     assert "Adapter agenda" not in caplog.text
     assert len(adapter.inputs) == 1
-    assert adapter.inputs[0].artifact_path.parent == paths.source_pdfs
+    assert adapter.inputs[0].artifact_path.parent == paths.source_artifacts
     assert adapter.inputs[0].media_type == "application/pdf"
     with sqlite3.connect(paths.database) as connection:
         unit = connection.execute(
@@ -648,10 +739,17 @@ def test_mocked_local_pdf_job_creates_document_pages_chunks_and_vector_records(
     assert source is not None
     assert source["kind"] == "local_path"
     assert source["submitted_reference"] == str(source_pdf.resolve())
+    assert source["resolved_reference"] == str(source_pdf.resolve())
     assert artifact is not None
     assert artifact["source_id"] == source["id"]
     assert artifact["content_hash"] == documents[0].source_hash
     assert artifact["byte_size"] == source_pdf.stat().st_size
+    assert artifact["reported_media_type"] == "application/pdf"
+    assert Path(artifact["stored_path"]).parent == paths.source_artifacts
+    local_provenance = json.loads(artifact["provenance_json"])
+    assert local_provenance["submitted_path"] == str(source_pdf.resolve())
+    assert local_provenance["resolved_path"] == str(source_pdf.resolve())
+    assert local_provenance["file_mtime_ns"] == source_pdf.stat().st_mtime_ns
     assert len(source_units) == 2
     assert [unit["ordinal"] for unit in source_units] == [1, 2]
     assert [json.loads(unit["location_json"]) for unit in source_units] == [
@@ -675,6 +773,48 @@ def test_mocked_local_pdf_job_creates_document_pages_chunks_and_vector_records(
     assert {vector["source_unit_end_id"] for vector in passage_vectors} == set(unit_ids)
     assert {record.source_unit_start_id for record in embedding_records} == set(unit_ids)
     assert {record.source_unit_end_id for record in embedding_records} == set(unit_ids)
+
+
+def test_explicit_symlink_is_acquired_in_background_with_both_paths(
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / ".newsrag"
+    target_path = tmp_path / "target.pdf"
+    target_path.write_bytes(b"%PDF-1.4\nsymlink")
+    submitted_path = tmp_path / "submitted.pdf"
+    submitted_path.symlink_to(target_path)
+    paths = initialize_storage(data_dir)
+    jobs = enqueue_ingest_jobs(paths.database, source_path=submitted_path)
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        adapter=FakeSourceAdapter(),
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+
+    asyncio.run(
+        DaemonRunner(
+            database_path=paths.database,
+            handlers={INGEST_JOB_KIND: handler},
+            poll_interval=0,
+        ).run_cycle()
+    )
+
+    assert len(jobs) == 1
+    assert get_job(paths.database, jobs[0].id).status == "done"
+    with sqlite3.connect(paths.database) as connection:
+        connection.row_factory = sqlite3.Row
+        source = connection.execute("SELECT * FROM sources").fetchone()
+        artifact = connection.execute("SELECT * FROM source_artifacts").fetchone()
+    assert source is not None
+    assert source["submitted_reference"] == str(submitted_path)
+    assert source["normalized_reference"] == str(submitted_path)
+    assert source["resolved_reference"] == str(target_path.resolve())
+    assert artifact is not None
+    provenance = json.loads(artifact["provenance_json"])
+    assert provenance["submitted_path"] == str(submitted_path)
+    assert provenance["resolved_path"] == str(target_path.resolve())
 
 
 def test_build_pdf_text_extractor_can_choose_extraction_path_under_test() -> None:
@@ -878,24 +1018,19 @@ def test_same_bytes_from_different_local_paths_ignore_the_second_source(
     assert len(adapter.inputs) == 1
 
 
-def test_same_bytes_from_different_urls_ignore_the_second_source(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_same_bytes_from_different_urls_ignore_the_second_source(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
     paths = initialize_storage(data_dir)
     first_url = "https://one.example.gov/packet.pdf"
     second_url = "https://two.example.gov/renamed.pdf"
     content = b"%PDF-1.4\nidentical-url"
-    monkeypatch.setattr(
-        "newsrag.ingest.httpx.get",
-        _fake_pdf_url_map_getter({first_url: content, second_url: content}),
-    )
+    acquirer = FakeUrlAcquirer(content_by_url={first_url: content, second_url: content})
     first_job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=first_url)
     adapter = FakeSourceAdapter()
     handler = build_ingest_handler(
         data_dir=data_dir,
         embedding_config=EmbeddingConfig(),
+        acquirer=acquirer,
         adapter=adapter,
         embedding_provider=FakeEmbeddingProvider(),
         vector_store=LanceDbVectorStore(paths.lancedb),
@@ -920,8 +1055,8 @@ def test_same_bytes_from_different_urls_ignore_the_second_source(
     assert second_result is not None and second_result["outcome"] == "duplicate_ignored"
     assert get_job(paths.database, second_job.id).payload == {}
     assert sources == [(first_url,)]
-    assert len(list(paths.downloaded_pdfs.iterdir())) == 1
-    assert len(list(paths.source_pdfs.iterdir())) == 1
+    assert list(paths.downloaded_pdfs.iterdir()) == []
+    assert len(list(paths.source_artifacts.iterdir())) == 1
     assert len(adapter.inputs) == 1
 
 
@@ -1134,7 +1269,7 @@ def test_concurrent_exact_duplicates_converge_on_one_document(tmp_path: Path) ->
     assert len(list_pages(paths.database)) == 1
     assert len(list_chunks(paths.database)) == 1
     assert len(list_chunk_vectors(paths.lancedb)) == 1
-    assert len(list(paths.source_pdfs.iterdir())) == 1
+    assert len(list(paths.source_artifacts.iterdir())) == 1
     with sqlite3.connect(paths.database) as connection:
         assert connection.execute("SELECT COUNT(*) FROM sources").fetchone() == (1,)
         assert connection.execute("SELECT COUNT(*) FROM source_artifacts").fetchone() == (1,)
@@ -1190,6 +1325,37 @@ def test_retried_ingest_job_keeps_duplicate_detection_idempotent(tmp_path: Path)
     assert len(list_chunks(paths.database)) == 1
     assert len(list_chunk_vectors(paths.lancedb)) == 1
     assert len(list_embedding_records(paths.database)) == 2
+
+
+def test_missing_local_source_failure_is_recorded_by_background_job(
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / ".newsrag"
+    paths = initialize_storage(data_dir)
+    missing_path = tmp_path / "missing.pdf"
+    jobs = enqueue_ingest_jobs(paths.database, source_path=missing_path)
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        adapter=FakeSourceAdapter(),
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+
+    asyncio.run(
+        DaemonRunner(
+            database_path=paths.database,
+            handlers={INGEST_JOB_KIND: handler},
+            poll_interval=0,
+        ).run_cycle()
+    )
+
+    updated_job = get_job(paths.database, jobs[0].id)
+    assert updated_job.status == FAILED
+    assert "Acquisition local_validation failed" in (updated_job.error or "")
+    assert str(missing_path) in (updated_job.error or "")
+    with sqlite3.connect(paths.database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM source_artifacts").fetchone() == (0,)
 
 
 def test_ingest_failures_are_recorded_with_context(tmp_path: Path) -> None:
@@ -1374,36 +1540,84 @@ class FakeEmbeddingProvider:
         ]
 
 
-def _fake_pdf_getter(
-    url: str,
-    content: bytes,
-) -> Callable[..., httpx.Response]:
-    def fake_get(target_url: str, *, follow_redirects: bool, timeout: float) -> httpx.Response:
-        del follow_redirects, timeout
-        assert target_url == url
-        request = httpx.Request("GET", target_url)
-        return httpx.Response(
-            200,
-            request=request,
-            headers={"Content-Type": "application/pdf"},
-            content=content,
+@dataclass
+class PipelineHttpResponse:
+    status_code: int
+    headers: Mapping[str, str]
+    chunks: tuple[bytes, ...]
+    closed: bool = False
+
+    def iter_raw(self) -> Iterator[bytes]:
+        yield from self.chunks
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@dataclass
+class PipelineHttpTransport:
+    response: PipelineHttpResponse
+    requests: list[tuple[str, str]] = field(default_factory=list)
+
+    def get(
+        self,
+        *,
+        url: str,
+        connect_ip: str,
+        timeout_seconds: float,
+    ) -> HttpResponseStream:
+        del timeout_seconds
+        self.requests.append((url, connect_ip))
+        return self.response
+
+
+@dataclass
+class PublicResolver:
+    def __call__(self, host: str, port: int) -> tuple[str, ...]:
+        del host, port
+        return ("93.184.216.34",)
+
+
+@dataclass
+class FakeUrlAcquirer:
+    content_by_url: dict[str, bytes]
+    resolved_url_by_url: dict[str, str] = field(default_factory=dict)
+    media_type_by_url: dict[str, str] = field(default_factory=dict)
+    error: AcquisitionError | None = None
+
+    ACQUIRED_AT = "2026-09-04T00:00:00+00:00"
+
+    def acquire(
+        self,
+        request: AcquisitionRequest,
+        staging_dir: Path,
+    ) -> StagedSourceArtifact:
+        if self.error is not None:
+            raise self.error
+        assert request.kind == SOURCE_KIND_URL
+        content = self.content_by_url[request.reference]
+        resolved_url = self.resolved_url_by_url.get(request.reference, request.reference)
+        staging_dir.mkdir(parents=True, exist_ok=True)
+        staged_path = staging_dir / f"fake-{len(list(staging_dir.iterdir()))}.artifact"
+        staged_path.write_bytes(content)
+        redirects = [resolved_url] if resolved_url != request.reference else []
+        return StagedSourceArtifact(
+            source_kind=SOURCE_KIND_URL,
+            submitted_reference=request.reference,
+            normalized_reference=normalize_url_reference(request.reference),
+            resolved_reference=resolved_url,
+            staged_path=staged_path,
+            content_hash=hashlib.sha256(content).hexdigest(),
+            byte_size=len(content),
+            acquired_at=self.ACQUIRED_AT,
+            reported_media_type=self.media_type_by_url.get(
+                request.reference,
+                "application/pdf",
+            ),
+            provenance={
+                "redirects": redirects,
+                "resolved_url": resolved_url,
+                "retrieved_at": self.ACQUIRED_AT,
+                "submitted_url": request.reference,
+            },
         )
-
-    return fake_get
-
-
-def _fake_pdf_url_map_getter(
-    url_map: dict[str, bytes],
-) -> Callable[..., httpx.Response]:
-    def fake_get(target_url: str, *, follow_redirects: bool, timeout: float) -> httpx.Response:
-        del follow_redirects, timeout
-        assert target_url in url_map
-        request = httpx.Request("GET", target_url)
-        return httpx.Response(
-            200,
-            request=request,
-            headers={"Content-Type": "application/pdf"},
-            content=url_map[target_url],
-        )
-
-    return fake_get

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -37,6 +37,25 @@ def test_build_source_identity_distinguishes_urls_and_local_paths(tmp_path: Path
     assert local_identity.id != url_identity.id
 
 
+def test_local_source_identity_keeps_symlink_path_separate_from_resolved_target(
+    tmp_path: Path,
+) -> None:
+    target_path = tmp_path / "target.pdf"
+    target_path.write_bytes(b"pdf")
+    submitted_path = tmp_path / "submitted.pdf"
+    submitted_path.symlink_to(target_path)
+
+    identity = build_source_identity(
+        source_path=submitted_path,
+        source_url=None,
+        resolved_reference=str(target_path.resolve()),
+    )
+
+    assert identity.submitted_reference == str(submitted_path)
+    assert identity.normalized_reference == str(submitted_path)
+    assert identity.resolved_reference == str(target_path.resolve())
+
+
 def test_derived_artifact_and_source_unit_ids_are_stable() -> None:
     assert artifact_id_for_hash("hash-a") == artifact_id_for_hash("hash-a")
     assert artifact_id_for_hash("hash-a") != artifact_id_for_hash("hash-b")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -34,6 +34,8 @@ def test_initialize_storage_creates_layout_and_schema(tmp_path: Path) -> None:
     assert paths.lancedb.is_dir()
     assert paths.logs.is_dir()
     assert paths.artifacts.is_dir()
+    assert paths.source_artifacts.is_dir()
+    assert paths.artifact_staging.is_dir()
     assert paths.database.is_file()
     assert REQUIRED_TABLES.issubset(_existing_tables(paths.database))
 
@@ -296,6 +298,8 @@ def test_initialize_storage_migrates_pdf_records_to_source_units(tmp_path: Path)
     assert artifact["content_hash"] == source_hash
     assert artifact["stored_path"] == str(source_pdf)
     assert artifact["state"] == "published"
+    assert artifact["reported_media_type"] is None
+    assert artifact["provenance_json"] == "{}"
     assert document is not None
     assert document["artifact_id"] == artifact["id"]
     assert unit is not None


### PR DESCRIPTION
## Summary

Add bounded, auditable local-file and public HTTP(S) artifact acquisition before adapter processing.

## Task

Todu `task-8dd80bf7`

## Changes

- stage and hash local files with regular-file, symlink, size, and stability checks
- fetch public HTTP(S) resources with pinned validated addresses, safe redirects, timeouts, gzip handling, and 250 MiB limits
- preserve exact bytes in content-addressed durable storage before adapter extraction
- run URL acquisition in the daemon instead of the enqueueing CLI process
- persist acquisition provenance and redact sensitive URL details from diagnostics
- migrate storage to schema version 4 and document the acquisition boundary

## Testing

- [x] Unit tests added/updated
- [x] Manual dev-environment smoke test: restarted `make dev` on this branch, ingested a generated one-page PDF through the CLI/background daemon, confirmed `outcome=created`, retrieved it with search, then reingested it and confirmed `outcome=duplicate_ignored` with the same source, artifact, and document IDs

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated
- [x] No unrelated changes included
