### PR TITLE
Unify source ingestion commands

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ newsrag doctor
 newsrag daemon run
 newsrag watch add ./pdfs --body "City Council" --document-type agenda_packet
 newsrag ingest ./pdfs --body "City Council" --document-type agenda_packet
-newsrag ingest-url https://example.gov/packet.pdf --meeting-date 2026-04-12
+newsrag ingest https://example.gov/packet.pdf --meeting-date 2026-04-12
 newsrag ingest-manifest sources.yaml
 newsrag search "stormwater downtown" --body "Planning Commission" --since 2025-01-01
 newsrag packet "affordable housing funding" --out packets/housing.md
@@ -53,13 +53,14 @@ NewsRAG is organized around a small set of durable entities rather than a server
 
 ## Ingestion pipeline
 
-Ingestion registers documents and jobs quickly; processing happens in the daemon. Sources supported by the MVP are local PDFs/folders, direct PDF URLs, and YAML manifests. URL support is direct PDF download only. A manifest is the preferred way to provide civic metadata for multiple documents.
+Ingestion registers documents and jobs quickly; processing happens in the daemon. `newsrag ingest <source>` accepts one public HTTP(S) URL, local file, or local directory. A one-time directory scan recursively queues supported regular files, does not follow symlinks, and reports queued and skipped inputs by type. Watched folders remain a separate continuous-ingestion workflow. A manifest is the preferred way to provide civic metadata for multiple documents; every entry is validated before its jobs are created atomically, and relative local paths resolve from the manifest file's directory.
 
 Example manifest:
 
 ```yaml
 documents:
-  - url: https://example.gov/council/packet-2026-04-12.pdf
+  - source: https://example.gov/council/packet-2026-04-12.pdf
+    type: pdf
     title: City Council Packet
     meeting_date: 2026-04-12
     body: City Council
@@ -83,7 +84,7 @@ Each PDF is normalized through OCR, then text is extracted from the normalized P
 
 ## Source adapter contract
 
-A format adapter receives an `AdapterInput` identifying one immutable raw artifact, its validated media type and content hash, an isolated work directory, and format-specific options. Its `extract` method must validate the artifact and return an `AdapterResult` containing ordered `CanonicalSourceUnit` values, extractor identity, validated media type, and any derived artifact used for extraction.
+A format adapter receives an `AdapterInput` identifying one immutable raw artifact, its validated media type and content hash, an isolated work directory, and format-specific options. Its `extract` method must validate the artifact and return an `AdapterResult` containing ordered `CanonicalSourceUnit` values, extractor identity, validated media type, and any derived artifact used for extraction. The adapter registry selects a supported adapter from an optional `--type` hint, reported media type, conservative content signature, and filename extension, in that order. A hint selects an adapter but never bypasses that adapter's validation. PDF is the only currently registered source type.
 
 Each canonical source unit has a contiguous one-based ordinal, typed machine location, human-readable location label, normalized text, structure metadata, and extractor name/version. Adapters do not chunk, embed, index, publish documents, or modify source identity. Those stages belong to the shared ingestion pipeline.
 

--- a/docs/plans/06-url-ingest-e2e.md
+++ b/docs/plans/06-url-ingest-e2e.md
@@ -6,7 +6,7 @@ Allow users to ingest a direct PDF URL into the selected corpus with supplied ci
 
 ## Requirements
 
-- Add `newsrag ingest-url <url>` with metadata options such as title, meeting date, body, document type, and jurisdiction.
+- Add direct URL ingestion with metadata options such as title, meeting date, body, document type, and jurisdiction; this workflow now uses the unified `newsrag ingest <source>` interface.
 - Download direct PDF URLs into the data directory while preserving source URL and retrieval timestamp.
 - Hash downloaded content and avoid duplicate indexing of unchanged files.
 - Reuse the same background processing path as local PDF ingestion.
@@ -14,7 +14,7 @@ Allow users to ingest a direct PDF URL into the selected corpus with supplied ci
 
 ## Acceptance criteria
 
-- [ ] `newsrag ingest-url` enqueues a processing job for a direct PDF URL.
+- [ ] The ingestion command enqueues a processing job for a direct PDF URL.
 - [ ] Download behavior is unit-tested with mocked HTTP responses.
 - [ ] Source URL and retrieval timestamp are stored with the document.
 - [ ] Download failures create failed jobs or clear CLI errors with actionable messages.

--- a/docs/plans/07-yaml-manifest-ingest.md
+++ b/docs/plans/07-yaml-manifest-ingest.md
@@ -2,22 +2,22 @@
 
 ## Goal
 
-Allow users to ingest a hand-curated YAML manifest of direct PDF URLs and metadata so civic document batches can be managed reproducibly.
+Allow users to ingest a hand-curated YAML manifest of source URLs or local paths and metadata so civic document batches can be managed reproducibly.
 
 ## Requirements
 
 - Add `newsrag ingest-manifest <path>` for YAML manifests.
-- Support a `documents` list with URL and optional metadata fields including title, meeting date, body, document type, and jurisdiction.
-- Validate manifest shape and report useful errors for missing URLs, invalid dates, and unsupported fields.
-- Enqueue one processing job per valid manifest document.
-- Reuse direct URL ingestion and local processing behavior.
+- Support a `documents` list with a `source` URL or local path, an optional `type` hint, and metadata fields including title, meeting date, body, document type, and jurisdiction.
+- Validate the entire manifest and report useful errors for missing sources, invalid dates, unsupported types, and unsupported fields.
+- Enqueue all processing jobs atomically after validation.
+- Reuse unified source ingestion behavior.
 
 ## Acceptance criteria
 
 - [ ] A valid manifest enqueues one job per document.
-- [ ] Invalid manifests fail with clear validation errors and do not enqueue partial ambiguous work unless behavior is explicit.
+- [ ] Invalid manifests fail with clear validation errors and enqueue no partial work.
 - [ ] Manifest metadata is preserved on created documents.
-- [ ] Unit tests cover valid manifests, missing required fields, invalid date values, and duplicate URLs.
+- [ ] Unit tests cover URL and local sources, missing required fields, invalid date values, type hints, and duplicate sources.
 
 ## Dependencies
 

--- a/docs/research/non-pdf-source-ingestion.md
+++ b/docs/research/non-pdf-source-ingestion.md
@@ -29,7 +29,7 @@ A separate discovery tool may supply a concrete URL, but NewsRAG has no dependen
 
 ## One ingestion interface
 
-`newsrag ingest <source>` is the primary command for one public HTTP(S) URL, local file, or local directory. The redundant `newsrag ingest-url` command will be removed without a deprecation period.
+`newsrag ingest <source>` is the primary command for one public HTTP(S) URL, local file, or local directory. A separate URL-specific command is not retained.
 
 `newsrag ingest <directory>` performs a one-time recursive scan. It queues supported regular files, does not follow symlinks, and reports queued and skipped files by type. Continuous folder watching remains a separate workflow.
 

--- a/newsrag/adapters.py
+++ b/newsrag/adapters.py
@@ -10,6 +10,10 @@ class AdapterError(Exception):
     """Raised when a source adapter cannot validate or extract an artifact."""
 
 
+class AdapterSelectionError(AdapterError):
+    """Raised when an acquired artifact cannot select one registered adapter."""
+
+
 @dataclass(frozen=True)
 class ExtractorIdentity:
     """Stable identity metadata for one source extractor."""
@@ -61,3 +65,111 @@ class SourceAdapter(Protocol):
 
     def extract(self, artifact: AdapterInput) -> AdapterResult:
         """Validate and extract one immutable raw artifact."""
+
+
+@dataclass(frozen=True)
+class RegisteredSourceAdapter:
+    """One source type and the evidence that may select its adapter."""
+
+    source_type: str
+    media_type: str
+    extensions: tuple[str, ...]
+    signatures: tuple[bytes, ...]
+    adapter: SourceAdapter
+
+
+class SourceAdapterRegistry:
+    """Select one registered adapter from explicit or acquired format evidence."""
+
+    def __init__(self, registrations: Sequence[RegisteredSourceAdapter]) -> None:
+        self._registrations = tuple(registrations)
+        source_types = [registration.source_type for registration in self._registrations]
+        if len(source_types) != len(set(source_types)):
+            raise ValueError("Source adapter registrations must use unique source types")
+        if not self._registrations:
+            raise ValueError("At least one source adapter must be registered")
+
+    @property
+    def source_types(self) -> tuple[str, ...]:
+        """Return registered source-type names in registration order."""
+
+        return tuple(registration.source_type for registration in self._registrations)
+
+    def select(
+        self,
+        *,
+        artifact_path: Path,
+        source_type_hint: str | None,
+        reported_media_type: str | None,
+        filename: str,
+    ) -> RegisteredSourceAdapter:
+        """Select an adapter using hint, media type, signature, then extension."""
+
+        if source_type_hint is not None:
+            normalized_hint = source_type_hint.strip().lower()
+            for registration in self._registrations:
+                if registration.source_type == normalized_hint:
+                    return registration
+            raise AdapterSelectionError(
+                f"Unsupported source type {source_type_hint!r}; expected one of: "
+                + ", ".join(self.source_types)
+            )
+
+        normalized_media_type = (reported_media_type or "").partition(";")[0].strip().lower()
+        media_matches = tuple(
+            registration
+            for registration in self._registrations
+            if normalized_media_type == registration.media_type
+        )
+        selected = _one_adapter_match(media_matches, evidence="reported media type")
+        if selected is not None:
+            return selected
+
+        maximum_signature_bytes = max(
+            (
+                len(signature)
+                for registration in self._registrations
+                for signature in registration.signatures
+            ),
+            default=0,
+        )
+        try:
+            with artifact_path.open("rb") as artifact_file:
+                header = artifact_file.read(maximum_signature_bytes)
+        except OSError as exc:
+            raise AdapterSelectionError(
+                f"Could not inspect acquired artifact ({type(exc).__name__})"
+            ) from exc
+        signature_matches = tuple(
+            registration
+            for registration in self._registrations
+            if any(header.startswith(signature) for signature in registration.signatures)
+        )
+        selected = _one_adapter_match(signature_matches, evidence="content signature")
+        if selected is not None:
+            return selected
+
+        extension = Path(filename).suffix.lower()
+        extension_matches = tuple(
+            registration
+            for registration in self._registrations
+            if extension in registration.extensions
+        )
+        selected = _one_adapter_match(extension_matches, evidence="filename extension")
+        if selected is not None:
+            return selected
+
+        raise AdapterSelectionError(
+            "Unsupported source type; provide --type with one of: " + ", ".join(self.source_types)
+        )
+
+
+def _one_adapter_match(
+    matches: Sequence[RegisteredSourceAdapter],
+    *,
+    evidence: str,
+) -> RegisteredSourceAdapter | None:
+    if len(matches) > 1:
+        source_types = ", ".join(registration.source_type for registration in matches)
+        raise AdapterSelectionError(f"Ambiguous {evidence}; matched: {source_types}")
+    return matches[0] if matches else None

--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -19,6 +19,7 @@ from newsrag.config import (
 
 if TYPE_CHECKING:
     from newsrag.discovery_browse import DiscoveryBrowseFilters
+    from newsrag.ingest import IngestEnqueueResult
     from newsrag.jobs import Job
     from newsrag.search import SearchFilters
 
@@ -265,28 +266,33 @@ def daemon_run(
 @app.command("ingest")
 def ingest_command(
     ctx: typer.Context,
-    path: Path,
-    title: str | None = typer.Option(None, help="Document title override for the ingested PDFs."),
-    body: str | None = typer.Option(None, help="Civic body metadata for the ingested PDFs."),
+    source: str,
+    title: str | None = typer.Option(None, help="Document title override for ingested sources."),
+    body: str | None = typer.Option(None, help="Civic body metadata for ingested sources."),
     document_type: str | None = typer.Option(
         None,
         "--document-type",
-        help="Document type metadata for the ingested PDFs.",
+        help="Document type metadata for ingested sources.",
     ),
     meeting_date: str | None = typer.Option(
         None,
         "--meeting-date",
-        help="Meeting date metadata for the ingested PDFs.",
+        help="Meeting date metadata for ingested sources.",
     ),
     jurisdiction: str | None = typer.Option(
         None,
-        help="Jurisdiction metadata for the ingested PDFs.",
+        help="Jurisdiction metadata for ingested sources.",
+    ),
+    source_type: str | None = typer.Option(
+        None,
+        "--type",
+        help="Explicit source type hint; currently supported: pdf.",
     ),
     pdf_extractor: str = PDF_EXTRACTOR_OPTION,
 ) -> None:
-    """Enqueue one local PDF or directory of PDFs for ingestion."""
+    """Enqueue one URL, local file, or local directory for ingestion."""
 
-    from newsrag.ingest import IngestError, enqueue_ingest_jobs, normalize_pdf_extractor_mode
+    from newsrag.ingest import IngestError, enqueue_ingest_source
     from newsrag.storage import initialize_storage
 
     settings, _ = _resolve_runtime_settings(ctx)
@@ -300,83 +306,29 @@ def ingest_command(
     )
 
     try:
-        extraction_mode = normalize_pdf_extractor_mode(pdf_extractor)
-        jobs = enqueue_ingest_jobs(
+        result = enqueue_ingest_source(
             database_path,
-            source_path=path,
+            source=source,
             metadata=metadata,
-            pdf_extractor=extraction_mode,
+            source_type=source_type,
+            pdf_extractor=pdf_extractor,
         )
     except IngestError as exc:
         typer.echo(str(exc))
         raise typer.Exit(code=1) from exc
 
-    typer.echo(f"Enqueued {len(jobs)} ingest job(s)")
-    for job in jobs:
-        typer.echo(f"{job.id} {job.payload['path']}")
-
-
-@app.command("ingest-url")
-def ingest_url_command(
-    ctx: typer.Context,
-    url: str,
-    title: str | None = typer.Option(None, help="Document title override for the downloaded PDF."),
-    body: str | None = typer.Option(None, help="Civic body metadata for the downloaded PDF."),
-    document_type: str | None = typer.Option(
-        None,
-        "--document-type",
-        help="Document type metadata for the downloaded PDF.",
-    ),
-    meeting_date: str | None = typer.Option(
-        None,
-        "--meeting-date",
-        help="Meeting date metadata for the downloaded PDF.",
-    ),
-    jurisdiction: str | None = typer.Option(
-        None,
-        help="Jurisdiction metadata for the downloaded PDF.",
-    ),
-    pdf_extractor: str = PDF_EXTRACTOR_OPTION,
-) -> None:
-    """Enqueue one direct PDF URL for background acquisition and ingestion."""
-
-    from newsrag.acquisition import safe_url_reference
-    from newsrag.ingest import IngestError, enqueue_ingest_url_job, normalize_pdf_extractor_mode
-    from newsrag.storage import initialize_storage
-
-    settings, _ = _resolve_runtime_settings(ctx)
-    storage_paths = initialize_storage(settings.data_dir)
-    metadata = _build_document_metadata_options(
-        title=title,
-        body=body,
-        document_type=document_type,
-        meeting_date=meeting_date,
-        jurisdiction=jurisdiction,
-    )
-
-    try:
-        extraction_mode = normalize_pdf_extractor_mode(pdf_extractor)
-        job = enqueue_ingest_url_job(
-            storage_paths.database,
-            storage_paths=storage_paths,
-            url=url,
-            metadata=metadata,
-            pdf_extractor=extraction_mode,
-        )
-    except IngestError as exc:
-        typer.echo(str(exc))
-        raise typer.Exit(code=1) from exc
-
-    typer.echo("Enqueued 1 ingest job(s)")
-    typer.echo(f"{job.id} {safe_url_reference(str(job.payload['url']))}")
+    _echo_ingest_result(result)
 
 
 @app.command("ingest-manifest")
 def ingest_manifest_command(ctx: typer.Context, path: Path) -> None:
-    """Load a YAML manifest and enqueue one URL-ingest job per document."""
+    """Validate a YAML source manifest and atomically enqueue its jobs."""
 
-    from newsrag.acquisition import safe_url_reference
-    from newsrag.ingest import IngestError, enqueue_ingest_url_job
+    from newsrag.ingest import (
+        IngestError,
+        enqueue_prepared_ingest_batches,
+        prepare_ingest_source,
+    )
     from newsrag.manifests import ManifestError, load_manifest
     from newsrag.storage import initialize_storage
 
@@ -385,28 +337,24 @@ def ingest_manifest_command(ctx: typer.Context, path: Path) -> None:
 
     try:
         manifest = load_manifest(path)
-    except ManifestError as exc:
-        typer.echo(str(exc))
-        raise typer.Exit(code=1) from exc
-
-    jobs = []
-    try:
-        for document in manifest.documents:
-            jobs.append(
-                enqueue_ingest_url_job(
-                    storage_paths.database,
-                    storage_paths=storage_paths,
-                    url=document.url,
-                    metadata=document.metadata,
-                )
+        manifest_directory = path.expanduser().resolve().parent
+        batches = tuple(
+            prepare_ingest_source(
+                source=document.source,
+                metadata=document.metadata,
+                source_type=document.source_type,
+                origin="manifest",
+                base_dir=manifest_directory,
+                require_existing=not document.is_url,
             )
-    except IngestError as exc:
+            for document in manifest.documents
+        )
+        result = enqueue_prepared_ingest_batches(storage_paths.database, batches)
+    except (ManifestError, IngestError) as exc:
         typer.echo(str(exc))
         raise typer.Exit(code=1) from exc
 
-    typer.echo(f"Enqueued {len(jobs)} ingest job(s)")
-    for job in jobs:
-        typer.echo(f"{job.id} {safe_url_reference(str(job.payload['url']))}")
+    _echo_ingest_result(result)
 
 
 @app.command("search")
@@ -1086,6 +1034,30 @@ def run() -> None:
     """Run the Typer application."""
 
     app()
+
+
+def _echo_ingest_result(result: IngestEnqueueResult) -> None:
+    from newsrag.acquisition import safe_url_reference
+
+    typer.echo(f"Enqueued {len(result.jobs)} ingest job(s)")
+    typer.echo(f"Queued by type: {_format_type_counts(result.queued_by_type)}")
+    typer.echo(f"Skipped by type: {_format_type_counts(result.skipped_by_type)}")
+    for job in result.jobs:
+        source_path = job.payload.get("path")
+        source_url = job.payload.get("url")
+        if isinstance(source_path, str):
+            reference = source_path
+        elif isinstance(source_url, str):
+            reference = safe_url_reference(source_url)
+        else:
+            reference = "unknown-source"
+        typer.echo(f"{job.id} {reference}")
+
+
+def _format_type_counts(counts: dict[str, int]) -> str:
+    if not counts:
+        return "none"
+    return ", ".join(f"{name}={count}" for name, count in sorted(counts.items()))
 
 
 def _format_job_line(job: Job) -> str:

--- a/newsrag/ingest.py
+++ b/newsrag/ingest.py
@@ -6,12 +6,14 @@ import logging
 import os
 import sqlite3
 import uuid
+from collections import Counter
 from collections.abc import Awaitable, Callable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from time import perf_counter
 from typing import Any, Protocol
+from urllib.parse import urlsplit
 
 import lancedb  # type: ignore[import-untyped]
 
@@ -29,9 +31,12 @@ from newsrag.adapters import (
     AdapterError,
     AdapterInput,
     AdapterResult,
+    AdapterSelectionError,
     CanonicalSourceUnit,
     ExtractorIdentity,
+    RegisteredSourceAdapter,
     SourceAdapter,
+    SourceAdapterRegistry,
 )
 from newsrag.config import EmbeddingConfig
 from newsrag.embeddings import (
@@ -48,7 +53,7 @@ from newsrag.ingestion_identity import (
     find_stored_artifact_path,
     register_acquired_artifact,
 )
-from newsrag.jobs import Job, create_job
+from newsrag.jobs import Job, create_jobs
 from newsrag.passages import build_passage_rows
 from newsrag.pdf_adapter import (
     PDF_EXTRACTOR_AUTO,
@@ -77,6 +82,7 @@ from newsrag.sources import (
     PDF_MEDIA_TYPE,
     artifact_id_for_hash,
     build_source_identity,
+    normalize_url_reference,
     source_unit_id_for_ordinal,
     source_unit_id_for_page,
 )
@@ -102,11 +108,34 @@ INGEST_JOB_KIND = "ingest-file"
 DEFAULT_CHUNK_MAX_CHARS = 2000
 DEFAULT_CHUNK_OVERLAP_CHARS = 200
 VECTOR_TABLE_NAME = "chunk_embeddings"
+SOURCE_TYPE_PDF = "pdf"
+SUPPORTED_SOURCE_TYPES = frozenset({SOURCE_TYPE_PDF})
+_PDF_EXTENSIONS = (".pdf",)
+_PDF_SIGNATURES = (b"%PDF-",)
+_UNKNOWN_MEDIA_TYPE = "application/octet-stream"
 LOGGER = logging.getLogger(__name__)
 
 
 class IngestError(Exception):
-    """Raised when source acquisition or PDF ingestion cannot complete."""
+    """Raised when source acquisition or ingestion cannot complete."""
+
+
+@dataclass(frozen=True)
+class PreparedIngestBatch:
+    """Validated job payloads and scan reporting before durable enqueue."""
+
+    payloads: tuple[dict[str, Any], ...]
+    queued_by_type: dict[str, int]
+    skipped_by_type: dict[str, int]
+
+
+@dataclass(frozen=True)
+class IngestEnqueueResult:
+    """Durable jobs and grouped results for one ingestion request."""
+
+    jobs: tuple[Job, ...]
+    queued_by_type: dict[str, int]
+    skipped_by_type: dict[str, int]
 
 
 @dataclass(frozen=True)
@@ -367,9 +396,16 @@ class SourceProcessingPipeline:
         self.vector_store = vector_store
         self.passage_vector_store = passage_vector_store
 
-    def process(self, artifact: PreparedSourceArtifact, *, job_id: str) -> str:
+    def process(
+        self,
+        artifact: PreparedSourceArtifact,
+        *,
+        job_id: str,
+        adapter: SourceAdapter | None = None,
+    ) -> str:
+        resolved_adapter = adapter or self.adapter
         with _ingest_stage(job_id, "adapter_extraction", artifact.source_path):
-            adapter_result = self._extract_source_units(artifact)
+            adapter_result = self._extract_source_units(artifact, adapter=resolved_adapter)
         LOGGER.info(
             "ingest_units_ready job_id=%s source_path=%r units=%d extractor=%s",
             job_id,
@@ -434,6 +470,7 @@ class SourceProcessingPipeline:
                 self.storage_paths.database,
                 document_id=document_id,
                 artifact_id=artifact_id,
+                media_type=adapter_result.media_type,
                 source_path=artifact.source_path,
                 source_url=artifact.source_url,
                 title=_resolve_document_title(artifact.metadata, artifact.source_path),
@@ -463,7 +500,12 @@ class SourceProcessingPipeline:
         )
         return document_id
 
-    def _extract_source_units(self, artifact: PreparedSourceArtifact) -> AdapterResult:
+    def _extract_source_units(
+        self,
+        artifact: PreparedSourceArtifact,
+        *,
+        adapter: SourceAdapter,
+    ) -> AdapterResult:
         adapter_input = AdapterInput(
             artifact_path=artifact.artifact_path,
             content_hash=artifact.content_hash,
@@ -472,10 +514,10 @@ class SourceProcessingPipeline:
             options=artifact.adapter_options,
         )
         try:
-            result = self.adapter.extract(adapter_input)
+            result = adapter.extract(adapter_input)
         except AdapterError as exc:
             raise IngestError(f"Source adapter failed for {artifact.source_path}: {exc}") from exc
-        _validate_adapter_result(result, adapter=self.adapter)
+        _validate_adapter_result(result, adapter=adapter)
         return result
 
 
@@ -489,6 +531,7 @@ class IngestionPipeline:
         embedding_config: EmbeddingConfig,
         acquirer: SourceArtifactAcquirer | None = None,
         adapter: SourceAdapter | None = None,
+        adapter_registry: SourceAdapterRegistry | None = None,
         ocr_runner: OcrRunner | None = None,
         text_extractor: TextExtractor | None = None,
         chunker: Chunker | None = None,
@@ -501,6 +544,17 @@ class IngestionPipeline:
         resolved_adapter = adapter or PdfSourceAdapter(
             ocr_runner=ocr_runner or SubprocessOcrRunner(),
             text_extractor=text_extractor,
+        )
+        self.adapter_registry = adapter_registry or SourceAdapterRegistry(
+            (
+                RegisteredSourceAdapter(
+                    source_type=SOURCE_TYPE_PDF,
+                    media_type=PDF_MEDIA_TYPE,
+                    extensions=_PDF_EXTENSIONS,
+                    signatures=_PDF_SIGNATURES,
+                    adapter=resolved_adapter,
+                ),
+            )
         )
         self.processor = SourceProcessingPipeline(
             storage_paths=storage_paths,
@@ -536,6 +590,18 @@ class IngestionPipeline:
                 if duplicate is not None:
                     return self._completed_identity_result(job, duplicate.result())
 
+                selected_adapter: RegisteredSourceAdapter | None = None
+                selection_error: AdapterSelectionError | None = None
+                try:
+                    selected_adapter = self.adapter_registry.select(
+                        artifact_path=staged_artifact.staged_path,
+                        source_type_hint=_payload_source_type_hint(job.payload),
+                        reported_media_type=staged_artifact.reported_media_type,
+                        filename=_source_filename(staged_artifact.submitted_reference),
+                    )
+                except AdapterSelectionError as exc:
+                    selection_error = exc
+
                 stored_path = find_stored_artifact_path(
                     self.storage_paths.database,
                     staged_artifact.content_hash,
@@ -564,7 +630,11 @@ class IngestionPipeline:
                         resolved_reference=resolved_reference,
                     ),
                     content_hash=staged_artifact.content_hash,
-                    media_type=PDF_MEDIA_TYPE,
+                    media_type=(
+                        selected_adapter.media_type
+                        if selected_adapter is not None
+                        else _UNKNOWN_MEDIA_TYPE
+                    ),
                     byte_size=staged_artifact.byte_size,
                     stored_path=stored_path,
                     acquired_at=staged_artifact.acquired_at,
@@ -573,6 +643,12 @@ class IngestionPipeline:
                 )
                 if decision.action == "complete":
                     return self._completed_identity_result(job, decision.result())
+                if selection_error is not None:
+                    raise IngestError(
+                        f"Source adapter selection failed for {safe_reference}: {selection_error}"
+                    ) from selection_error
+                if selected_adapter is None:
+                    raise IngestError(f"Source adapter selection failed for {safe_reference}")
 
             document_metadata = dict(metadata)
             document_metadata["source_size_bytes"] = staged_artifact.byte_size
@@ -589,7 +665,7 @@ class IngestionPipeline:
                         source_path=decision.document_source_path,
                         artifact_path=decision.artifact_path,
                         content_hash=staged_artifact.content_hash,
-                        media_type=PDF_MEDIA_TYPE,
+                        media_type=selected_adapter.media_type,
                         source_url=decision.document_source_url,
                         acquired_at=decision.acquired_at,
                         work_dir=self.storage_paths.ocr_pdfs,
@@ -597,6 +673,7 @@ class IngestionPipeline:
                         adapter_options={"pdf_extractor": _payload_pdf_extractor_mode(job.payload)},
                     ),
                     job_id=job.id,
+                    adapter=selected_adapter.adapter,
                 )
             except sqlite3.IntegrityError as exc:
                 published_document_id = find_document_for_artifact(
@@ -638,63 +715,137 @@ class IngestionPipeline:
         return result
 
 
-def enqueue_ingest_jobs(
-    database_path: Path,
-    *,
-    source_path: Path,
-    metadata: dict[str, Any] | None = None,
-    pdf_extractor: str | None = None,
-) -> list[Job]:
-    """Enqueue local-PDF ingestion jobs for one file or directory."""
+def normalize_source_type_hint(value: str | None) -> str | None:
+    """Normalize an optional source-type hint accepted by the current registry."""
 
-    payload_metadata = dict(metadata or {})
-    payload: dict[str, Any] = {
-        "metadata": payload_metadata,
-        "source": "cli",
-    }
-    if pdf_extractor is not None:
-        payload["pdf_extractor"] = normalize_pdf_extractor_mode(pdf_extractor)
-
-    jobs: list[Job] = []
-    for pdf_path in _iter_pdf_inputs(source_path):
-        jobs.append(
-            create_job(
-                database_path,
-                kind=INGEST_JOB_KIND,
-                payload={**payload, "path": str(pdf_path)},
-            )
+    if value is None or not value.strip():
+        return None
+    normalized = value.strip().lower()
+    if normalized not in SUPPORTED_SOURCE_TYPES:
+        raise IngestError(
+            f"Unsupported source type {value!r}; expected one of: "
+            + ", ".join(sorted(SUPPORTED_SOURCE_TYPES))
         )
-    return jobs
+    return normalized
 
 
-def enqueue_ingest_url_job(
+def prepare_ingest_source(
+    *,
+    source: str,
+    metadata: dict[str, Any] | None = None,
+    source_type: str | None = None,
+    pdf_extractor: str | None = None,
+    origin: str = "cli",
+    base_dir: Path | None = None,
+    require_existing: bool = False,
+) -> PreparedIngestBatch:
+    """Validate one source and prepare job payloads without writing them."""
+
+    reference = source.strip()
+    if not reference:
+        raise IngestError("Source must not be empty")
+    normalized_source_type = normalize_source_type_hint(source_type)
+    base_payload: dict[str, Any] = {
+        "metadata": dict(metadata or {}),
+        "source": origin,
+    }
+    if normalized_source_type is not None:
+        base_payload["source_type"] = normalized_source_type
+    if pdf_extractor is not None:
+        base_payload["pdf_extractor"] = normalize_pdf_extractor_mode(pdf_extractor)
+
+    try:
+        parsed = urlsplit(reference)
+        _ = parsed.port
+    except ValueError as exc:
+        raise IngestError("Source URL is malformed") from exc
+    if parsed.scheme.lower() in {"http", "https"}:
+        try:
+            submitted_url = validate_url_submission(reference)
+        except AcquisitionError as exc:
+            raise IngestError(str(exc)) from exc
+        queued_type = (
+            normalized_source_type or _source_type_for_extension(Path(parsed.path)) or "auto"
+        )
+        return PreparedIngestBatch(
+            payloads=({**base_payload, "url": submitted_url},),
+            queued_by_type={queued_type: 1},
+            skipped_by_type={},
+        )
+    if parsed.scheme:
+        raise IngestError(
+            f"Unsupported source scheme {parsed.scheme!r}; expected HTTP(S) or a local path"
+        )
+
+    submitted_path = Path(os.path.expanduser(reference))
+    if not submitted_path.is_absolute():
+        submitted_path = (base_dir or Path.cwd()) / submitted_path
+    absolute_path = Path(os.path.abspath(submitted_path))
+    if require_existing and not absolute_path.exists():
+        raise IngestError(f"Local source path does not exist: {absolute_path}")
+
+    if absolute_path.is_dir() and not absolute_path.is_symlink():
+        paths, queued_by_type, skipped_by_type = _scan_ingest_directory(
+            absolute_path,
+            source_type=normalized_source_type,
+        )
+        return PreparedIngestBatch(
+            payloads=tuple({**base_payload, "path": str(path)} for path in paths),
+            queued_by_type=queued_by_type,
+            skipped_by_type=skipped_by_type,
+        )
+
+    queued_type = normalized_source_type or _source_type_for_extension(absolute_path) or "auto"
+    return PreparedIngestBatch(
+        payloads=({**base_payload, "path": str(absolute_path)},),
+        queued_by_type={queued_type: 1},
+        skipped_by_type={},
+    )
+
+
+def enqueue_prepared_ingest_batches(
+    database_path: Path,
+    batches: Sequence[PreparedIngestBatch],
+) -> IngestEnqueueResult:
+    """Atomically enqueue fully prepared ingestion batches."""
+
+    payloads = tuple(payload for batch in batches for payload in batch.payloads)
+    seen_references: set[tuple[str, str]] = set()
+    for payload in payloads:
+        identity = _job_payload_identity(payload)
+        if identity in seen_references:
+            raise IngestError("Ingestion batch contains a duplicate source")
+        seen_references.add(identity)
+    jobs = create_jobs(database_path, kind=INGEST_JOB_KIND, payloads=payloads)
+    queued_by_type: Counter[str] = Counter()
+    skipped_by_type: Counter[str] = Counter()
+    for batch in batches:
+        queued_by_type.update(batch.queued_by_type)
+        skipped_by_type.update(batch.skipped_by_type)
+    return IngestEnqueueResult(
+        jobs=tuple(jobs),
+        queued_by_type=dict(sorted(queued_by_type.items())),
+        skipped_by_type=dict(sorted(skipped_by_type.items())),
+    )
+
+
+def enqueue_ingest_source(
     database_path: Path,
     *,
-    storage_paths: StoragePaths,
-    url: str,
+    source: str,
     metadata: dict[str, Any] | None = None,
+    source_type: str | None = None,
     pdf_extractor: str | None = None,
-) -> Job:
-    """Enqueue one direct URL for safe background acquisition and ingestion."""
+) -> IngestEnqueueResult:
+    """Validate and enqueue one URL, local file, or local directory."""
 
-    del storage_paths
-    try:
-        submitted_url = validate_url_submission(url)
-    except AcquisitionError as exc:
-        raise IngestError(str(exc)) from exc
-    payload: dict[str, Any] = {
-        "url": submitted_url,
-        "metadata": dict(metadata or {}),
-        "source": "ingest-url",
-    }
-    if pdf_extractor is not None:
-        payload["pdf_extractor"] = normalize_pdf_extractor_mode(pdf_extractor)
-
-    return create_job(
-        database_path,
-        kind=INGEST_JOB_KIND,
-        payload=payload,
+    batch = prepare_ingest_source(
+        source=source,
+        metadata=metadata,
+        source_type=source_type,
+        pdf_extractor=pdf_extractor,
     )
+    return enqueue_prepared_ingest_batches(database_path, (batch,))
 
 
 def build_ingest_handler(
@@ -703,6 +854,7 @@ def build_ingest_handler(
     embedding_config: EmbeddingConfig,
     acquirer: SourceArtifactAcquirer | None = None,
     adapter: SourceAdapter | None = None,
+    adapter_registry: SourceAdapterRegistry | None = None,
     ocr_runner: OcrRunner | None = None,
     text_extractor: TextExtractor | None = None,
     chunker: Chunker | None = None,
@@ -717,6 +869,7 @@ def build_ingest_handler(
         embedding_config=embedding_config,
         acquirer=acquirer,
         adapter=adapter,
+        adapter_registry=adapter_registry,
         ocr_runner=ocr_runner,
         text_extractor=text_extractor,
         chunker=chunker,
@@ -868,25 +1021,77 @@ def list_chunk_vectors(
     return [dict(row) for row in rows if isinstance(row, dict)]
 
 
-def _iter_pdf_inputs(source_path: Path) -> tuple[Path, ...]:
-    submitted_path = Path(os.path.abspath(source_path.expanduser()))
-    if submitted_path.is_dir() and not submitted_path.is_symlink():
-        pdf_paths = tuple(
-            sorted(
-                Path(os.path.abspath(candidate))
-                for candidate in submitted_path.rglob("*")
-                if not candidate.is_symlink()
-                and candidate.is_file()
-                and candidate.suffix.lower() == ".pdf"
-            )
-        )
-        if pdf_paths:
-            return pdf_paths
-        raise IngestError(f"No PDF files found under {submitted_path}")
+def _scan_ingest_directory(
+    directory: Path,
+    *,
+    source_type: str | None,
+) -> tuple[tuple[Path, ...], dict[str, int], dict[str, int]]:
+    queued_paths: list[Path] = []
+    queued_by_type: Counter[str] = Counter()
+    skipped_by_type: Counter[str] = Counter()
 
-    if submitted_path.suffix.lower() != ".pdf":
-        raise IngestError(f"Input file is not a PDF: {submitted_path}")
-    return (submitted_path,)
+    def raise_scan_error(error: OSError) -> None:
+        raise IngestError(
+            f"Could not scan directory {directory} ({type(error).__name__})"
+        ) from error
+
+    for root, directory_names, filenames in os.walk(
+        directory,
+        topdown=True,
+        onerror=raise_scan_error,
+        followlinks=False,
+    ):
+        root_path = Path(root)
+        retained_directories: list[str] = []
+        for name in sorted(directory_names):
+            candidate = root_path / name
+            if candidate.is_symlink():
+                skipped_by_type["symlink"] += 1
+            else:
+                retained_directories.append(name)
+        directory_names[:] = retained_directories
+
+        for name in sorted(filenames):
+            candidate = root_path / name
+            if candidate.is_symlink():
+                skipped_by_type["symlink"] += 1
+                continue
+            if not candidate.is_file():
+                skipped_by_type["special"] += 1
+                continue
+            selected_type = source_type or _source_type_for_extension(candidate)
+            if selected_type is None:
+                skipped_by_type[_unsupported_extension_label(candidate)] += 1
+                continue
+            queued_paths.append(Path(os.path.abspath(candidate)))
+            queued_by_type[selected_type] += 1
+
+    return (
+        tuple(queued_paths),
+        dict(sorted(queued_by_type.items())),
+        dict(sorted(skipped_by_type.items())),
+    )
+
+
+def _source_type_for_extension(path: Path) -> str | None:
+    if path.suffix.lower() in _PDF_EXTENSIONS:
+        return SOURCE_TYPE_PDF
+    return None
+
+
+def _unsupported_extension_label(path: Path) -> str:
+    extension = path.suffix.lower().lstrip(".")
+    return extension or "no-extension"
+
+
+def _job_payload_identity(payload: dict[str, Any]) -> tuple[str, str]:
+    raw_url = payload.get("url")
+    if isinstance(raw_url, str) and raw_url.strip():
+        return "url", normalize_url_reference(raw_url)
+    raw_path = payload.get("path")
+    if isinstance(raw_path, str) and raw_path.strip():
+        return "path", str(Path(os.path.abspath(Path(raw_path).expanduser())))
+    raise IngestError("Ingest job payload is missing a valid URL or path")
 
 
 def _payload_acquisition_request(payload: dict[str, Any]) -> AcquisitionRequest:
@@ -899,6 +1104,22 @@ def _payload_acquisition_request(payload: dict[str, Any]) -> AcquisitionRequest:
     if isinstance(raw_path, str) and raw_path.strip():
         return AcquisitionRequest(kind="local_path", reference=raw_path)
     raise IngestError("Ingest job payload is missing a valid URL or path")
+
+
+def _payload_source_type_hint(payload: dict[str, Any]) -> str | None:
+    value = payload.get("source_type")
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise IngestError("Ingest job payload source_type must be a string")
+    return normalize_source_type_hint(value)
+
+
+def _source_filename(reference: str) -> str:
+    parsed = urlsplit(reference)
+    if parsed.scheme.lower() in {"http", "https"}:
+        return Path(parsed.path).name
+    return Path(reference).name
 
 
 def _safe_acquisition_reference(request: AcquisitionRequest) -> str:
@@ -1190,6 +1411,7 @@ def _publish_document_bundle(
     *,
     document_id: str,
     artifact_id: str,
+    media_type: str,
     source_path: Path,
     source_url: str | None,
     title: str,
@@ -1241,8 +1463,8 @@ def _publish_document_bundle(
             ),
         )
         connection.execute(
-            "UPDATE source_artifacts SET state = 'published' WHERE id = ?",
-            (artifact_id,),
+            "UPDATE source_artifacts SET state = 'published', media_type = ? WHERE id = ?",
+            (media_type, artifact_id),
         )
         connection.executemany(
             """

--- a/newsrag/ingestion_identity.py
+++ b/newsrag/ingestion_identity.py
@@ -92,6 +92,18 @@ def register_acquired_artifact(
 
         artifact_row = _artifact_row(connection, content_hash)
         if artifact_row is not None:
+            if (
+                artifact_row["document_id"] is None
+                and str(artifact_row["state"]) == ARTIFACT_STATE_PROCESSING
+                and str(artifact_row["media_type"]) != media_type
+            ):
+                connection.execute(
+                    "UPDATE source_artifacts SET media_type = ? WHERE id = ?",
+                    (media_type, str(artifact_row["artifact_id"])),
+                )
+                artifact_row = _artifact_row(connection, content_hash)
+                if artifact_row is None:
+                    raise RuntimeError("Updated source artifact could not be reloaded")
             decision = _decision_for_existing_artifact(connection, artifact_row)
             connection.commit()
             return decision
@@ -252,6 +264,7 @@ def _artifact_row(connection: sqlite3.Connection, content_hash: str) -> sqlite3.
             source_artifacts.stored_path,
             source_artifacts.acquired_at,
             source_artifacts.state,
+            source_artifacts.media_type,
             sources.kind AS source_kind,
             sources.submitted_reference,
             documents.id AS document_id

--- a/newsrag/jobs.py
+++ b/newsrag/jobs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -44,19 +45,48 @@ def create_job(
     """Insert a durable pending job into SQLite."""
 
     resolved_job_id = job_id or f"job-{uuid.uuid4().hex[:8]}"
-    payload_json = json.dumps(payload or {}, sort_keys=True)
+    return create_jobs(
+        database_path,
+        kind=kind,
+        payloads=(payload or {},),
+        job_ids=(resolved_job_id,),
+    )[0]
 
+
+def create_jobs(
+    database_path: Path,
+    *,
+    kind: str,
+    payloads: Sequence[dict[str, Any]],
+    job_ids: Sequence[str] | None = None,
+) -> list[Job]:
+    """Atomically insert a batch of durable pending jobs into SQLite."""
+
+    resolved_job_ids = (
+        tuple(job_ids)
+        if job_ids is not None
+        else tuple(f"job-{uuid.uuid4().hex[:8]}" for _ in payloads)
+    )
+    if len(resolved_job_ids) != len(payloads):
+        raise ValueError("job_ids must contain one ID for each payload")
+    if not payloads:
+        return []
+
+    rows = [
+        (job_id, kind, PENDING, json.dumps(payload, sort_keys=True))
+        for job_id, payload in zip(resolved_job_ids, payloads, strict=True)
+    ]
     with sqlite3.connect(database_path) as connection:
-        connection.execute(
+        connection.executemany(
             """
             INSERT INTO jobs(id, kind, status, payload_json, error)
             VALUES(?, ?, ?, ?, NULL)
             """,
-            (resolved_job_id, kind, PENDING, payload_json),
+            rows,
         )
         connection.commit()
 
-    return get_job(database_path, resolved_job_id)
+    return [get_job(database_path, job_id) for job_id in resolved_job_ids]
 
 
 def get_job(database_path: Path, job_id: str) -> Job:

--- a/newsrag/manifests.py
+++ b/newsrag/manifests.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import yaml
 
-from newsrag.ingest import IngestError
+from newsrag.acquisition import AcquisitionError, safe_url_reference, validate_url_submission
+from newsrag.ingest import IngestError, normalize_source_type_hint
+from newsrag.sources import normalize_url_reference
 
 ALLOWED_DOCUMENT_FIELDS = {
-    "url",
+    "source",
+    "type",
     "title",
     "meeting_date",
     "body",
@@ -22,7 +27,9 @@ ALLOWED_DOCUMENT_FIELDS = {
 class ManifestDocument:
     """One validated document entry from a YAML manifest."""
 
-    url: str
+    source: str
+    source_type: str | None
+    is_url: bool
     metadata: dict[str, str]
 
 
@@ -67,10 +74,17 @@ def load_manifest(path: Path) -> Manifest:
     if not raw_documents:
         raise ManifestError("Manifest field 'documents' must not be empty")
 
-    seen_urls: set[str] = set()
+    seen_sources: set[str] = set()
     documents: list[ManifestDocument] = []
     for index, raw_document in enumerate(raw_documents, start=1):
-        documents.append(_validate_document(raw_document, index=index, seen_urls=seen_urls))
+        documents.append(
+            _validate_document(
+                raw_document,
+                index=index,
+                manifest_directory=resolved_path.parent,
+                seen_sources=seen_sources,
+            )
+        )
 
     return Manifest(documents=tuple(documents))
 
@@ -79,7 +93,8 @@ def _validate_document(
     raw_document: object,
     *,
     index: int,
-    seen_urls: set[str],
+    manifest_directory: Path,
+    seen_sources: set[str],
 ) -> ManifestDocument:
     if not isinstance(raw_document, dict):
         raise ManifestError(f"Manifest document #{index} must be a mapping")
@@ -90,13 +105,27 @@ def _validate_document(
             f"Manifest document #{index} has unsupported fields: " + ", ".join(sorted(extra_fields))
         )
 
-    raw_url = raw_document.get("url")
-    if not isinstance(raw_url, str) or not raw_url.strip():
-        raise ManifestError(f"Manifest document #{index} is missing a non-empty 'url'")
-    url = raw_url.strip()
-    if url in seen_urls:
-        raise ManifestError(f"Manifest contains duplicate URL: {url}")
-    seen_urls.add(url)
+    raw_source = raw_document.get("source")
+    if not isinstance(raw_source, str) or not raw_source.strip():
+        raise ManifestError(f"Manifest document #{index} is missing a non-empty 'source'")
+    source = raw_source.strip()
+    is_url, identity = _manifest_source_identity(
+        source,
+        index=index,
+        manifest_directory=manifest_directory,
+    )
+    if identity in seen_sources:
+        display_source = safe_url_reference(source) if is_url else source
+        raise ManifestError(f"Manifest contains duplicate source: {display_source}")
+    seen_sources.add(identity)
+
+    raw_source_type = raw_document.get("type")
+    if raw_source_type is not None and not isinstance(raw_source_type, str):
+        raise ManifestError(f"Manifest document #{index} field 'type' must be a string")
+    try:
+        source_type = normalize_source_type_hint(raw_source_type)
+    except IngestError as exc:
+        raise ManifestError(f"Manifest document #{index}: {exc}") from exc
 
     metadata: dict[str, str] = {}
     for key in ("title", "body", "document_type", "jurisdiction"):
@@ -128,4 +157,41 @@ def _validate_document(
 
         metadata["meeting_date"] = normalized_meeting_date
 
-    return ManifestDocument(url=url, metadata=metadata)
+    return ManifestDocument(
+        source=source,
+        source_type=source_type,
+        is_url=is_url,
+        metadata=metadata,
+    )
+
+
+def _manifest_source_identity(
+    source: str,
+    *,
+    index: int,
+    manifest_directory: Path,
+) -> tuple[bool, str]:
+    try:
+        parsed = urlsplit(source)
+        _ = parsed.port
+    except ValueError as exc:
+        raise ManifestError(f"Manifest document #{index} has a malformed source URL") from exc
+
+    if parsed.scheme.lower() in {"http", "https"}:
+        try:
+            validate_url_submission(source)
+        except AcquisitionError as exc:
+            raise ManifestError(f"Manifest document #{index}: {exc}") from exc
+        if parsed.hostname is None:
+            raise ManifestError(f"Manifest document #{index} URL must include a host")
+        return True, f"url:{normalize_url_reference(source)}"
+
+    if parsed.scheme:
+        raise ManifestError(
+            f"Manifest document #{index} uses unsupported source scheme {parsed.scheme!r}"
+        )
+
+    local_path = Path(os.path.expanduser(source))
+    if not local_path.is_absolute():
+        local_path = manifest_directory / local_path
+    return False, f"path:{os.path.abspath(local_path)}"

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -6,7 +6,13 @@ from pathlib import Path
 
 import pytest
 
-from newsrag.adapters import AdapterError, AdapterInput
+from newsrag.adapters import (
+    AdapterError,
+    AdapterInput,
+    AdapterSelectionError,
+    RegisteredSourceAdapter,
+    SourceAdapterRegistry,
+)
 from newsrag.pdf_adapter import ExtractedPage, PdfSourceAdapter
 
 
@@ -93,6 +99,92 @@ def test_pdf_adapter_rejects_invalid_artifacts(
                 work_dir=tmp_path / "normalized",
                 options=_empty_options(),
             )
+        )
+
+
+def test_adapter_registry_uses_hint_media_signature_and_extension_without_extracting(
+    tmp_path: Path,
+) -> None:
+    artifact_path = tmp_path / "artifact"
+    artifact_path.write_bytes(b"%PDF-1.4\nmock")
+    adapter = PdfSourceAdapter(
+        ocr_runner=FakeOcrRunner(),
+        text_extractor=FakeTextExtractor(pages=()),
+    )
+    registration = RegisteredSourceAdapter(
+        source_type="pdf",
+        media_type="application/pdf",
+        extensions=(".pdf",),
+        signatures=(b"%PDF-",),
+        adapter=adapter,
+    )
+    registry = SourceAdapterRegistry((registration,))
+
+    assert (
+        registry.select(
+            artifact_path=artifact_path,
+            source_type_hint="pdf",
+            reported_media_type="text/plain",
+            filename="wrong.txt",
+        )
+        is registration
+    )
+    assert (
+        registry.select(
+            artifact_path=artifact_path,
+            source_type_hint=None,
+            reported_media_type="application/pdf",
+            filename="wrong.txt",
+        )
+        is registration
+    )
+    assert (
+        registry.select(
+            artifact_path=artifact_path,
+            source_type_hint=None,
+            reported_media_type=None,
+            filename="no-extension",
+        )
+        is registration
+    )
+
+    artifact_path.write_bytes(b"unknown")
+    assert (
+        registry.select(
+            artifact_path=artifact_path,
+            source_type_hint=None,
+            reported_media_type=None,
+            filename="packet.PDF",
+        )
+        is registration
+    )
+
+
+def test_adapter_registry_rejects_unsupported_evidence(tmp_path: Path) -> None:
+    artifact_path = tmp_path / "unknown.bin"
+    artifact_path.write_bytes(b"unknown")
+    adapter = PdfSourceAdapter(
+        ocr_runner=FakeOcrRunner(),
+        text_extractor=FakeTextExtractor(pages=()),
+    )
+    registry = SourceAdapterRegistry(
+        (
+            RegisteredSourceAdapter(
+                source_type="pdf",
+                media_type="application/pdf",
+                extensions=(".pdf",),
+                signatures=(b"%PDF-",),
+                adapter=adapter,
+            ),
+        )
+    )
+
+    with pytest.raises(AdapterSelectionError, match="provide --type"):
+        registry.select(
+            artifact_path=artifact_path,
+            source_type_hint=None,
+            reported_media_type="application/octet-stream",
+            filename=artifact_path.name,
         )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from click import unstyle
 from typer.testing import CliRunner
 
 from newsrag import __version__
@@ -41,9 +42,10 @@ def test_help_shows_cli_commands() -> None:
 def test_ingest_help_describes_unified_source_input() -> None:
     result = runner.invoke(app, ["ingest", "--help"])
 
+    output = unstyle(result.stdout)
     assert result.exit_code == 0
-    assert "URL, local file, or local directory" in result.stdout
-    assert "--type" in result.stdout
+    assert "URL, local file, or local directory" in output
+    assert "--type" in output
 
 
 def test_version_option_shows_project_version() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,7 @@ def test_help_shows_cli_commands() -> None:
     assert "status" in result.stdout
     assert "daemon" in result.stdout
     assert "ingest" in result.stdout
-    assert "ingest-url" in result.stdout
+    assert "ingest-url" not in result.stdout
     assert "ingest-manifest" in result.stdout
     assert "search" in result.stdout
     assert "jobs" in result.stdout
@@ -36,6 +36,14 @@ def test_help_shows_cli_commands() -> None:
     assert "entities" in result.stdout
     assert "timeline" in result.stdout
     assert "leads" in result.stdout
+
+
+def test_ingest_help_describes_unified_source_input() -> None:
+    result = runner.invoke(app, ["ingest", "--help"])
+
+    assert result.exit_code == 0
+    assert "URL, local file, or local directory" in result.stdout
+    assert "--type" in result.stdout
 
 
 def test_version_option_shows_project_version() -> None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -16,13 +17,29 @@ from newsrag.jobs import (
     RUNNING,
     Job,
     create_job,
+    create_jobs,
     get_job,
+    list_jobs,
     mark_job_done,
     set_job_status,
 )
 from newsrag.storage import initialize_storage
 
 runner = CliRunner()
+
+
+def test_create_jobs_rolls_back_the_entire_batch_on_failure(tmp_path: Path) -> None:
+    paths = initialize_storage(tmp_path / ".newsrag")
+
+    with pytest.raises(sqlite3.IntegrityError):
+        create_jobs(
+            paths.database,
+            kind="test",
+            payloads=({"index": 1}, {"index": 2}),
+            job_ids=("job-duplicate", "job-duplicate"),
+        )
+
+    assert list_jobs(paths.database) == []
 
 
 def test_daemon_run_command_starts_against_initialized_storage(tmp_path: Path) -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
 import sqlite3
 from collections.abc import Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
@@ -52,8 +53,7 @@ from newsrag.ingest import (
     PyMuPdfTextExtractor,
     build_ingest_handler,
     build_pdf_text_extractor,
-    enqueue_ingest_jobs,
-    enqueue_ingest_url_job,
+    enqueue_ingest_source,
     list_chunk_vectors,
     list_chunks,
     list_documents,
@@ -82,6 +82,11 @@ def test_ingest_command_enqueues_local_pdf_jobs(tmp_path: Path) -> None:
     (source_dir / "packet-b.PDF").write_bytes(b"%PDF-1.4\nB")
     (source_dir / "alias.pdf").symlink_to(source_dir / "packet-a.pdf")
     (source_dir / "notes.txt").write_text("ignore me", encoding="utf-8")
+    os.mkfifo(source_dir / "special.pdf")
+    external_dir = tmp_path / "external"
+    external_dir.mkdir()
+    (external_dir / "hidden.pdf").write_bytes(b"%PDF-1.4\nhidden")
+    (source_dir / "linked-directory").symlink_to(external_dir, target_is_directory=True)
 
     result = runner.invoke(
         app,
@@ -102,6 +107,8 @@ def test_ingest_command_enqueues_local_pdf_jobs(tmp_path: Path) -> None:
 
     assert result.exit_code == 0, result.stdout
     assert "Enqueued 2 ingest job(s)" in result.stdout
+    assert "Queued by type: pdf=2" in result.stdout
+    assert "Skipped by type: special=1, symlink=2, txt=1" in result.stdout
     assert len(jobs) == 2
     assert all(job.kind == INGEST_JOB_KIND for job in jobs)
     assert jobs[0].payload["metadata"]["body"] == "City Council"
@@ -134,7 +141,72 @@ def test_ingest_command_records_pdf_extractor_mode(tmp_path: Path) -> None:
     assert jobs[0].payload["pdf_extractor"] == PDF_EXTRACTOR_TABLE
 
 
-def test_ingest_url_command_enqueues_background_acquisition(tmp_path: Path) -> None:
+def test_source_type_hint_selects_pdf_without_bypassing_validation(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    source_file = tmp_path / "not-a-pdf.bin"
+    source_file.write_bytes(b"plain text")
+
+    result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "ingest", str(source_file), "--type", "pdf"],
+    )
+    paths = initialize_storage(data_dir)
+    jobs = list_jobs(paths.database)
+    assert result.exit_code == 0, result.stdout
+    assert jobs[0].payload["source_type"] == "pdf"
+
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        ocr_runner=FakeOcrRunner(),
+        text_extractor=FakeTextExtractor(pages=[]),
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+    asyncio.run(
+        DaemonRunner(
+            database_path=paths.database,
+            handlers={INGEST_JOB_KIND: handler},
+            poll_interval=0,
+        ).run_cycle()
+    )
+
+    updated_job = get_job(paths.database, jobs[0].id)
+    assert updated_job.status == FAILED
+    assert "invalid signature" in (updated_job.error or "")
+
+
+def test_ingest_rejects_unsupported_source_type_hint_before_enqueue(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    source_file = tmp_path / "packet.pdf"
+    source_file.write_bytes(b"%PDF-1.4\nmock")
+
+    result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "ingest", str(source_file), "--type", "html"],
+    )
+
+    paths = initialize_storage(data_dir)
+    assert result.exit_code == 1
+    assert "Unsupported source type 'html'" in result.stdout
+    assert list_jobs(paths.database) == []
+
+
+def test_ingest_rejects_unsupported_source_scheme_before_enqueue(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+
+    result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "ingest", "ftp://example.gov/packet.pdf"],
+    )
+
+    paths = initialize_storage(data_dir)
+    assert result.exit_code == 1
+    assert "Unsupported source scheme 'ftp'" in result.stdout
+    assert list_jobs(paths.database) == []
+
+
+def test_ingest_command_enqueues_url_for_background_acquisition(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
     url = "https://example.gov/packet.pdf?token=secret"
 
@@ -143,7 +215,7 @@ def test_ingest_url_command_enqueues_background_acquisition(tmp_path: Path) -> N
         [
             "--data-dir",
             str(data_dir),
-            "ingest-url",
+            "ingest",
             url,
             "--body",
             "City Council",
@@ -178,7 +250,7 @@ def test_ingest_url_rejects_credentials_without_persisting_or_displaying_them(
         [
             "--data-dir",
             str(data_dir),
-            "ingest-url",
+            "ingest",
             "https://user:secret@example.gov/packet.pdf",
         ],
     )
@@ -190,12 +262,12 @@ def test_ingest_url_rejects_credentials_without_persisting_or_displaying_them(
     assert list_jobs(paths.database) == []
 
 
-def test_enqueue_ingest_url_job_does_not_fetch_before_daemon_processing(tmp_path: Path) -> None:
+def test_enqueue_ingest_url_does_not_fetch_before_daemon_processing(tmp_path: Path) -> None:
     paths = initialize_storage(tmp_path / ".newsrag")
     url = "https://example.gov/packet.pdf"
 
-    first_job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
-    second_job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
+    first_job = enqueue_ingest_source(paths.database, source=url).jobs[0]
+    second_job = enqueue_ingest_source(paths.database, source=url).jobs[0]
 
     assert first_job.payload["url"] == url
     assert second_job.payload["url"] == url
@@ -213,7 +285,7 @@ def test_url_ingest_stores_source_url_and_acquisition_provenance(tmp_path: Path)
         resolved_url_by_url={url: resolved_url},
     )
 
-    enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
+    enqueue_ingest_source(paths.database, source=url)
 
     handler = build_ingest_handler(
         data_dir=data_dir,
@@ -264,14 +336,14 @@ def test_url_ingest_stores_source_url_and_acquisition_provenance(tmp_path: Path)
 def test_safe_url_acquisition_runs_inside_daemon(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
     paths = initialize_storage(data_dir)
-    url = "https://example.gov/packet.pdf"
+    url = "https://example.gov/download"
     response = PipelineHttpResponse(
         status_code=200,
         headers={"content-type": "application/pdf"},
         chunks=(b"%PDF-1.4\nbackground",),
     )
     transport = PipelineHttpTransport(response=response)
-    job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
+    job = enqueue_ingest_source(paths.database, source=url).jobs[0]
     handler = build_ingest_handler(
         data_dir=data_dir,
         embedding_config=EmbeddingConfig(),
@@ -304,7 +376,7 @@ def test_ingest_url_reports_non_pdf_validation_failure_from_background_job(
     data_dir = tmp_path / ".newsrag"
     paths = initialize_storage(data_dir)
     url = "https://example.gov/not-a-pdf"
-    job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
+    job = enqueue_ingest_source(paths.database, source=url).jobs[0]
     handler = build_ingest_handler(
         data_dir=data_dir,
         embedding_config=EmbeddingConfig(),
@@ -328,11 +400,28 @@ def test_ingest_url_reports_non_pdf_validation_failure_from_background_job(
 
     updated_job = get_job(paths.database, job.id)
     assert updated_job.status == FAILED
-    assert "invalid signature" in (updated_job.error or "")
+    assert "Unsupported source type" in (updated_job.error or "")
     with sqlite3.connect(paths.database) as connection:
         assert connection.execute("SELECT COUNT(*) FROM sources").fetchone() == (1,)
         assert connection.execute("SELECT COUNT(*) FROM source_artifacts").fetchone() == (1,)
         assert connection.execute("SELECT COUNT(*) FROM documents").fetchone() == (0,)
+        assert connection.execute("SELECT media_type FROM source_artifacts").fetchone() == (
+            "application/octet-stream",
+        )
+
+    hinted_job = enqueue_ingest_source(paths.database, source=url, source_type="pdf").jobs[0]
+    asyncio.run(
+        DaemonRunner(
+            database_path=paths.database,
+            handlers={INGEST_JOB_KIND: handler},
+            poll_interval=0,
+        ).run_cycle()
+    )
+    assert get_job(paths.database, hinted_job.id).status == FAILED
+    with sqlite3.connect(paths.database) as connection:
+        assert connection.execute("SELECT media_type FROM source_artifacts").fetchone() == (
+            "application/pdf",
+        )
 
 
 def test_ingest_manifest_enqueues_one_job_per_document(tmp_path: Path) -> None:
@@ -341,12 +430,12 @@ def test_ingest_manifest_enqueues_one_job_per_document(tmp_path: Path) -> None:
     manifest_path.write_text(
         """
         documents:
-          - url: https://example.gov/packet-1.pdf
+          - source: https://example.gov/packet-1.pdf
             title: Packet One
             meeting_date: 2026-05-01
             body: City Council
             document_type: agenda_packet
-          - url: https://example.gov/packet-2.pdf
+          - source: https://example.gov/packet-2.pdf
             jurisdiction: Example City
         """.strip(),
         encoding="utf-8",
@@ -373,13 +462,93 @@ def test_ingest_manifest_enqueues_one_job_per_document(tmp_path: Path) -> None:
     assert list(paths.source_artifacts.iterdir()) == []
 
 
-def test_invalid_manifest_missing_url_fails_without_enqueuing(tmp_path: Path) -> None:
+def test_manifest_accepts_url_and_relative_local_path_with_type_hint(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    manifest_dir = tmp_path / "manifest"
+    manifest_dir.mkdir()
+    local_pdf = manifest_dir / "packet.pdf"
+    local_pdf.write_bytes(b"%PDF-1.4\nlocal")
+    manifest_path = manifest_dir / "sources.yaml"
+    manifest_path.write_text(
+        """
+        documents:
+          - source: https://example.gov/remote.pdf
+            type: pdf
+          - source: ./packet.pdf
+            type: pdf
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app, ["--data-dir", str(data_dir), "ingest-manifest", str(manifest_path)]
+    )
+
+    paths = initialize_storage(data_dir)
+    jobs = list_jobs(paths.database)
+    assert result.exit_code == 0, result.stdout
+    assert "Queued by type: pdf=2" in result.stdout
+    assert len(jobs) == 2
+    payloads_by_reference = {
+        str(job.payload.get("url") or job.payload.get("path")): job.payload for job in jobs
+    }
+    assert "https://example.gov/remote.pdf" in payloads_by_reference
+    assert str(local_pdf) in payloads_by_reference
+    assert all(job.payload["source_type"] == "pdf" for job in jobs)
+
+
+def test_manifest_validation_is_atomic_for_unsupported_type(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
     manifest_path = tmp_path / "sources.yaml"
     manifest_path.write_text(
         """
         documents:
-          - title: Missing URL
+          - source: https://example.gov/packet.pdf
+          - source: https://example.gov/page.html
+            type: html
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app, ["--data-dir", str(data_dir), "ingest-manifest", str(manifest_path)]
+    )
+
+    paths = initialize_storage(data_dir)
+    assert result.exit_code == 1
+    assert "Unsupported source type 'html'" in result.stdout
+    assert list_jobs(paths.database) == []
+
+
+def test_manifest_missing_local_path_fails_before_any_jobs_are_created(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    manifest_path = tmp_path / "sources.yaml"
+    manifest_path.write_text(
+        """
+        documents:
+          - source: https://example.gov/packet.pdf
+          - source: ./missing.pdf
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app, ["--data-dir", str(data_dir), "ingest-manifest", str(manifest_path)]
+    )
+
+    paths = initialize_storage(data_dir)
+    assert result.exit_code == 1
+    assert "Local source path does not exist" in result.stdout
+    assert list_jobs(paths.database) == []
+
+
+def test_invalid_manifest_missing_source_fails_without_enqueuing(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    manifest_path = tmp_path / "sources.yaml"
+    manifest_path.write_text(
+        """
+        documents:
+          - title: Missing Source
         """.strip(),
         encoding="utf-8",
     )
@@ -390,7 +559,7 @@ def test_invalid_manifest_missing_url_fails_without_enqueuing(tmp_path: Path) ->
     paths = initialize_storage(data_dir)
 
     assert result.exit_code == 1
-    assert "missing a non-empty 'url'" in result.stdout
+    assert "missing a non-empty 'source'" in result.stdout
     assert list_jobs(paths.database) == []
 
 
@@ -400,7 +569,7 @@ def test_invalid_manifest_invalid_meeting_date_fails_without_enqueuing(tmp_path:
     manifest_path.write_text(
         """
         documents:
-          - url: https://example.gov/packet.pdf
+          - source: https://example.gov/packet.pdf
             meeting_date: 05-01-2026
         """.strip(),
         encoding="utf-8",
@@ -416,14 +585,14 @@ def test_invalid_manifest_invalid_meeting_date_fails_without_enqueuing(tmp_path:
     assert list_jobs(paths.database) == []
 
 
-def test_invalid_manifest_duplicate_urls_fail_without_partial_work(tmp_path: Path) -> None:
+def test_invalid_manifest_duplicate_sources_fail_without_partial_work(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
     manifest_path = tmp_path / "sources.yaml"
     manifest_path.write_text(
         """
         documents:
-          - url: https://example.gov/packet.pdf
-          - url: https://example.gov/packet.pdf
+          - source: https://example.gov/packet.pdf?token=secret
+          - source: https://example.gov/packet.pdf?token=secret
         """.strip(),
         encoding="utf-8",
     )
@@ -434,7 +603,8 @@ def test_invalid_manifest_duplicate_urls_fail_without_partial_work(tmp_path: Pat
     paths = initialize_storage(data_dir)
 
     assert result.exit_code == 1
-    assert "duplicate URL" in result.stdout
+    assert "duplicate source" in result.stdout
+    assert "token=secret" not in result.stdout
     assert list_jobs(paths.database) == []
 
 
@@ -443,7 +613,7 @@ def test_invalid_manifest_unsupported_fields_fail(tmp_path: Path) -> None:
     manifest_path.write_text(
         """
         documents:
-          - url: https://example.gov/packet.pdf
+          - source: https://example.gov/packet.pdf
             committee: Finance
         """.strip(),
         encoding="utf-8",
@@ -459,7 +629,7 @@ def test_manifest_metadata_is_preserved_on_created_documents(tmp_path: Path) -> 
     manifest_path.write_text(
         """
         documents:
-          - url: https://example.gov/packet.pdf
+          - source: https://example.gov/packet.pdf
             title: Manifest Packet
             meeting_date: 2026-05-01
             body: City Council
@@ -511,7 +681,7 @@ def test_ingest_url_acquisition_failures_are_recorded_by_background_job(
     data_dir = tmp_path / ".newsrag"
     paths = initialize_storage(data_dir)
     url = "https://example.gov/packet.pdf"
-    job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=url)
+    job = enqueue_ingest_source(paths.database, source=url).jobs[0]
     handler = build_ingest_handler(
         data_dir=data_dir,
         embedding_config=EmbeddingConfig(),
@@ -784,7 +954,7 @@ def test_explicit_symlink_is_acquired_in_background_with_both_paths(
     submitted_path = tmp_path / "submitted.pdf"
     submitted_path.symlink_to(target_path)
     paths = initialize_storage(data_dir)
-    jobs = enqueue_ingest_jobs(paths.database, source_path=submitted_path)
+    jobs = list(enqueue_ingest_source(paths.database, source=str(submitted_path)).jobs)
     handler = build_ingest_handler(
         data_dir=data_dir,
         embedding_config=EmbeddingConfig(),
@@ -1025,7 +1195,7 @@ def test_same_bytes_from_different_urls_ignore_the_second_source(tmp_path: Path)
     second_url = "https://two.example.gov/renamed.pdf"
     content = b"%PDF-1.4\nidentical-url"
     acquirer = FakeUrlAcquirer(content_by_url={first_url: content, second_url: content})
-    first_job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=first_url)
+    first_job = enqueue_ingest_source(paths.database, source=first_url).jobs[0]
     adapter = FakeSourceAdapter()
     handler = build_ingest_handler(
         data_dir=data_dir,
@@ -1042,7 +1212,7 @@ def test_same_bytes_from_different_urls_ignore_the_second_source(tmp_path: Path)
     )
 
     asyncio.run(runner_instance.run_cycle())
-    second_job = enqueue_ingest_url_job(paths.database, storage_paths=paths, url=second_url)
+    second_job = enqueue_ingest_source(paths.database, source=second_url).jobs[0]
     asyncio.run(runner_instance.run_cycle())
 
     with sqlite3.connect(paths.database) as connection:
@@ -1333,7 +1503,7 @@ def test_missing_local_source_failure_is_recorded_by_background_job(
     data_dir = tmp_path / ".newsrag"
     paths = initialize_storage(data_dir)
     missing_path = tmp_path / "missing.pdf"
-    jobs = enqueue_ingest_jobs(paths.database, source_path=missing_path)
+    jobs = list(enqueue_ingest_source(paths.database, source=str(missing_path)).jobs)
     handler = build_ingest_handler(
         data_dir=data_dir,
         embedding_config=EmbeddingConfig(),


### PR DESCRIPTION
## Summary

Expose URL, file, directory, and manifest ingestion through one source-neutral command and adapter-selection path.

## Task

Todu `task-fbf94b96`

## Changes

- make `newsrag ingest <source>` accept HTTP(S) URLs, local files, and recursive local directories
- remove the URL-specific ingestion command and report queued/skipped directory inputs by type
- add source-adapter registration and selection using hints, media types, signatures, and extensions while preserving adapter validation
- change manifests to `source` plus optional `type`, resolve relative paths from the manifest directory, fully validate before enqueue, and insert job batches atomically
- preserve existing PDF processing, acquisition, metadata, duplicate behavior, watches, and page citations
- update architecture and ingestion documentation for the unified interface

## Testing

- [x] Unit tests added/updated
- [x] Manual dev-environment testing: restarted `make dev`, ingested a mixed local directory through the real daemon as `job-05fa46d0`, verified grouped skips and a searchable cited document, then ingested a live public PDF URL through the same command as `job-3f3f3cde` and verified `outcome=created`

## Checklist

- [x] `./scripts/pre-pr.sh` passes with all 217 tests
- [x] Documentation updated
- [x] No unrelated changes included
