### PR TITLE
Connect static HTML ingestion end to end

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,9 +74,9 @@ When a known source returns different bytes, NewsRAG preserves the new artifact 
 
 Raw bytes are retained as immutable, content-addressed source artifacts. Acquisition runs in the daemon before format extraction. One acquisition accepts either an explicitly submitted local regular file or a public HTTP(S) URL, stages bytes while hashing, applies the duplicate decision, and durably promotes bytes that must be retained before invoking an adapter.
 
-Remote acquisition resolves and pins a validated public address for each request, revalidates every redirect destination, follows at most five redirects, and applies a 30-second request timeout. URL credentials, localhost, non-public addresses, unsafe redirects, ambient proxy or cookie state, and unsupported content encodings are rejected. HTTP bodies are streamed with separate 250 MiB compressed and decompressed limits. Only the submitted resource and required HTTP redirects are fetched; linked and embedded resources are not retrieved.
+Remote acquisition resolves and pins a validated public address for each request, revalidates every redirect destination, follows at most five redirects, and applies a 30-second request timeout. URL credentials, localhost, non-public addresses, unsafe redirects, ambient proxy or cookie state, and unsupported content encodings are rejected. HTTP bodies are streamed with separate 250 MiB compressed and decompressed limits, reduced to 10 MiB when an HTML hint, extension, or response media type identifies static HTML. Only the submitted resource and required HTTP redirects are fetched; linked and embedded resources are not retrieved.
 
-Local acquisition has a 250 MiB limit and accepts only regular files. An explicitly submitted symlink is allowed only when its resolved regular-file target remains stable. Directory scans skip symlinks. Device/inode, size, modification time, resolved target, and bytes read are checked around the read so missing, special, changed, or oversized inputs fail without preserving a partial artifact.
+Local acquisition has a 250 MiB limit, reduced to 10 MiB for recognized HTML input, and accepts only regular files. An explicitly submitted symlink is allowed only when its resolved regular-file target remains stable. Directory scans skip symlinks. Device/inode, size, modification time, resolved target, and bytes read are checked around the read so missing, special, changed, or oversized inputs fail without preserving a partial artifact.
 
 Acquisition provenance stores submitted and resolved references, redirects, retrieval or file-read timestamps, reported media type, exact byte size and SHA-256, and the durable artifact path. Diagnostics use stage-specific errors and omit URL credentials, query data, response bodies, and ambient secrets.
 
@@ -84,26 +84,27 @@ Each PDF is normalized through OCR, then text is extracted from the normalized P
 
 ## Source adapter contract
 
-A format adapter receives an `AdapterInput` identifying one immutable raw artifact, its validated media type and content hash, an isolated work directory, and format-specific options. Its `extract` method must validate the artifact and return an `AdapterResult` containing ordered `CanonicalSourceUnit` values, extractor identity, validated media type, and any derived artifact used for extraction. The adapter registry selects a supported adapter from an optional `--type` hint, reported media type, conservative content signature, and filename extension, in that order. A hint selects an adapter but never bypasses that adapter's validation. PDF is the only currently registered source type.
+A format adapter receives an `AdapterInput` identifying one immutable raw artifact, its validated media type and content hash, an isolated work directory, and format-specific options. Its `extract` method must validate the artifact and return an `AdapterResult` containing ordered `CanonicalSourceUnit` values, extractor identity, validated media type, metadata candidates, and any derived artifact used for extraction. The adapter registry selects a supported adapter from an optional `--type` hint, reported media type, conservative content signature, and filename extension, in that order. A hint selects an adapter but never bypasses that adapter's validation. PDF and static HTML are currently registered.
 
 Each canonical source unit has a contiguous one-based ordinal, typed machine location, human-readable location label, normalized text, structure metadata, and extractor name/version. Adapters do not chunk, embed, index, publish documents, or modify source identity. Those stages belong to the shared ingestion pipeline.
 
 PDF is the first implementation of this contract. The PDF adapter validates the raw PDF, runs the existing OCR and extraction fallback behavior, and emits one page source unit per PDF page. The shared pipeline then performs page-compatible chunking, passage generation, embeddings, FTS/vector indexing, and publication. SQLite publication is transactional; failed vector publication rolls back the document bundle and removes staged vectors so incomplete documents cannot appear in search.
 
-The standalone static HTML adapter accepts `text/html` and `application/xhtml+xml` artifacts with conservative document signatures and a restricted encoding set. It parses with network access, entity resolution, recovery, and oversized parser trees disabled; it never executes JavaScript or retrieves linked resources. The adapter selects one unambiguous `article`, then one `main` or `role=main`, then the document body, and emits deterministic `html_block` units for retained headings, paragraphs, list items, quotations, preformatted text, captions, and table rows. Units carry block numbers, heading paths, element kinds, normalized text, and `static-html` extractor identity. Safe title, language, author, and publication-time values are returned only as metadata candidates. The independent adapter is not registered with ingestion until the static HTML end-to-end task adds non-page chunking and publication support.
+The static HTML adapter accepts `text/html` and `application/xhtml+xml` artifacts with conservative document signatures and a restricted encoding set. It parses with network access, entity resolution, recovery, and oversized parser trees disabled; it never executes JavaScript or retrieves linked resources. The adapter selects one unambiguous `article`, then one `main` or `role=main`, then the document body, and emits deterministic `html_block` units for retained headings, paragraphs, list items, quotations, preformatted text, captions, and table rows. Units carry block numbers, heading paths, element kinds, normalized text, and `static-html` extractor identity. Safe title, language, author, and publication-time metadata candidates fill missing user metadata. HTML files and public URLs use the same background acquisition, exact-byte identity, chunking, embedding, indexing, and atomic publication path as PDFs.
 
 Static HTML extraction fails rather than truncating when input exceeds 10 MiB, the parsed tree exceeds 100,000 elements or 256 levels, or retained text exceeds 10 MiB. It also rejects unsupported or conflicting encodings, unsafe external declarations, malformed input, ambiguous content roots, and empty evidentiary output.
 
 ## Chunking and citations
 
-The MVP uses page-first chunking. Each page is stored as canonical extracted text. Short pages may produce one chunk; long pages are split into overlapping passages while preserving page start/end. This keeps citations simple and reliable for city hall PDFs, where page numbers are often the most important reference.
+PDF uses page-first chunking. Each page is stored as canonical extracted text. Short pages may produce one chunk; long pages are split into overlapping passages while preserving page start/end. HTML uses block-first chunking, keeping each source unit tied to its stable block ordinal and heading path. Shared chunks and passages retain authoritative source-unit start/end IDs for either format.
 
-The data model should allow structure-aware chunking later without changing the retrieval contract. Optional chunk metadata can include section title, heading path, agenda item, table marker, and bounding box.
+The data model allows further structure-aware chunking without changing the retrieval contract. Optional chunk metadata can include section title, heading path, agenda item, table marker, and bounding box.
 
 Terminal citations use a concise format:
 
 ```text
 City Council Packet — 2026-04-12 — p. 27
+Council Update — Budget — block 12
 ```
 
 Markdown packet/source-list citations can include richer context:

--- a/newsrag/acquisition.py
+++ b/newsrag/acquisition.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Literal, Protocol
 from urllib.parse import SplitResult, urljoin, urlsplit, urlunsplit
 
-from newsrag.sources import normalize_url_reference
+from newsrag.sources import HTML_MAX_SOURCE_BYTES, HTML_MEDIA_TYPES, normalize_url_reference
 
 SOURCE_KIND_LOCAL_PATH: Literal["local_path"] = "local_path"
 SOURCE_KIND_URL: Literal["url"] = "url"
@@ -59,6 +59,8 @@ class AcquisitionRequest:
 
     kind: SourceKind
     reference: str
+    max_bytes: int | None = None
+    apply_reported_media_limit: bool = True
 
 
 @dataclass(frozen=True)
@@ -262,14 +264,27 @@ class SafeSourceArtifactAcquirer:
     def acquire(self, request: AcquisitionRequest, staging_dir: Path) -> StagedSourceArtifact:
         """Acquire one source into a staged exact-byte artifact."""
 
+        if request.max_bytes is not None and request.max_bytes < 1:
+            raise AcquisitionError("validation", "Source byte limit must be positive")
         if request.kind == SOURCE_KIND_LOCAL_PATH:
-            return self._acquire_local(request.reference, staging_dir)
+            return self._acquire_local(request, staging_dir)
         if request.kind == SOURCE_KIND_URL:
-            return self._acquire_url(request.reference, staging_dir)
+            return self._acquire_url(request, staging_dir)
         raise AcquisitionError("validation", f"Unsupported source kind: {request.kind}")
 
-    def _acquire_local(self, reference: str, staging_dir: Path) -> StagedSourceArtifact:
-        submitted_path = _absolute_path(reference)
+    def _acquire_local(
+        self,
+        request: AcquisitionRequest,
+        staging_dir: Path,
+    ) -> StagedSourceArtifact:
+        submitted_path = _absolute_path(request.reference)
+        reported_media_type, _ = mimetypes.guess_type(submitted_path.name)
+        max_local_bytes = _effective_source_limit(
+            self.limits.max_local_bytes,
+            request.max_bytes,
+            reported_media_type,
+            apply_reported_media_limit=request.apply_reported_media_limit,
+        )
         try:
             supplied_state = os.lstat(submitted_path)
             resolved_path = submitted_path.resolve(strict=True)
@@ -285,10 +300,10 @@ class SafeSourceArtifactAcquirer:
                 "local_validation",
                 f"Local source is not a regular file: {submitted_path}",
             )
-        if target_state.size > self.limits.max_local_bytes:
+        if target_state.size > max_local_bytes:
             raise AcquisitionError(
                 "local_size_limit",
-                f"Local source exceeds {self.limits.max_local_bytes} bytes: {submitted_path}",
+                f"Local source exceeds {max_local_bytes} bytes: {submitted_path}",
             )
 
         staged_path = _new_staging_path(staging_dir)
@@ -319,11 +334,10 @@ class SafeSourceArtifactAcquirer:
                         if not chunk:
                             break
                         byte_size += len(chunk)
-                        if byte_size > self.limits.max_local_bytes:
+                        if byte_size > max_local_bytes:
                             raise AcquisitionError(
                                 "local_size_limit",
-                                f"Local source exceeds {self.limits.max_local_bytes} bytes: "
-                                f"{submitted_path}",
+                                f"Local source exceeds {max_local_bytes} bytes: {submitted_path}",
                             )
                         output.write(chunk)
                         digest.update(chunk)
@@ -358,7 +372,6 @@ class SafeSourceArtifactAcquirer:
             ) from exc
 
         acquired_at = _current_timestamp()
-        reported_media_type, _ = mimetypes.guess_type(submitted_path.name)
         return StagedSourceArtifact(
             source_kind=SOURCE_KIND_LOCAL_PATH,
             submitted_reference=str(submitted_path),
@@ -378,8 +391,12 @@ class SafeSourceArtifactAcquirer:
             },
         )
 
-    def _acquire_url(self, reference: str, staging_dir: Path) -> StagedSourceArtifact:
-        submitted_url = reference.strip()
+    def _acquire_url(
+        self,
+        request: AcquisitionRequest,
+        staging_dir: Path,
+    ) -> StagedSourceArtifact:
+        submitted_url = request.reference.strip()
         current_url = _without_fragment(submitted_url)
         redirects: list[str] = []
 
@@ -437,11 +454,29 @@ class SafeSourceArtifactAcquirer:
                         f"HTTP status {response.status_code} for {safe_reference}",
                     )
 
+                reported_media_type = _reported_media_type(response.headers)
+                max_compressed_bytes = _effective_source_limit(
+                    self.limits.max_compressed_bytes,
+                    request.max_bytes,
+                    reported_media_type,
+                    apply_reported_media_limit=request.apply_reported_media_limit,
+                )
+                max_decompressed_bytes = _effective_source_limit(
+                    self.limits.max_decompressed_bytes,
+                    request.max_bytes,
+                    reported_media_type,
+                    apply_reported_media_limit=request.apply_reported_media_limit,
+                )
                 staged_path, content_hash, byte_size, compressed_byte_size = (
-                    self._stage_response_body(response, staging_dir, safe_reference)
+                    self._stage_response_body(
+                        response,
+                        staging_dir,
+                        safe_reference,
+                        max_compressed_bytes=max_compressed_bytes,
+                        max_decompressed_bytes=max_decompressed_bytes,
+                    )
                 )
                 acquired_at = _current_timestamp()
-                reported_media_type = _reported_media_type(response.headers)
                 return StagedSourceArtifact(
                     source_kind=SOURCE_KIND_URL,
                     submitted_reference=submitted_url,
@@ -470,13 +505,15 @@ class SafeSourceArtifactAcquirer:
         response: HttpResponseStream,
         staging_dir: Path,
         safe_reference: str,
+        *,
+        max_compressed_bytes: int,
+        max_decompressed_bytes: int,
     ) -> tuple[Path, str, int, int]:
         content_length = _content_length(response.headers)
-        if content_length is not None and content_length > self.limits.max_compressed_bytes:
+        if content_length is not None and content_length > max_compressed_bytes:
             raise AcquisitionError(
                 "remote_compressed_size_limit",
-                f"Response exceeds {self.limits.max_compressed_bytes} compressed bytes for "
-                f"{safe_reference}",
+                f"Response exceeds {max_compressed_bytes} compressed bytes for {safe_reference}",
             )
 
         encoding = _content_encoding(response.headers)
@@ -494,40 +531,40 @@ class SafeSourceArtifactAcquirer:
             with staged_path.open("wb") as output:
                 for chunk in response.iter_raw():
                     compressed_byte_size += len(chunk)
-                    if compressed_byte_size > self.limits.max_compressed_bytes:
+                    if compressed_byte_size > max_compressed_bytes:
                         raise AcquisitionError(
                             "remote_compressed_size_limit",
-                            f"Response exceeds {self.limits.max_compressed_bytes} compressed "
-                            f"bytes for {safe_reference}",
+                            f"Response exceeds {max_compressed_bytes} compressed bytes for "
+                            f"{safe_reference}",
                         )
                     decoded = _decode_chunk(
                         decompressor,
                         chunk,
-                        remaining=self.limits.max_decompressed_bytes - byte_size,
+                        remaining=max_decompressed_bytes - byte_size,
                         safe_reference=safe_reference,
-                        limit=self.limits.max_decompressed_bytes,
+                        limit=max_decompressed_bytes,
                     )
                     byte_size = _write_decoded_chunk(
                         output,
                         digest,
                         decoded,
                         byte_size=byte_size,
-                        limit=self.limits.max_decompressed_bytes,
+                        limit=max_decompressed_bytes,
                         safe_reference=safe_reference,
                     )
                 if decompressor is not None:
                     decoded = _flush_decoder(
                         decompressor,
-                        remaining=self.limits.max_decompressed_bytes - byte_size,
+                        remaining=max_decompressed_bytes - byte_size,
                         safe_reference=safe_reference,
-                        limit=self.limits.max_decompressed_bytes,
+                        limit=max_decompressed_bytes,
                     )
                     byte_size = _write_decoded_chunk(
                         output,
                         digest,
                         decoded,
                         byte_size=byte_size,
-                        limit=self.limits.max_decompressed_bytes,
+                        limit=max_decompressed_bytes,
                         safe_reference=safe_reference,
                     )
                 if content_length is not None and compressed_byte_size != content_length:
@@ -832,6 +869,22 @@ def _content_length(headers: Mapping[str, str]) -> int | None:
     if value < 0:
         raise AcquisitionError("remote_headers", "Content-Length is invalid")
     return value
+
+
+def _effective_source_limit(
+    configured_limit: int,
+    requested_limit: int | None,
+    reported_media_type: str | None,
+    *,
+    apply_reported_media_limit: bool,
+) -> int:
+    limits = [configured_limit]
+    if requested_limit is not None:
+        limits.append(requested_limit)
+    normalized_media_type = (reported_media_type or "").partition(";")[0].strip().lower()
+    if apply_reported_media_limit and normalized_media_type in HTML_MEDIA_TYPES:
+        limits.append(HTML_MAX_SOURCE_BYTES)
+    return min(limits)
 
 
 def _reported_media_type(headers: Mapping[str, str]) -> str | None:

--- a/newsrag/adapters.py
+++ b/newsrag/adapters.py
@@ -77,6 +77,13 @@ class RegisteredSourceAdapter:
     extensions: tuple[str, ...]
     signatures: tuple[bytes, ...]
     adapter: SourceAdapter
+    media_type_aliases: tuple[str, ...] = ()
+
+    @property
+    def accepted_media_types(self) -> tuple[str, ...]:
+        """Return canonical and alias media types accepted for selection."""
+
+        return (self.media_type, *self.media_type_aliases)
 
 
 class SourceAdapterRegistry:
@@ -120,7 +127,7 @@ class SourceAdapterRegistry:
         media_matches = tuple(
             registration
             for registration in self._registrations
-            if normalized_media_type == registration.media_type
+            if normalized_media_type in registration.accepted_media_types
         )
         selected = _one_adapter_match(media_matches, evidence="reported media type")
         if selected is not None:
@@ -136,7 +143,7 @@ class SourceAdapterRegistry:
         )
         try:
             with artifact_path.open("rb") as artifact_file:
-                header = artifact_file.read(maximum_signature_bytes)
+                header = artifact_file.read(maximum_signature_bytes + 256)
         except OSError as exc:
             raise AdapterSelectionError(
                 f"Could not inspect acquired artifact ({type(exc).__name__})"
@@ -144,7 +151,7 @@ class SourceAdapterRegistry:
         signature_matches = tuple(
             registration
             for registration in self._registrations
-            if any(header.startswith(signature) for signature in registration.signatures)
+            if any(_matches_signature(header, signature) for signature in registration.signatures)
         )
         selected = _one_adapter_match(signature_matches, evidence="content signature")
         if selected is not None:
@@ -163,6 +170,10 @@ class SourceAdapterRegistry:
         raise AdapterSelectionError(
             "Unsupported source type; provide --type with one of: " + ", ".join(self.source_types)
         )
+
+
+def _matches_signature(header: bytes, signature: bytes) -> bool:
+    return header.startswith(signature) or header.lstrip().lower().startswith(signature.lower())
 
 
 def _one_adapter_match(

--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -286,7 +286,7 @@ def ingest_command(
     source_type: str | None = typer.Option(
         None,
         "--type",
-        help="Explicit source type hint; currently supported: pdf.",
+        help="Explicit source type hint; currently supported: html, pdf.",
     ),
     pdf_extractor: str = PDF_EXTRACTOR_OPTION,
 ) -> None:

--- a/newsrag/html_adapter.py
+++ b/newsrag/html_adapter.py
@@ -16,9 +16,9 @@ from newsrag.adapters import (
     CanonicalSourceUnit,
     ExtractorIdentity,
 )
-from newsrag.sources import HTML_BLOCK_LOCATION_TYPE, HTML_MEDIA_TYPES
+from newsrag.sources import HTML_BLOCK_LOCATION_TYPE, HTML_MAX_SOURCE_BYTES, HTML_MEDIA_TYPES
 
-MAX_HTML_BYTES = 10 * 1024 * 1024
+MAX_HTML_BYTES = HTML_MAX_SOURCE_BYTES
 MAX_HTML_ELEMENTS = 100_000
 MAX_HTML_NESTING_DEPTH = 256
 MAX_EXTRACTED_TEXT_CHARS = 10 * 1024 * 1024

--- a/newsrag/ingest.py
+++ b/newsrag/ingest.py
@@ -45,6 +45,7 @@ from newsrag.embeddings import (
     EmbeddingProvider,
     build_embedding_provider,
 )
+from newsrag.html_adapter import StaticHtmlSourceAdapter
 from newsrag.ingestion_identity import (
     OUTCOME_CREATED,
     OUTCOME_DUPLICATE_IGNORED,
@@ -78,6 +79,8 @@ from newsrag.pdf_adapter import (
 )
 from newsrag.search import LanceDbPassageVectorStore, PassageVectorRecord
 from newsrag.sources import (
+    HTML_MAX_SOURCE_BYTES,
+    HTML_MEDIA_TYPES,
     PAGE_LOCATION_TYPE,
     PDF_MEDIA_TYPE,
     artifact_id_for_hash,
@@ -109,9 +112,12 @@ DEFAULT_CHUNK_MAX_CHARS = 2000
 DEFAULT_CHUNK_OVERLAP_CHARS = 200
 VECTOR_TABLE_NAME = "chunk_embeddings"
 SOURCE_TYPE_PDF = "pdf"
-SUPPORTED_SOURCE_TYPES = frozenset({SOURCE_TYPE_PDF})
+SOURCE_TYPE_HTML = "html"
+SUPPORTED_SOURCE_TYPES = frozenset({SOURCE_TYPE_HTML, SOURCE_TYPE_PDF})
 _PDF_EXTENSIONS = (".pdf",)
 _PDF_SIGNATURES = (b"%PDF-",)
+_HTML_EXTENSIONS = (".html", ".htm", ".xhtml")
+_HTML_SIGNATURES = (b"<!doctype html", b"<html", b"<?xml")
 _UNKNOWN_MEDIA_TYPE = "application/octet-stream"
 LOGGER = logging.getLogger(__name__)
 
@@ -315,6 +321,45 @@ class PageChunker:
 
 
 @dataclass(frozen=True)
+class SourceUnitChunker:
+    """Chunk page units compatibly and non-page units by stable source ordinal."""
+
+    page_chunker: PageChunker = PageChunker()
+    max_chars: int = DEFAULT_CHUNK_MAX_CHARS
+    overlap_chars: int = DEFAULT_CHUNK_OVERLAP_CHARS
+
+    def chunk_units(self, units: Sequence[CanonicalSourceUnit]) -> list[ChunkDraft]:
+        if all(unit.location_type == PAGE_LOCATION_TYPE for unit in units):
+            return self.page_chunker.chunk_units(units)
+        if any(unit.location_type == PAGE_LOCATION_TYPE for unit in units):
+            raise IngestError("Cannot chunk mixed page and non-page source units")
+
+        chunks: list[ChunkDraft] = []
+        for unit in units:
+            text = unit.normalized_text.strip()
+            if not text:
+                continue
+            start = 0
+            while start < len(text):
+                end = min(start + self.max_chars, len(text))
+                chunk_text = text[start:end].strip()
+                if chunk_text:
+                    chunks.append(
+                        ChunkDraft(
+                            text=chunk_text,
+                            page_start=unit.ordinal,
+                            page_end=unit.ordinal,
+                            source_unit_start_ordinal=unit.ordinal,
+                            source_unit_end_ordinal=unit.ordinal,
+                        )
+                    )
+                if end >= len(text):
+                    break
+                start = max(0, end - self.overlap_chars)
+        return chunks
+
+
+@dataclass(frozen=True)
 class LanceDbVectorStore:
     """Vector persistence backed by LanceDB."""
 
@@ -434,8 +479,10 @@ class SourceProcessingPipeline:
 
         document_id = f"document-{uuid.uuid4().hex[:8]}"
         artifact_id = artifact_id_for_hash(artifact.content_hash)
+        resolved_metadata = dict(adapter_result.metadata_candidates)
+        resolved_metadata.update(artifact.metadata)
         document_metadata = _build_document_metadata(
-            artifact.metadata,
+            resolved_metadata,
             artifact.source_path,
             artifact.artifact_path,
         )
@@ -473,7 +520,7 @@ class SourceProcessingPipeline:
                 media_type=adapter_result.media_type,
                 source_path=artifact.source_path,
                 source_url=artifact.source_url,
-                title=_resolve_document_title(artifact.metadata, artifact.source_path),
+                title=_resolve_document_title(resolved_metadata, artifact.source_path),
                 source_hash=artifact.content_hash,
                 normalized_path=adapter_result.derived_artifact_path,
                 metadata=document_metadata,
@@ -522,7 +569,7 @@ class SourceProcessingPipeline:
 
 
 class IngestionPipeline:
-    """Current PDF job front end for the shared source-processing pipeline."""
+    """Job front end for the shared source-processing pipeline."""
 
     def __init__(
         self,
@@ -554,12 +601,20 @@ class IngestionPipeline:
                     signatures=_PDF_SIGNATURES,
                     adapter=resolved_adapter,
                 ),
+                RegisteredSourceAdapter(
+                    source_type=SOURCE_TYPE_HTML,
+                    media_type=HTML_MEDIA_TYPES[0],
+                    media_type_aliases=HTML_MEDIA_TYPES[1:],
+                    extensions=_HTML_EXTENSIONS,
+                    signatures=_HTML_SIGNATURES,
+                    adapter=StaticHtmlSourceAdapter(),
+                ),
             )
         )
         self.processor = SourceProcessingPipeline(
             storage_paths=storage_paths,
             adapter=resolved_adapter,
-            chunker=chunker or PageChunker(),
+            chunker=chunker or SourceUnitChunker(),
             embedding_provider=embedding_provider or build_embedding_provider(embedding_config),
             vector_store=vector_store or LanceDbVectorStore(storage_paths.lancedb),
             passage_vector_store=passage_vector_store
@@ -665,7 +720,10 @@ class IngestionPipeline:
                         source_path=decision.document_source_path,
                         artifact_path=decision.artifact_path,
                         content_hash=staged_artifact.content_hash,
-                        media_type=selected_adapter.media_type,
+                        media_type=_adapter_input_media_type(
+                            selected_adapter,
+                            staged_artifact.reported_media_type,
+                        ),
                         source_url=decision.document_source_url,
                         acquired_at=decision.acquired_at,
                         work_dir=self.storage_paths.ocr_pdfs,
@@ -862,7 +920,7 @@ def build_ingest_handler(
     vector_store: VectorStore | None = None,
     passage_vector_store: PassageVectorStore | None = None,
 ) -> Callable[[Job], Awaitable[dict[str, object]]]:
-    """Build an async handler for safely acquired PDF ingest jobs."""
+    """Build an async handler for safely acquired source-ingest jobs."""
 
     pipeline = IngestionPipeline(
         storage_paths=initialize_storage(data_dir),
@@ -1074,8 +1132,11 @@ def _scan_ingest_directory(
 
 
 def _source_type_for_extension(path: Path) -> str | None:
-    if path.suffix.lower() in _PDF_EXTENSIONS:
+    extension = path.suffix.lower()
+    if extension in _PDF_EXTENSIONS:
         return SOURCE_TYPE_PDF
+    if extension in _HTML_EXTENSIONS:
+        return SOURCE_TYPE_HTML
     return None
 
 
@@ -1100,9 +1161,20 @@ def _payload_acquisition_request(payload: dict[str, Any]) -> AcquisitionRequest:
     if isinstance(raw_url, str) and raw_url.strip():
         if isinstance(raw_path, str) and raw_path.strip():
             raise IngestError("Ingest job payload cannot contain both a URL and path")
-        return AcquisitionRequest(kind=SOURCE_KIND_URL, reference=raw_url.strip())
+        reference = raw_url.strip()
+        return AcquisitionRequest(
+            kind=SOURCE_KIND_URL,
+            reference=reference,
+            max_bytes=_payload_source_max_bytes(payload, Path(urlsplit(reference).path)),
+            apply_reported_media_limit=_payload_source_type_hint(payload) is None,
+        )
     if isinstance(raw_path, str) and raw_path.strip():
-        return AcquisitionRequest(kind="local_path", reference=raw_path)
+        return AcquisitionRequest(
+            kind="local_path",
+            reference=raw_path,
+            max_bytes=_payload_source_max_bytes(payload, Path(raw_path)),
+            apply_reported_media_limit=_payload_source_type_hint(payload) is None,
+        )
     raise IngestError("Ingest job payload is missing a valid URL or path")
 
 
@@ -1113,6 +1185,21 @@ def _payload_source_type_hint(payload: dict[str, Any]) -> str | None:
     if not isinstance(value, str):
         raise IngestError("Ingest job payload source_type must be a string")
     return normalize_source_type_hint(value)
+
+
+def _payload_source_max_bytes(payload: dict[str, Any], path: Path) -> int | None:
+    source_type = _payload_source_type_hint(payload) or _source_type_for_extension(path)
+    return HTML_MAX_SOURCE_BYTES if source_type == SOURCE_TYPE_HTML else None
+
+
+def _adapter_input_media_type(
+    registration: RegisteredSourceAdapter,
+    reported_media_type: str | None,
+) -> str:
+    normalized_reported_type = (reported_media_type or "").partition(";")[0].strip().lower()
+    if normalized_reported_type in registration.accepted_media_types:
+        return str(reported_media_type)
+    return registration.media_type
 
 
 def _source_filename(reference: str) -> str:

--- a/newsrag/search.py
+++ b/newsrag/search.py
@@ -19,6 +19,7 @@ from newsrag.embeddings import (
     build_embedding_provider,
     create_embedding_record,
 )
+from newsrag.sources import HTML_BLOCK_LOCATION_TYPE
 
 DEFAULT_SEARCH_LIMIT = 5
 DEFAULT_SEARCH_CANDIDATE_LIMIT = 20
@@ -137,6 +138,12 @@ class SearchResult:
     source_path: str | None = None
     source_unit_start_id: str | None = None
     source_unit_end_id: str | None = None
+
+
+@dataclass(frozen=True)
+class _HtmlCitationDetails:
+    heading_path: tuple[str, ...]
+    location_label: str
 
 
 class Reranker(Protocol):
@@ -442,9 +449,14 @@ def merge_search_candidates(
         }
     )
 
+    source_citations = _load_html_citation_details(
+        database_path,
+        tuple(passage_context.values()),
+    )
     merged: dict[str, SearchResult] = {}
     for passage_id in sorted(set(passage_context)):
         context = passage_context[passage_id]
+        source_citation = source_citations.get(passage_id)
         score = keyword_weight * keyword_normalized.get(
             passage_id, 0.0
         ) + vector_weight * vector_normalized.get(passage_id, 0.0)
@@ -458,6 +470,10 @@ def merge_search_candidates(
                 title=context.title,
                 meeting_date=context.meeting_date,
                 page_number=context.page_start,
+                heading_path=(source_citation.heading_path if source_citation is not None else ()),
+                location_label=(
+                    source_citation.location_label if source_citation is not None else None
+                ),
             ),
             score=score,
             keyword_score=context.keyword_score,
@@ -479,16 +495,114 @@ def merge_search_candidates(
     )[:limit]
 
 
-def format_citation(*, title: str | None, meeting_date: str | None, page_number: int) -> str:
-    """Format one concise terminal citation."""
+def format_citation(
+    *,
+    title: str | None,
+    meeting_date: str | None,
+    page_number: int,
+    heading_path: Sequence[str] = (),
+    location_label: str | None = None,
+) -> str:
+    """Format one concise page or structured-source terminal citation."""
 
     parts = []
-    if title:
-        parts.append(title)
-    if meeting_date:
-        parts.append(meeting_date)
-    parts.append(f"p. {page_number}")
+    resolved_title = _optional_string(title)
+    if resolved_title is not None:
+        parts.append(resolved_title)
+    resolved_meeting_date = _optional_string(meeting_date)
+    if resolved_meeting_date is not None:
+        parts.append(resolved_meeting_date)
+    for index, heading in enumerate(heading_path):
+        resolved_heading = _optional_string(heading)
+        if resolved_heading is None:
+            continue
+        if (
+            index == 0
+            and resolved_title is not None
+            and resolved_heading.casefold() == resolved_title.casefold()
+        ):
+            continue
+        parts.append(resolved_heading)
+    parts.append(location_label or f"p. {page_number}")
     return " — ".join(parts)
+
+
+def _load_html_citation_details(
+    database_path: Path,
+    candidates: Sequence[SearchCandidate],
+) -> dict[str, _HtmlCitationDetails]:
+    source_unit_ids = {
+        source_unit_id
+        for candidate in candidates
+        for source_unit_id in (
+            candidate.source_unit_start_id,
+            candidate.source_unit_end_id,
+        )
+        if source_unit_id is not None
+    }
+    if not source_unit_ids:
+        return {}
+
+    placeholders = ", ".join("?" for _ in source_unit_ids)
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(
+            f"""
+            SELECT id, location_type, location_json, structure_json
+            FROM source_units
+            WHERE id IN ({placeholders})
+            """,
+            tuple(sorted(source_unit_ids)),
+        ).fetchall()
+    units = {str(row["id"]): row for row in rows}
+
+    citations: dict[str, _HtmlCitationDetails] = {}
+    for candidate in candidates:
+        if candidate.source_unit_start_id is None:
+            continue
+        start_unit = units.get(candidate.source_unit_start_id)
+        end_unit = units.get(candidate.source_unit_end_id or candidate.source_unit_start_id)
+        if start_unit is None or end_unit is None:
+            continue
+        if (
+            str(start_unit["location_type"]) != HTML_BLOCK_LOCATION_TYPE
+            or str(end_unit["location_type"]) != HTML_BLOCK_LOCATION_TYPE
+        ):
+            continue
+        start_location = _load_metadata(start_unit["location_json"])
+        end_location = _load_metadata(end_unit["location_json"])
+        start_block = start_location.get("block_number")
+        end_block = end_location.get("block_number")
+        if (
+            isinstance(start_block, bool)
+            or not isinstance(start_block, int)
+            or isinstance(end_block, bool)
+            or not isinstance(end_block, int)
+            or start_block < 1
+            or end_block < start_block
+        ):
+            continue
+        structure = _load_metadata(start_unit["structure_json"])
+        raw_heading_path = structure.get("heading_path")
+        heading_path = (
+            tuple(
+                heading.strip()
+                for heading in raw_heading_path
+                if isinstance(heading, str) and heading.strip()
+            )
+            if isinstance(raw_heading_path, list)
+            else ()
+        )
+        location_label = (
+            f"block {start_block}"
+            if start_block == end_block
+            else f"blocks {start_block}–{end_block}"
+        )
+        citations[candidate.passage_id] = _HtmlCitationDetails(
+            heading_path=heading_path,
+            location_label=location_label,
+        )
+    return citations
 
 
 def format_search_results(

--- a/newsrag/sources.py
+++ b/newsrag/sources.py
@@ -10,6 +10,7 @@ SOURCE_KIND_LOCAL_PATH = "local_path"
 SOURCE_KIND_URL = "url"
 PDF_MEDIA_TYPE = "application/pdf"
 HTML_MEDIA_TYPES = ("text/html", "application/xhtml+xml")
+HTML_MAX_SOURCE_BYTES = 10 * 1024 * 1024
 PAGE_LOCATION_TYPE = "page"
 HTML_BLOCK_LOCATION_TYPE = "html_block"
 

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -19,6 +19,7 @@ from newsrag.acquisition import (
     SafeSourceArtifactAcquirer,
     preserve_staged_artifact,
 )
+from newsrag.sources import HTML_MAX_SOURCE_BYTES
 
 PUBLIC_IP = "93.184.216.34"
 
@@ -31,6 +32,41 @@ def test_default_acquisition_limits_match_approved_policy() -> None:
     assert limits.max_decompressed_bytes == 250 * 1024 * 1024
     assert limits.max_redirects == 5
     assert limits.timeout_seconds == 30.0
+
+
+def test_html_acquisition_applies_ten_mib_limit_to_local_and_remote_sources(
+    tmp_path: Path,
+) -> None:
+    assert HTML_MAX_SOURCE_BYTES == 10 * 1024 * 1024
+    local_html = tmp_path / "oversized.html"
+    with local_html.open("wb") as file_handle:
+        file_handle.truncate(HTML_MAX_SOURCE_BYTES + 1)
+
+    acquirer = SafeSourceArtifactAcquirer()
+    with pytest.raises(AcquisitionError, match="local_size_limit"):
+        acquirer.acquire(
+            AcquisitionRequest(kind=SOURCE_KIND_LOCAL_PATH, reference=str(local_html)),
+            tmp_path / "local-staging",
+        )
+
+    url = "https://example.gov/oversized"
+    response = FakeHttpResponse(
+        status_code=200,
+        headers={
+            "content-type": "text/html",
+            "content-length": str(HTML_MAX_SOURCE_BYTES + 1),
+        },
+    )
+    remote_acquirer = SafeSourceArtifactAcquirer(
+        resolver=RecordingResolver(addresses={"example.gov": (PUBLIC_IP,)}),
+        transport=FakeHttpTransport(responses={url: [response]}),
+    )
+    with pytest.raises(AcquisitionError, match="remote_compressed_size_limit"):
+        remote_acquirer.acquire(
+            AcquisitionRequest(kind=SOURCE_KIND_URL, reference=url),
+            tmp_path / "remote-staging",
+        )
+    assert response.closed is True
 
 
 def test_local_acquisition_stages_exact_bytes_and_provenance(tmp_path: Path) -> None:

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -117,6 +117,7 @@ def test_adapter_registry_uses_hint_media_signature_and_extension_without_extrac
         extensions=(".pdf",),
         signatures=(b"%PDF-",),
         adapter=adapter,
+        media_type_aliases=("application/x-pdf",),
     )
     registry = SourceAdapterRegistry((registration,))
 
@@ -134,6 +135,15 @@ def test_adapter_registry_uses_hint_media_signature_and_extension_without_extrac
             artifact_path=artifact_path,
             source_type_hint=None,
             reported_media_type="application/pdf",
+            filename="wrong.txt",
+        )
+        is registration
+    )
+    assert (
+        registry.select(
+            artifact_path=artifact_path,
+            source_type_hint=None,
+            reported_media_type="application/x-pdf",
             filename="wrong.txt",
         )
         is registration

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,7 @@ def test_ingest_help_describes_unified_source_input() -> None:
     assert result.exit_code == 0
     assert "URL, local file, or local directory" in output
     assert "--type" in output
+    assert "html, pdf" in output
 
 
 def test_version_option_shows_project_version() -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -68,18 +68,23 @@ from newsrag.jobs import (
     set_job_status,
 )
 from newsrag.manifests import ManifestError, load_manifest
+from newsrag.search import SearchResult, merge_search_candidates, search_keyword_candidates
 from newsrag.sources import normalize_url_reference
 from newsrag.storage import initialize_storage
 
 runner = CliRunner()
 
 
-def test_ingest_command_enqueues_local_pdf_jobs(tmp_path: Path) -> None:
+def test_ingest_command_enqueues_supported_local_source_jobs(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
-    source_dir = tmp_path / "pdfs"
+    source_dir = tmp_path / "sources"
     source_dir.mkdir()
     (source_dir / "packet-a.pdf").write_bytes(b"%PDF-1.4\nA")
     (source_dir / "packet-b.PDF").write_bytes(b"%PDF-1.4\nB")
+    (source_dir / "notice.html").write_text(
+        "<!doctype html><html><body><p>Notice</p></body></html>",
+        encoding="utf-8",
+    )
     (source_dir / "alias.pdf").symlink_to(source_dir / "packet-a.pdf")
     (source_dir / "notes.txt").write_text("ignore me", encoding="utf-8")
     os.mkfifo(source_dir / "special.pdf")
@@ -106,14 +111,13 @@ def test_ingest_command_enqueues_local_pdf_jobs(tmp_path: Path) -> None:
     jobs = list_jobs(paths.database)
 
     assert result.exit_code == 0, result.stdout
-    assert "Enqueued 2 ingest job(s)" in result.stdout
-    assert "Queued by type: pdf=2" in result.stdout
+    assert "Enqueued 3 ingest job(s)" in result.stdout
+    assert "Queued by type: html=1, pdf=2" in result.stdout
     assert "Skipped by type: special=1, symlink=2, txt=1" in result.stdout
-    assert len(jobs) == 2
+    assert len(jobs) == 3
     assert all(job.kind == INGEST_JOB_KIND for job in jobs)
-    assert jobs[0].payload["metadata"]["body"] == "City Council"
-    assert jobs[0].payload["metadata"]["document_type"] == "agenda_packet"
-    assert jobs[1].payload["metadata"]["body"] == "City Council"
+    assert all(job.payload["metadata"]["body"] == "City Council" for job in jobs)
+    assert all(job.payload["metadata"]["document_type"] == "agenda_packet" for job in jobs)
 
 
 def test_ingest_command_records_pdf_extractor_mode(tmp_path: Path) -> None:
@@ -183,12 +187,12 @@ def test_ingest_rejects_unsupported_source_type_hint_before_enqueue(tmp_path: Pa
 
     result = runner.invoke(
         app,
-        ["--data-dir", str(data_dir), "ingest", str(source_file), "--type", "html"],
+        ["--data-dir", str(data_dir), "ingest", str(source_file), "--type", "docx"],
     )
 
     paths = initialize_storage(data_dir)
     assert result.exit_code == 1
-    assert "Unsupported source type 'html'" in result.stdout
+    assert "Unsupported source type 'docx'" in result.stdout
     assert list_jobs(paths.database) == []
 
 
@@ -370,7 +374,131 @@ def test_safe_url_acquisition_runs_inside_daemon(tmp_path: Path) -> None:
     assert len(list(paths.source_artifacts.iterdir())) == 1
 
 
-def test_ingest_url_reports_non_pdf_validation_failure_from_background_job(
+def test_local_html_ingests_and_searches_with_block_citation(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    source_path = tmp_path / "river-notice.html"
+    content = (
+        b'<!doctype html><html lang="en"><head><title>River Notice</title>'
+        b'<meta name="author" content="City Clerk"></head><body><article>'
+        b"<h1>River Notice</h1><h2>Stormwater</h2>"
+        b"<p>Downtown stormwater construction begins Monday near the public library.</p>"
+        b"</article></body></html>"
+    )
+    source_path.write_bytes(content)
+
+    cli_result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "ingest", str(source_path)],
+    )
+    paths = initialize_storage(data_dir)
+    jobs = list_jobs(paths.database)
+    assert cli_result.exit_code == 0, cli_result.stdout
+    assert "Queued by type: html=1" in cli_result.stdout
+
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        ocr_runner=FakeOcrRunner(),
+        text_extractor=FakeTextExtractor(pages=[]),
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+    asyncio.run(
+        DaemonRunner(
+            database_path=paths.database,
+            handlers={INGEST_JOB_KIND: handler},
+            poll_interval=0,
+        ).run_cycle()
+    )
+
+    assert get_job(paths.database, jobs[0].id).status == "done"
+    documents = list_documents(paths.database)
+    assert len(documents) == 1
+    assert documents[0].title == "River Notice"
+    assert documents[0].metadata["language"] == "en"
+    assert documents[0].metadata["author"] == "City Clerk"
+    assert list_pages(paths.database) == []
+    assert [chunk.page_start for chunk in list_chunks(paths.database)] == [1, 2, 3]
+    with sqlite3.connect(paths.database) as connection:
+        connection.row_factory = sqlite3.Row
+        artifact = connection.execute("SELECT * FROM source_artifacts").fetchone()
+        units = connection.execute(
+            "SELECT location_type, location_json, structure_json FROM source_units ORDER BY ordinal"
+        ).fetchall()
+    assert artifact is not None
+    assert artifact["media_type"] == "text/html"
+    assert Path(artifact["stored_path"]).read_bytes() == content
+    assert [unit["location_type"] for unit in units] == ["html_block"] * 3
+
+    results = _keyword_search_results(paths.database, "construction")
+    assert len(results) == 1
+    assert results[0].citation == "River Notice — Stormwater — block 3"
+    assert results[0].source_path == str(source_path)
+    assert results[0].source_unit_start_id == results[0].source_unit_end_id
+
+
+def test_public_html_url_ingests_and_searches_with_provenance(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    paths = initialize_storage(data_dir)
+    url = "https://example.gov/notices/current"
+    content = (
+        b"<!doctype html><html><head><title>Housing Notice</title></head>"
+        b"<body><main><h1>Housing Notice</h1><h2>Public Hearing</h2>"
+        b"<p>The housing hearing accepts public comment through Friday afternoon.</p>"
+        b"</main></body></html>"
+    )
+    response = PipelineHttpResponse(
+        status_code=200,
+        headers={"content-type": "text/html", "content-length": str(len(content))},
+        chunks=(content,),
+    )
+    transport = PipelineHttpTransport(response=response)
+
+    cli_result = runner.invoke(app, ["--data-dir", str(data_dir), "ingest", url])
+    jobs = list_jobs(paths.database)
+    assert cli_result.exit_code == 0, cli_result.stdout
+    handler = build_ingest_handler(
+        data_dir=data_dir,
+        embedding_config=EmbeddingConfig(),
+        acquirer=SafeSourceArtifactAcquirer(
+            resolver=PublicResolver(),
+            transport=transport,
+        ),
+        ocr_runner=FakeOcrRunner(),
+        text_extractor=FakeTextExtractor(pages=[]),
+        embedding_provider=FakeEmbeddingProvider(),
+        vector_store=LanceDbVectorStore(paths.lancedb),
+    )
+    asyncio.run(
+        DaemonRunner(
+            database_path=paths.database,
+            handlers={INGEST_JOB_KIND: handler},
+            poll_interval=0,
+        ).run_cycle()
+    )
+
+    assert get_job(paths.database, jobs[0].id).status == "done"
+    assert transport.requests == [(url, "93.184.216.34")]
+    assert transport.timeouts == [30.0]
+    documents = list_documents(paths.database)
+    assert documents[0].source_url == url
+    assert documents[0].title == "Housing Notice"
+    with sqlite3.connect(paths.database) as connection:
+        connection.row_factory = sqlite3.Row
+        artifact = connection.execute("SELECT * FROM source_artifacts").fetchone()
+    assert artifact is not None
+    assert artifact["reported_media_type"] == "text/html"
+    assert Path(artifact["stored_path"]).read_bytes() == content
+    provenance = json.loads(artifact["provenance_json"])
+    assert provenance["submitted_url"] == url
+    assert provenance["resolved_url"] == url
+
+    results = _keyword_search_results(paths.database, "Friday")
+    assert results[0].citation == "Housing Notice — Public Hearing — block 3"
+    assert results[0].source_url == url
+
+
+def test_ingest_url_reports_html_validation_failure_from_background_job(
     tmp_path: Path,
 ) -> None:
     data_dir = tmp_path / ".newsrag"
@@ -400,14 +528,18 @@ def test_ingest_url_reports_non_pdf_validation_failure_from_background_job(
 
     updated_job = get_job(paths.database, job.id)
     assert updated_job.status == FAILED
-    assert "Unsupported source type" in (updated_job.error or "")
+    assert "no evidentiary content" in (updated_job.error or "")
     with sqlite3.connect(paths.database) as connection:
         assert connection.execute("SELECT COUNT(*) FROM sources").fetchone() == (1,)
         assert connection.execute("SELECT COUNT(*) FROM source_artifacts").fetchone() == (1,)
         assert connection.execute("SELECT COUNT(*) FROM documents").fetchone() == (0,)
+        assert connection.execute("SELECT COUNT(*) FROM source_units").fetchone() == (0,)
+        assert connection.execute("SELECT COUNT(*) FROM chunks").fetchone() == (0,)
+        assert connection.execute("SELECT COUNT(*) FROM passages").fetchone() == (0,)
         assert connection.execute("SELECT media_type FROM source_artifacts").fetchone() == (
-            "application/octet-stream",
+            "text/html",
         )
+    assert list_chunk_vectors(paths.lancedb) == []
 
     hinted_job = enqueue_ingest_source(paths.database, source=url, source_type="pdf").jobs[0]
     asyncio.run(
@@ -466,16 +598,19 @@ def test_manifest_accepts_url_and_relative_local_path_with_type_hint(tmp_path: P
     data_dir = tmp_path / ".newsrag"
     manifest_dir = tmp_path / "manifest"
     manifest_dir.mkdir()
-    local_pdf = manifest_dir / "packet.pdf"
-    local_pdf.write_bytes(b"%PDF-1.4\nlocal")
+    local_html = manifest_dir / "notice.html"
+    local_html.write_text(
+        "<!doctype html><html><body><p>Local notice</p></body></html>",
+        encoding="utf-8",
+    )
     manifest_path = manifest_dir / "sources.yaml"
     manifest_path.write_text(
         """
         documents:
-          - source: https://example.gov/remote.pdf
-            type: pdf
-          - source: ./packet.pdf
-            type: pdf
+          - source: https://example.gov/remote.html
+            type: html
+          - source: ./notice.html
+            type: html
         """.strip(),
         encoding="utf-8",
     )
@@ -487,14 +622,14 @@ def test_manifest_accepts_url_and_relative_local_path_with_type_hint(tmp_path: P
     paths = initialize_storage(data_dir)
     jobs = list_jobs(paths.database)
     assert result.exit_code == 0, result.stdout
-    assert "Queued by type: pdf=2" in result.stdout
+    assert "Queued by type: html=2" in result.stdout
     assert len(jobs) == 2
     payloads_by_reference = {
         str(job.payload.get("url") or job.payload.get("path")): job.payload for job in jobs
     }
-    assert "https://example.gov/remote.pdf" in payloads_by_reference
-    assert str(local_pdf) in payloads_by_reference
-    assert all(job.payload["source_type"] == "pdf" for job in jobs)
+    assert "https://example.gov/remote.html" in payloads_by_reference
+    assert str(local_html) in payloads_by_reference
+    assert all(job.payload["source_type"] == "html" for job in jobs)
 
 
 def test_manifest_validation_is_atomic_for_unsupported_type(tmp_path: Path) -> None:
@@ -505,7 +640,7 @@ def test_manifest_validation_is_atomic_for_unsupported_type(tmp_path: Path) -> N
         documents:
           - source: https://example.gov/packet.pdf
           - source: https://example.gov/page.html
-            type: html
+            type: docx
         """.strip(),
         encoding="utf-8",
     )
@@ -516,7 +651,7 @@ def test_manifest_validation_is_atomic_for_unsupported_type(tmp_path: Path) -> N
 
     paths = initialize_storage(data_dir)
     assert result.exit_code == 1
-    assert "Unsupported source type 'html'" in result.stdout
+    assert "Unsupported source type 'docx'" in result.stdout
     assert list_jobs(paths.database) == []
 
 
@@ -1566,6 +1701,18 @@ def test_ingest_failures_are_recorded_with_context(tmp_path: Path) -> None:
     assert list_chunk_vectors(paths.lancedb) == []
 
 
+def _keyword_search_results(database_path: Path, query: str) -> list[SearchResult]:
+    candidates = search_keyword_candidates(database_path, query, limit=10)
+    return merge_search_candidates(
+        candidates,
+        (),
+        database_path=database_path,
+        limit=10,
+        keyword_weight=1.0,
+        vector_weight=0.0,
+    )
+
+
 @dataclass
 class FakeSourceAdapter:
     inputs: list[AdapterInput] = field(default_factory=list)
@@ -1728,6 +1875,7 @@ class PipelineHttpResponse:
 class PipelineHttpTransport:
     response: PipelineHttpResponse
     requests: list[tuple[str, str]] = field(default_factory=list)
+    timeouts: list[float] = field(default_factory=list)
 
     def get(
         self,
@@ -1736,8 +1884,8 @@ class PipelineHttpTransport:
         connect_ip: str,
         timeout_seconds: float,
     ) -> HttpResponseStream:
-        del timeout_seconds
         self.requests.append((url, connect_ip))
+        self.timeouts.append(timeout_seconds)
         return self.response
 
 


### PR DESCRIPTION
## Summary

Connect the static HTML adapter to durable acquisition, indexing, and search while preserving PDF behavior.

## Task

Todu `task-f32c1b04`

## Changes

- register static HTML for HTML/XHTML media types, conservative signatures, `.html`/`.htm`/`.xhtml` extensions, and `--type html`
- recognize HTML in direct, directory, and manifest ingestion
- enforce the 10 MiB HTML limit during local or HTTP acquisition when identified by hint, extension, or response media type
- retain existing five-redirect, 30-second timeout, public-network-only, provenance, and exact-byte artifact behavior
- add source-unit chunking for non-page formats while delegating PDFs unchanged to page-first chunking
- merge adapter metadata candidates without overriding user metadata
- resolve persisted HTML source-unit structures into heading/block search citations while preserving PDF page citations
- keep discovery, inventory formatting, and packet output unchanged

## Testing

- [x] Deterministic local-file and mocked-public-URL end-to-end tests cover CLI enqueue, daemon acquisition, provenance, extraction, source units, chunks, indexes, publication, and search
- [x] Directory and manifest recognition, HTML acquisition limits, adapter aliases, failed-job atomicity, and help output are covered
- [x] `./scripts/pre-pr.sh` passes with formatting, Ruff, mypy, and all 238 tests
- [x] Manual dev-environment smoke test: restarted `make dev`, ingested `/tmp/newsrag-html-e2e-smoke.html` as `job-5242ed8a`, confirmed `outcome=created`, listed the document through the CLI, and searched it with citation `HTML ingestion smoke test — Transit funding — block 3`

## Checklist

- [x] Unit/integration tests added or updated
- [x] Documentation updated
- [x] No unrelated discovery, inventory-formatting, or packet changes included
