### PR TITLE
Extend inventory and search for mixed sources

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,7 +126,9 @@ The MVP retrieval pipeline uses hybrid search:
 5. A reranker interface exists in the pipeline, but the MVP implementation is a no-op.
 6. Final results are returned as cited passages.
 
-Search filters should use user-supplied civic metadata, including body, document type, meeting date ranges, jurisdiction/source, and source URL where useful.
+Search filters should use user-supplied civic metadata, including body, document type, meeting date ranges, jurisdiction/source, and source URL where useful. Search spans every indexed source type by default; the optional `--source-type` filter on `newsrag search` and `newsrag documents list` narrows results to `pdf` or `html` while composing with the existing filters.
+
+Document inventory derives source type from the published artifact and reports typed extents rather than treating every document as paginated: PDFs show page counts and HTML documents show canonical block counts. Search citations likewise resolve persisted typed source-unit locations, preserving PDF page citations and HTML heading/block citations.
 
 ## Embeddings
 

--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -376,6 +376,11 @@ def search_command(
         "--source-url",
         help="Only search documents with this source URL.",
     ),
+    source_type: str | None = typer.Option(
+        None,
+        "--source-type",
+        help="Only search documents with this source type: html or pdf.",
+    ),
     since: str | None = typer.Option(
         None,
         "--since",
@@ -401,6 +406,7 @@ def search_command(
         source_url=source_url,
         since=since,
         until=until,
+        source_type=source_type,
     )
 
     try:
@@ -469,6 +475,7 @@ def packet_command(
         source_url=source_url,
         since=since,
         until=until,
+        source_type=None,
     )
 
     try:
@@ -508,6 +515,11 @@ def documents_list_command(
         None,
         "--source-url",
         help="Only list documents with this source URL.",
+    ),
+    source_type: str | None = typer.Option(
+        None,
+        "--source-type",
+        help="Only list documents with this source type: html or pdf.",
     ),
     since: str | None = typer.Option(
         None,
@@ -555,6 +567,7 @@ def documents_list_command(
         document_type=document_type,
         jurisdiction=jurisdiction,
         source_url=source_url,
+        source_type=source_type,
         since=since,
         until=until,
         ingested_since=ingested_since,
@@ -1092,6 +1105,7 @@ def _build_search_filters(
     source_url: str | None,
     since: str | None,
     until: str | None,
+    source_type: str | None,
 ) -> SearchFilters:
     from newsrag.search import SearchFilters
 
@@ -1102,6 +1116,7 @@ def _build_search_filters(
         source_url=source_url,
         since=since,
         until=until,
+        source_type=source_type,
     )
 
 

--- a/newsrag/documents.py
+++ b/newsrag/documents.py
@@ -7,6 +7,14 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
+from newsrag.sources import (
+    SOURCE_TYPE_HTML,
+    SOURCE_TYPE_PDF,
+    SUPPORTED_SOURCE_TYPES,
+    media_types_for_source_type,
+    source_type_for_media_type,
+)
+
 DEFAULT_DOCUMENT_LIST_LIMIT = 50
 MAX_DOCUMENT_LIST_LIMIT = 500
 
@@ -27,6 +35,7 @@ class DocumentFilters:
     document_type: str | None = None
     jurisdiction: str | None = None
     source_url: str | None = None
+    source_type: str | None = None
     since: str | None = None
     until: str | None = None
     ingested_since: str | None = None
@@ -43,8 +52,18 @@ class DocumentSummary:
     source_path: str | None
     source_url: str | None
     metadata: dict[str, Any]
-    page_count: int
+    source_type: str
+    extent_label: str
+    extent_count: int
     created_at: str
+
+    @property
+    def page_count(self) -> int | None:
+        """Return the PDF page count without inventing pages for other source types."""
+
+        if self.source_type != SOURCE_TYPE_PDF:
+            return None
+        return self.extent_count
 
 
 @dataclass(frozen=True)
@@ -58,8 +77,18 @@ class DocumentDetail:
     source_hash: str | None
     normalized_path: str | None
     metadata: dict[str, Any]
-    page_count: int
+    source_type: str
+    extent_label: str
+    extent_count: int
     created_at: str
+
+    @property
+    def page_count(self) -> int | None:
+        """Return the PDF page count without inventing pages for other source types."""
+
+        if self.source_type != SOURCE_TYPE_PDF:
+            return None
+        return self.extent_count
 
 
 @dataclass(frozen=True)
@@ -99,6 +128,7 @@ def list_document_summaries(
             f"""
             SELECT COUNT(*) AS total
             FROM documents
+            LEFT JOIN source_artifacts ON source_artifacts.id = documents.artifact_id
             {query.where_sql}
             """,
             query.parameters,
@@ -112,11 +142,22 @@ def list_document_summaries(
                 documents.title,
                 documents.metadata_json,
                 documents.created_at,
-                COUNT(pages.id) AS page_count
+                source_artifacts.media_type,
+                (SELECT COUNT(*) FROM pages WHERE pages.document_id = documents.id) AS page_count,
+                (
+                    SELECT COUNT(*)
+                    FROM source_units
+                    WHERE source_units.document_id = documents.id
+                        AND source_units.location_type = 'html_block'
+                ) AS html_block_count,
+                (
+                    SELECT COUNT(*)
+                    FROM source_units
+                    WHERE source_units.document_id = documents.id
+                ) AS source_unit_count
             FROM documents
-            LEFT JOIN pages ON pages.document_id = documents.id
+            LEFT JOIN source_artifacts ON source_artifacts.id = documents.artifact_id
             {query.where_sql}
-            GROUP BY documents.id
             ORDER BY documents.created_at DESC, documents.id ASC
             LIMIT ? OFFSET ?
             """,
@@ -149,11 +190,22 @@ def get_document_detail(database_path: Path, document_id: str) -> DocumentDetail
                 documents.normalized_path,
                 documents.metadata_json,
                 documents.created_at,
-                COUNT(pages.id) AS page_count
+                source_artifacts.media_type,
+                (SELECT COUNT(*) FROM pages WHERE pages.document_id = documents.id) AS page_count,
+                (
+                    SELECT COUNT(*)
+                    FROM source_units
+                    WHERE source_units.document_id = documents.id
+                        AND source_units.location_type = 'html_block'
+                ) AS html_block_count,
+                (
+                    SELECT COUNT(*)
+                    FROM source_units
+                    WHERE source_units.document_id = documents.id
+                ) AS source_unit_count
             FROM documents
-            LEFT JOIN pages ON pages.document_id = documents.id
+            LEFT JOIN source_artifacts ON source_artifacts.id = documents.artifact_id
             WHERE documents.id = ?
-            GROUP BY documents.id
             """,
             (document_id,),
         ).fetchone()
@@ -161,6 +213,7 @@ def get_document_detail(database_path: Path, document_id: str) -> DocumentDetail
     if row is None:
         raise DocumentNotFoundError(f"Unknown document: {document_id}")
 
+    source_type, extent_label, extent_count = _row_source_extent(row)
     return DocumentDetail(
         id=str(row["id"]),
         title=_optional_string(row["title"]),
@@ -169,7 +222,9 @@ def get_document_detail(database_path: Path, document_id: str) -> DocumentDetail
         source_hash=_optional_string(row["source_hash"]),
         normalized_path=_optional_string(row["normalized_path"]),
         metadata=_load_metadata(row["metadata_json"]),
-        page_count=int(row["page_count"]),
+        source_type=source_type,
+        extent_label=extent_label,
+        extent_count=extent_count,
         created_at=str(row["created_at"]),
     )
 
@@ -202,7 +257,8 @@ def format_document_list(page: DocumentListPage) -> str:
             f"meeting_date={_display_value(_metadata_string(metadata, 'meeting_date'))}",
             f"body={_display_value(_metadata_string(metadata, 'body'))}",
             f"document_type={_display_value(_metadata_string(metadata, 'document_type'))}",
-            f"pages={document.page_count}",
+            f"source_type={document.source_type}",
+            f"{document.extent_label}={document.extent_count}",
             f"source={_display_value(_best_source(document.source_url, document.source_path, metadata))}",
             f"created_at={document.created_at}",
         ]
@@ -219,7 +275,8 @@ def format_document_detail(document: DocumentDetail) -> str:
         f"id: {document.id}",
         f"title: {_display_value(document.title)}",
         f"created_at: {document.created_at}",
-        f"pages: {document.page_count}",
+        f"source_type: {document.source_type}",
+        f"{document.extent_label}: {document.extent_count}",
         f"source_url: {_display_value(document.source_url)}",
         f"source_path: {_display_value(document.source_path)}",
         f"source_hash: {_display_value(document.source_hash)}",
@@ -252,6 +309,13 @@ def _build_filter_query(filters: DocumentFilters) -> _QueryParts:
             continue
         clauses.append(f"json_extract(documents.metadata_json, '$.{key}') = ?")
         parameters.append(resolved_value)
+
+    source_type = _normalized_optional_string(filters.source_type)
+    if source_type is not None:
+        media_types = media_types_for_source_type(source_type.lower())
+        placeholders = ", ".join("?" for _ in media_types)
+        clauses.append(f"source_artifacts.media_type IN ({placeholders})")
+        parameters.extend(media_types)
 
     source_url = _normalized_optional_string(filters.source_url)
     if source_url is not None:
@@ -308,6 +372,7 @@ def _validate_pagination(*, limit: int, offset: int) -> None:
 
 
 def _validate_filters(filters: DocumentFilters) -> None:
+    _validate_source_type(filters.source_type)
     since_date = _parse_filter_date(filters.since, option_name="--since")
     until_date = _parse_filter_date(filters.until, option_name="--until")
     if since_date is not None and until_date is not None and since_date > until_date:
@@ -342,15 +407,40 @@ def _parse_filter_date(value: str | None, *, option_name: str) -> date | None:
 
 
 def _row_to_summary(row: sqlite3.Row) -> DocumentSummary:
+    source_type, extent_label, extent_count = _row_source_extent(row)
     return DocumentSummary(
         id=str(row["id"]),
         title=_optional_string(row["title"]),
         source_path=_optional_string(row["source_path"]),
         source_url=_optional_string(row["source_url"]),
         metadata=_load_metadata(row["metadata_json"]),
-        page_count=int(row["page_count"]),
+        source_type=source_type,
+        extent_label=extent_label,
+        extent_count=extent_count,
         created_at=str(row["created_at"]),
     )
+
+
+def _row_source_extent(row: sqlite3.Row) -> tuple[str, str, int]:
+    media_type = _optional_string(row["media_type"])
+    source_type = source_type_for_media_type(media_type)
+    if source_type == SOURCE_TYPE_PDF:
+        return source_type, "pages", int(row["page_count"])
+    if source_type == SOURCE_TYPE_HTML:
+        return source_type, "blocks", int(row["html_block_count"])
+    return media_type or "unknown", "units", int(row["source_unit_count"])
+
+
+def _validate_source_type(value: str | None) -> None:
+    source_type = _normalized_optional_string(value)
+    if source_type is None:
+        return
+    normalized_source_type = source_type.lower()
+    if normalized_source_type not in SUPPORTED_SOURCE_TYPES:
+        raise DocumentError(
+            f"Unsupported --source-type {source_type!r}; expected one of: "
+            + ", ".join(sorted(SUPPORTED_SOURCE_TYPES))
+        )
 
 
 def _load_metadata(raw_metadata: object) -> dict[str, Any]:

--- a/newsrag/ingest.py
+++ b/newsrag/ingest.py
@@ -83,6 +83,9 @@ from newsrag.sources import (
     HTML_MEDIA_TYPES,
     PAGE_LOCATION_TYPE,
     PDF_MEDIA_TYPE,
+    SOURCE_TYPE_HTML,
+    SOURCE_TYPE_PDF,
+    SUPPORTED_SOURCE_TYPES,
     artifact_id_for_hash,
     build_source_identity,
     normalize_url_reference,
@@ -111,9 +114,6 @@ INGEST_JOB_KIND = "ingest-file"
 DEFAULT_CHUNK_MAX_CHARS = 2000
 DEFAULT_CHUNK_OVERLAP_CHARS = 200
 VECTOR_TABLE_NAME = "chunk_embeddings"
-SOURCE_TYPE_PDF = "pdf"
-SOURCE_TYPE_HTML = "html"
-SUPPORTED_SOURCE_TYPES = frozenset({SOURCE_TYPE_HTML, SOURCE_TYPE_PDF})
 _PDF_EXTENSIONS = (".pdf",)
 _PDF_SIGNATURES = (b"%PDF-",)
 _HTML_EXTENSIONS = (".html", ".htm", ".xhtml")

--- a/newsrag/search.py
+++ b/newsrag/search.py
@@ -19,7 +19,12 @@ from newsrag.embeddings import (
     build_embedding_provider,
     create_embedding_record,
 )
-from newsrag.sources import HTML_BLOCK_LOCATION_TYPE
+from newsrag.sources import (
+    HTML_BLOCK_LOCATION_TYPE,
+    PAGE_LOCATION_TYPE,
+    SUPPORTED_SOURCE_TYPES,
+    source_type_for_media_type,
+)
 
 DEFAULT_SEARCH_LIMIT = 5
 DEFAULT_SEARCH_CANDIDATE_LIMIT = 20
@@ -44,6 +49,7 @@ class SearchFilters:
     document_type: str | None = None
     jurisdiction: str | None = None
     source_url: str | None = None
+    source_type: str | None = None
     since: str | None = None
     until: str | None = None
 
@@ -62,6 +68,7 @@ class SearchFilters:
             ("document_type", self.document_type),
             ("jurisdiction", self.jurisdiction),
             ("source_url", self.source_url),
+            ("source_type", self.source_type),
             ("since", self.since),
             ("until", self.until),
         ):
@@ -73,6 +80,7 @@ class SearchFilters:
     def validate(self) -> None:
         """Validate filter values before search execution."""
 
+        _validate_source_type(self.source_type)
         since_date = _parse_filter_date(self.since, option_name="--since")
         until_date = _parse_filter_date(self.until, option_name="--until")
         if since_date is not None and until_date is not None and since_date > until_date:
@@ -110,6 +118,7 @@ class SearchCandidate:
     jurisdiction: str | None = None
     source_url: str | None = None
     source_path: str | None = None
+    source_type: str | None = None
     source_unit_start_id: str | None = None
     source_unit_end_id: str | None = None
     keyword_score: float | None = None
@@ -136,12 +145,13 @@ class SearchResult:
     jurisdiction: str | None = None
     source_url: str | None = None
     source_path: str | None = None
+    source_type: str | None = None
     source_unit_start_id: str | None = None
     source_unit_end_id: str | None = None
 
 
 @dataclass(frozen=True)
-class _HtmlCitationDetails:
+class _CitationDetails:
     heading_path: tuple[str, ...]
     location_label: str
 
@@ -377,10 +387,12 @@ def search_keyword_candidates(
                 documents.source_url AS source_url,
                 documents.source_path AS source_path,
                 documents.metadata_json AS metadata_json,
+                source_artifacts.media_type AS source_media_type,
                 bm25(passages_fts) AS keyword_score
             FROM passages_fts
             JOIN passages ON passages.id = passages_fts.passage_id
             JOIN documents ON documents.id = passages.document_id
+            LEFT JOIN source_artifacts ON source_artifacts.id = documents.artifact_id
             WHERE passages_fts MATCH ?
             ORDER BY bm25(passages_fts) ASC, passages.id ASC
             LIMIT ?
@@ -408,6 +420,7 @@ def search_keyword_candidates(
                 source_path=_optional_string(row["source_path"])
                 or _optional_string(metadata.get("stored_source_path"))
                 or _optional_string(metadata.get("source_filename")),
+                source_type=source_type_for_media_type(_optional_string(row["source_media_type"])),
                 source_unit_start_id=_optional_string(row["source_unit_start_id"]),
                 source_unit_end_id=_optional_string(row["source_unit_end_id"]),
                 keyword_score=float(row["keyword_score"]),
@@ -449,7 +462,7 @@ def merge_search_candidates(
         }
     )
 
-    source_citations = _load_html_citation_details(
+    source_citations = _load_citation_details(
         database_path,
         tuple(passage_context.values()),
     )
@@ -485,6 +498,7 @@ def merge_search_candidates(
             jurisdiction=context.jurisdiction,
             source_url=context.source_url,
             source_path=context.source_path,
+            source_type=context.source_type,
             source_unit_start_id=context.source_unit_start_id,
             source_unit_end_id=context.source_unit_end_id,
         )
@@ -527,10 +541,10 @@ def format_citation(
     return " — ".join(parts)
 
 
-def _load_html_citation_details(
+def _load_citation_details(
     database_path: Path,
     candidates: Sequence[SearchCandidate],
-) -> dict[str, _HtmlCitationDetails]:
+) -> dict[str, _CitationDetails]:
     source_unit_ids = {
         source_unit_id
         for candidate in candidates
@@ -556,7 +570,7 @@ def _load_html_citation_details(
         ).fetchall()
     units = {str(row["id"]): row for row in rows}
 
-    citations: dict[str, _HtmlCitationDetails] = {}
+    citations: dict[str, _CitationDetails] = {}
     for candidate in candidates:
         if candidate.source_unit_start_id is None:
             continue
@@ -564,13 +578,22 @@ def _load_html_citation_details(
         end_unit = units.get(candidate.source_unit_end_id or candidate.source_unit_start_id)
         if start_unit is None or end_unit is None:
             continue
-        if (
-            str(start_unit["location_type"]) != HTML_BLOCK_LOCATION_TYPE
-            or str(end_unit["location_type"]) != HTML_BLOCK_LOCATION_TYPE
-        ):
+        start_location_type = str(start_unit["location_type"])
+        if start_location_type != str(end_unit["location_type"]):
             continue
         start_location = _load_metadata(start_unit["location_json"])
         end_location = _load_metadata(end_unit["location_json"])
+        if start_location_type == PAGE_LOCATION_TYPE:
+            start_page = start_location.get("page_number")
+            if isinstance(start_page, bool) or not isinstance(start_page, int) or start_page < 1:
+                continue
+            citations[candidate.passage_id] = _CitationDetails(
+                heading_path=(),
+                location_label=f"p. {start_page}",
+            )
+            continue
+        if start_location_type != HTML_BLOCK_LOCATION_TYPE:
+            continue
         start_block = start_location.get("block_number")
         end_block = end_location.get("block_number")
         if (
@@ -598,7 +621,7 @@ def _load_html_citation_details(
             if start_block == end_block
             else f"blocks {start_block}–{end_block}"
         )
-        citations[candidate.passage_id] = _HtmlCitationDetails(
+        citations[candidate.passage_id] = _CitationDetails(
             heading_path=heading_path,
             location_label=location_label,
         )
@@ -808,6 +831,7 @@ def _expand_contextual_keyword_candidates(
                     jurisdiction=neighbor.jurisdiction,
                     source_url=neighbor.source_url,
                     source_path=neighbor.source_path,
+                    source_type=neighbor.source_type,
                     source_unit_start_id=neighbor.source_unit_start_id,
                     source_unit_end_id=neighbor.source_unit_end_id,
                     keyword_score=(candidate.keyword_score or 0.0) + 0.5,
@@ -869,9 +893,11 @@ def _load_passage_context(
                     documents.title AS title,
                     documents.source_url AS source_url,
                     documents.source_path AS source_path,
-                    documents.metadata_json AS metadata_json
+                    documents.metadata_json AS metadata_json,
+                    source_artifacts.media_type AS source_media_type
                 FROM passages
                 JOIN documents ON documents.id = passages.document_id
+                LEFT JOIN source_artifacts ON source_artifacts.id = documents.artifact_id
                 WHERE passages.id IN ({placeholders})
                 """,
                 tuple(passage_ids_to_load),
@@ -895,6 +921,7 @@ def _load_passage_context(
                 source_path=_optional_string(row["source_path"])
                 or _optional_string(metadata.get("stored_source_path"))
                 or _optional_string(metadata.get("source_filename")),
+                source_type=source_type_for_media_type(_optional_string(row["source_media_type"])),
                 source_unit_start_id=_optional_string(row["source_unit_start_id"]),
                 source_unit_end_id=_optional_string(row["source_unit_end_id"]),
             )
@@ -916,6 +943,7 @@ def _load_passage_context(
             jurisdiction=existing.jurisdiction,
             source_url=existing.source_url,
             source_path=existing.source_path,
+            source_type=existing.source_type,
             source_unit_start_id=existing.source_unit_start_id,
             source_unit_end_id=existing.source_unit_end_id,
             keyword_score=existing.keyword_score,
@@ -979,12 +1007,14 @@ def _load_adjacent_passages(
                 documents.title AS title,
                 documents.source_url AS source_url,
                 documents.source_path AS source_path,
-                documents.metadata_json AS metadata_json
+                documents.metadata_json AS metadata_json,
+                source_artifacts.media_type AS source_media_type
             FROM passages
             JOIN origin
                 ON passages.chunk_id = origin.chunk_id
                 AND ABS(passages.ordinal - origin.ordinal) = 1
             JOIN documents ON documents.id = passages.document_id
+            LEFT JOIN source_artifacts ON source_artifacts.id = documents.artifact_id
             ORDER BY passages.ordinal ASC, passages.id ASC
             """,
             (passage_id,),
@@ -1010,6 +1040,7 @@ def _load_adjacent_passages(
                 source_path=_optional_string(row["source_path"])
                 or _optional_string(metadata.get("stored_source_path"))
                 or _optional_string(metadata.get("source_filename")),
+                source_type=source_type_for_media_type(_optional_string(row["source_media_type"])),
                 source_unit_start_id=_optional_string(row["source_unit_start_id"]),
                 source_unit_end_id=_optional_string(row["source_unit_end_id"]),
             )
@@ -1041,6 +1072,7 @@ def _matches_search_filters(candidate: SearchCandidate, filters: SearchFilters) 
         and _matches_text_filter(candidate.document_type, filters.document_type)
         and _matches_text_filter(candidate.jurisdiction, filters.jurisdiction)
         and _matches_text_filter(candidate.source_url, filters.source_url)
+        and _matches_text_filter(candidate.source_type, filters.source_type)
         and _matches_date_filter(candidate.meeting_date, since=filters.since, until=filters.until)
     )
 
@@ -1069,6 +1101,18 @@ def _matches_date_filter(meeting_date: str | None, *, since: str | None, until: 
     if until_date is not None and parsed_meeting_date > until_date:
         return False
     return True
+
+
+def _validate_source_type(value: str | None) -> None:
+    source_type = _optional_string(value)
+    if source_type is None:
+        return
+    normalized_source_type = source_type.lower()
+    if normalized_source_type not in SUPPORTED_SOURCE_TYPES:
+        raise SearchError(
+            f"Unsupported --source-type {source_type!r}; expected one of: "
+            + ", ".join(sorted(SUPPORTED_SOURCE_TYPES))
+        )
 
 
 def _parse_filter_date(value: str | None, *, option_name: str) -> date | None:

--- a/newsrag/sources.py
+++ b/newsrag/sources.py
@@ -8,11 +8,37 @@ from urllib.parse import SplitResult, urlsplit, urlunsplit
 
 SOURCE_KIND_LOCAL_PATH = "local_path"
 SOURCE_KIND_URL = "url"
+SOURCE_TYPE_PDF = "pdf"
+SOURCE_TYPE_HTML = "html"
+SUPPORTED_SOURCE_TYPES = frozenset({SOURCE_TYPE_HTML, SOURCE_TYPE_PDF})
 PDF_MEDIA_TYPE = "application/pdf"
 HTML_MEDIA_TYPES = ("text/html", "application/xhtml+xml")
 HTML_MAX_SOURCE_BYTES = 10 * 1024 * 1024
 PAGE_LOCATION_TYPE = "page"
 HTML_BLOCK_LOCATION_TYPE = "html_block"
+
+
+def source_type_for_media_type(media_type: str | None) -> str | None:
+    """Return the registered source type for one persisted artifact media type."""
+
+    if media_type is None:
+        return None
+    normalized_media_type = media_type.partition(";")[0].strip().lower()
+    if normalized_media_type == PDF_MEDIA_TYPE:
+        return SOURCE_TYPE_PDF
+    if normalized_media_type in HTML_MEDIA_TYPES:
+        return SOURCE_TYPE_HTML
+    return None
+
+
+def media_types_for_source_type(source_type: str) -> tuple[str, ...]:
+    """Return persisted media types represented by one registered source type."""
+
+    if source_type == SOURCE_TYPE_PDF:
+        return (PDF_MEDIA_TYPE,)
+    if source_type == SOURCE_TYPE_HTML:
+        return HTML_MEDIA_TYPES
+    return ()
 
 
 @dataclass(frozen=True)

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -264,6 +264,82 @@ def test_documents_list_rejects_invalid_limit_and_date(tmp_path: Path) -> None:
     assert "Invalid --since date" in date_result.stdout
 
 
+def test_mixed_source_inventory_shows_typed_extents_and_filters(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    database_path = _seed_mixed_document_inventory(data_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            "--data-dir",
+            str(data_dir),
+            "documents",
+            "list",
+            "--source-type",
+            "html",
+            "--body",
+            "City Council",
+        ],
+    )
+    page = list_document_summaries(
+        database_path,
+        filters=DocumentFilters(source_type="html", body="City Council"),
+    )
+    detail_result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "documents", "show", "document-html"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "document-html | Web Notice" in result.stdout
+    assert "source_type=html" in result.stdout
+    assert "blocks=3" in result.stdout
+    assert "pages=" not in result.stdout
+    assert [document.id for document in page.documents] == ["document-html"]
+    assert page.documents[0].source_type == "html"
+    assert page.documents[0].extent_label == "blocks"
+    assert page.documents[0].extent_count == 3
+    assert page.documents[0].page_count is None
+    assert detail_result.exit_code == 0, detail_result.stdout
+    assert "source_type: html" in detail_result.stdout
+    assert "blocks: 3" in detail_result.stdout
+    assert "pages:" not in detail_result.stdout
+
+
+def test_mixed_source_inventory_preserves_pdf_page_extents(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    database_path = _seed_mixed_document_inventory(data_dir)
+
+    result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "documents", "list", "--source-type", "pdf"],
+    )
+    detail = get_document_detail(database_path, "document-a")
+
+    assert result.exit_code == 0, result.stdout
+    assert "document-a | Stormwater Report" in result.stdout
+    assert "source_type=pdf" in result.stdout
+    assert "pages=2" in result.stdout
+    assert "document-html" not in result.stdout
+    assert detail.source_type == "pdf"
+    assert detail.extent_label == "pages"
+    assert detail.extent_count == 2
+    assert detail.page_count == 2
+
+
+def test_documents_list_rejects_unsupported_source_type(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    initialize_storage(data_dir)
+
+    result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "documents", "list", "--source-type", "docx"],
+    )
+
+    assert result.exit_code == 1
+    assert "Unsupported --source-type 'docx'; expected one of: html, pdf" in result.stdout
+
+
 def test_documents_show_outputs_detail_and_page_count(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
     database_path = _seed_document_inventory(data_dir)
@@ -306,6 +382,30 @@ def _seed_document_inventory(data_dir: Path) -> Path:
     with sqlite3.connect(database_path) as connection:
         connection.executemany(
             """
+            INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+            VALUES(?, 'local_path', ?, ?)
+            """,
+            [
+                ("source-a", "/tmp/stormwater.pdf", "/tmp/stormwater.pdf"),
+                ("source-b", "/tmp/budget.pdf", "/tmp/budget.pdf"),
+                ("source-c", "/tmp/zoning.pdf", "/tmp/zoning.pdf"),
+            ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, byte_size, content_hash, stored_path, acquired_at, state
+            )
+            VALUES(?, ?, 'application/pdf', 10, ?, ?, CURRENT_TIMESTAMP, 'published')
+            """,
+            [
+                ("artifact-a", "source-a", "hash-a", "/tmp/stormwater.pdf"),
+                ("artifact-b", "source-b", "hash-b", "/tmp/budget.pdf"),
+                ("artifact-c", "source-c", "hash-c", "/tmp/zoning.pdf"),
+            ],
+        )
+        connection.executemany(
+            """
             INSERT INTO documents(
                 id,
                 source_path,
@@ -314,9 +414,10 @@ def _seed_document_inventory(data_dir: Path) -> Path:
                 source_hash,
                 normalized_path,
                 metadata_json,
+                artifact_id,
                 created_at
             )
-            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
                 (
@@ -327,6 +428,7 @@ def _seed_document_inventory(data_dir: Path) -> Path:
                     "hash-a",
                     "/tmp/stormwater-ocr.pdf",
                     '{"body": "Planning Commission", "document_type": "staff_report", "jurisdiction": "Example City", "meeting_date": "2026-03-15", "source_filename": "stormwater.pdf"}',
+                    "artifact-a",
                     "2026-04-01T00:00:00+00:00",
                 ),
                 (
@@ -337,6 +439,7 @@ def _seed_document_inventory(data_dir: Path) -> Path:
                     "hash-b",
                     "/tmp/budget-ocr.pdf",
                     '{"body": "City Council", "document_type": "agenda_packet", "jurisdiction": "Example City", "meeting_date": "2026-04-20", "source_filename": "budget.pdf"}',
+                    "artifact-b",
                     "2026-04-02T23:59:59+00:00",
                 ),
                 (
@@ -347,6 +450,7 @@ def _seed_document_inventory(data_dir: Path) -> Path:
                     "hash-c",
                     "/tmp/zoning-ocr.pdf",
                     '{"body": "Planning Commission", "document_type": "agenda_packet", "jurisdiction": "Example City", "meeting_date": "2026-05-01", "source_filename": "zoning.pdf"}',
+                    "artifact-c",
                     "2026-04-03T00:00:00+00:00",
                 ),
             ],
@@ -360,6 +464,56 @@ def _seed_document_inventory(data_dir: Path) -> Path:
                 ("page-a-1", "document-a", 1, "Stormwater page one", "pymupdf"),
                 ("page-a-2", "document-a", 2, "Stormwater page two", "pymupdf"),
                 ("page-b-1", "document-b", 1, "Budget page", "pymupdf"),
+            ],
+        )
+        connection.commit()
+    return database_path
+
+
+def _seed_mixed_document_inventory(data_dir: Path) -> Path:
+    database_path = _seed_document_inventory(data_dir)
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+            VALUES('source-html', 'local_path', '/tmp/notice.html', '/tmp/notice.html')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, byte_size, content_hash, stored_path, acquired_at, state
+            )
+            VALUES(
+                'artifact-html', 'source-html', 'application/xhtml+xml', 20, 'hash-html',
+                '/tmp/notice.html', CURRENT_TIMESTAMP, 'published'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO documents(
+                id, source_path, title, source_hash, metadata_json, artifact_id, created_at
+            )
+            VALUES(
+                'document-html', '/tmp/notice.html', 'Web Notice', 'hash-html',
+                '{"body": "City Council", "document_type": "notice", "jurisdiction": "Example City"}',
+                'artifact-html', '2026-04-04T00:00:00+00:00'
+            )
+            """
+        )
+        connection.executemany(
+            """
+            INSERT INTO source_units(
+                id, artifact_id, document_id, ordinal, location_type, location_json,
+                human_label, normalized_text, structure_json, extractor
+            )
+            VALUES(?, 'artifact-html', 'document-html', ?, 'html_block', ?, ?, ?, '{}', 'static-html')
+            """,
+            [
+                ("html-unit-1", 1, '{"block_number": 1}', "block 1", "Web Notice"),
+                ("html-unit-2", 2, '{"block_number": 2}', "block 2", "Budget"),
+                ("html-unit-3", 3, '{"block_number": 3}', "block 3", "Public update"),
             ],
         )
         connection.commit()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from newsrag.cli import app
@@ -14,6 +15,7 @@ from newsrag.embeddings import ChunkEmbedding, EmbeddingMetadata, QueryEmbedding
 from newsrag.search import (
     PassageVectorRecord,
     SearchCandidate,
+    SearchError,
     SearchFilters,
     SearchResult,
     build_search_engine,
@@ -171,8 +173,8 @@ def test_search_candidates_and_results_retain_source_unit_ranges(tmp_path: Path)
             VALUES(?, 'artifact-1', 'document-1', ?, 'page', ?, ?, ?, 'pymupdf')
             """,
             [
-                ("unit-1", 1, '{"page_number": 1}', "p. 1", "stormwater"),
-                ("unit-2", 2, '{"page_number": 2}', "p. 2", "improvements"),
+                ("unit-1", 1, '{"page_number": 7}', "p. 7", "stormwater"),
+                ("unit-2", 2, '{"page_number": 8}', "p. 8", "improvements"),
             ],
         )
         connection.execute(
@@ -239,7 +241,7 @@ def test_search_candidates_and_results_retain_source_unit_ranges(tmp_path: Path)
     assert len(results) == 1
     assert results[0].source_unit_start_id == "unit-1"
     assert results[0].source_unit_end_id == "unit-2"
-    assert results[0].citation == "Stormwater Report — 2026-05-01 — p. 1"
+    assert results[0].citation == "Stormwater Report — 2026-05-01 — p. 7"
 
 
 def test_search_filters_by_document_metadata_and_meeting_date(tmp_path: Path) -> None:
@@ -270,6 +272,54 @@ def test_search_filters_by_document_metadata_and_meeting_date(tmp_path: Path) ->
     assert results[0].document_type == "staff_report"
     assert results[0].jurisdiction == "Example City"
     assert results[0].source_url == "https://example.test/stormwater.pdf"
+
+
+def test_mixed_source_search_defaults_to_all_types_and_filters_by_source_type(
+    tmp_path: Path,
+) -> None:
+    database_path = _seed_search_corpus(tmp_path)
+    engine = build_search_engine(
+        database_path=database_path,
+        lancedb_path=tmp_path / ".newsrag" / "lancedb",
+        embedding_config=EmbeddingConfig(),
+        embedding_provider=FakeQueryEmbeddingProvider(),
+        vector_searcher=FakeVectorSearcher(),
+        vector_store=FakeVectorStore(),
+    )
+
+    all_results = engine.search("budget")
+    html_results = engine.search("budget", filters=SearchFilters(source_type="html"))
+    pdf_results = engine.search(
+        "budget",
+        filters=SearchFilters(source_type="pdf", body="City Council"),
+    )
+
+    assert {result.passage_id for result in all_results} == {"passage-b", "passage-j"}
+    assert [result.passage_id for result in html_results] == ["passage-j"]
+    assert html_results[0].source_type == "html"
+    assert html_results[0].citation == "Web Notice — Budget — block 3"
+    assert [result.passage_id for result in pdf_results] == ["passage-b"]
+    assert pdf_results[0].source_type == "pdf"
+
+
+def test_search_rejects_unsupported_source_type(tmp_path: Path) -> None:
+    filters = SearchFilters(source_type="docx")
+
+    with pytest.raises(
+        SearchError,
+        match="Unsupported --source-type 'docx'; expected one of: html, pdf",
+    ):
+        filters.validate()
+
+    data_dir = tmp_path / ".newsrag"
+    initialize_storage(data_dir)
+    result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "search", "budget", "--source-type", "docx"],
+    )
+
+    assert result.exit_code == 1
+    assert "Unsupported --source-type 'docx'; expected one of: html, pdf" in result.stdout
 
 
 def test_search_filters_vector_candidates_without_leaking_out_of_filter_results(
@@ -358,6 +408,7 @@ def test_search_help_documents_metadata_filters() -> None:
     assert "--body" in plain_output
     assert "--document-type" in plain_output
     assert "--source-url" in plain_output
+    assert "--source-type" in plain_output
     assert "--since" in plain_output
 
 
@@ -602,8 +653,39 @@ def _seed_search_corpus(tmp_path: Path) -> Path:
     with sqlite3.connect(database_path) as connection:
         connection.executemany(
             """
-            INSERT INTO documents(id, source_path, source_url, title, source_hash, normalized_path, metadata_json)
-            VALUES(?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+            VALUES(?, 'local_path', ?, ?)
+            """,
+            [
+                ("source-a", "/tmp/stormwater.pdf", "/tmp/stormwater.pdf"),
+                ("source-b", "/tmp/budget.pdf", "/tmp/budget.pdf"),
+                ("source-c", "/tmp/zoning.pdf", "/tmp/zoning.pdf"),
+                ("source-d", "/tmp/mustang.pdf", "/tmp/mustang.pdf"),
+                ("source-html", "/tmp/notice.html", "/tmp/notice.html"),
+            ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, byte_size, content_hash, stored_path, acquired_at, state
+            )
+            VALUES(?, ?, ?, 10, ?, ?, CURRENT_TIMESTAMP, 'published')
+            """,
+            [
+                ("artifact-a", "source-a", "application/pdf", "hash-a", "/tmp/stormwater.pdf"),
+                ("artifact-b", "source-b", "application/pdf", "hash-b", "/tmp/budget.pdf"),
+                ("artifact-c", "source-c", "application/pdf", "hash-c", "/tmp/zoning.pdf"),
+                ("artifact-d", "source-d", "application/pdf", "hash-d", "/tmp/mustang.pdf"),
+                ("artifact-html", "source-html", "text/html", "hash-html", "/tmp/notice.html"),
+            ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO documents(
+                id, source_path, source_url, title, source_hash, normalized_path,
+                metadata_json, artifact_id
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
                 (
@@ -614,6 +696,7 @@ def _seed_search_corpus(tmp_path: Path) -> Path:
                     "hash-a",
                     "/tmp/stormwater-ocr.pdf",
                     '{"body": "Planning Commission", "document_type": "staff_report", "jurisdiction": "Example City", "meeting_date": "2026-05-01"}',
+                    "artifact-a",
                 ),
                 (
                     "document-b",
@@ -623,6 +706,7 @@ def _seed_search_corpus(tmp_path: Path) -> Path:
                     "hash-b",
                     "/tmp/budget-ocr.pdf",
                     '{"body": "City Council", "document_type": "agenda_packet", "jurisdiction": "Example City", "meeting_date": "2026-04-20"}',
+                    "artifact-b",
                 ),
                 (
                     "document-c",
@@ -632,6 +716,7 @@ def _seed_search_corpus(tmp_path: Path) -> Path:
                     "hash-c",
                     "/tmp/zoning-ocr.pdf",
                     '{"body": "Zoning Board", "document_type": "packet", "jurisdiction": "Example City", "meeting_date": "2026-03-15"}',
+                    "artifact-c",
                 ),
                 (
                     "document-d",
@@ -641,8 +726,33 @@ def _seed_search_corpus(tmp_path: Path) -> Path:
                     "hash-d",
                     "/tmp/mustang-ocr.pdf",
                     '{"body": "City Manager", "document_type": "manager_report", "jurisdiction": "Mustang", "meeting_date": "2026-05-01"}',
+                    "artifact-d",
+                ),
+                (
+                    "document-html",
+                    "/tmp/notice.html",
+                    "https://example.test/notice.html",
+                    "Web Notice",
+                    "hash-html",
+                    None,
+                    '{"body": "City Council", "document_type": "notice", "jurisdiction": "Example City"}',
+                    "artifact-html",
                 ),
             ],
+        )
+        connection.execute(
+            """
+            INSERT INTO source_units(
+                id, artifact_id, document_id, ordinal, location_type, location_json,
+                human_label, normalized_text, structure_json, extractor
+            )
+            VALUES(
+                'unit-html-3', 'artifact-html', 'document-html', 3, 'html_block',
+                '{"block_number": 3}', 'block 3', 'budget online public update',
+                '{"element_kind": "paragraph", "heading_path": ["Web Notice", "Budget"]}',
+                'static-html'
+            )
+            """
         )
         connection.executemany(
             """
@@ -731,7 +841,23 @@ def _seed_search_corpus(tmp_path: Path) -> Path:
                     5,
                     "• Geeky Cauldron Book Club – A book club for adults who love reading Young Adult books.",
                 ),
+                (
+                    "passage-j",
+                    "chunk-j",
+                    "document-html",
+                    3,
+                    3,
+                    1,
+                    "budget online public update",
+                ),
             ],
+        )
+        connection.execute(
+            """
+            UPDATE passages
+            SET source_unit_start_id = 'unit-html-3', source_unit_end_id = 'unit-html-3'
+            WHERE id = 'passage-j'
+            """
         )
         connection.executemany(
             """
@@ -763,6 +889,7 @@ def _seed_search_corpus(tmp_path: Path) -> Path:
                     "passage-i",
                     "Geeky Cauldron Book Club A book club for adults who love reading Young Adult books",
                 ),
+                ("passage-j", "budget online public update"),
             ],
         )
         connection.commit()


### PR DESCRIPTION
## Summary

Represent PDF and HTML documents accurately in inventory and search without changing discovery or source-packet behavior.

## Task

Todu `task-0d3cae4d`

## Changes

- derive document source types from published artifact media types
- display PDF extents as pages and HTML extents as canonical blocks in list and detail output
- retain a PDF-only optional `page_count` compatibility property without assigning page counts to HTML
- add optional `--source-type html|pdf` filters to `documents list` and `search`
- compose source-type filters with existing metadata, date, URL, ingestion-date, and query filters
- keep mixed-source search as the default
- carry source type through keyword/vector candidate context and search results
- resolve PDF page citations and HTML heading/block citations from persisted typed source units
- centralize registered source-type constants and media-type mappings
- leave discovery commands and packet output unchanged

## Testing

- [x] Mixed PDF/HTML inventory tests cover source types, PDF page extents, HTML block extents, XHTML mapping, list/detail output, and no invented HTML page count
- [x] Search tests cover default mixed-source results, HTML/PDF source filters, composition with body metadata, CLI validation/help, and typed PDF/HTML citations
- [x] Existing document, search, ingestion, discovery, and packet tests remain green
- [x] `./scripts/pre-pr.sh` passes with formatting, Ruff, mypy, and all 243 tests
- [x] Manual development CLI verification against the existing mixed corpus:
  - HTML inventory showed `source_type=html | blocks=3`
  - PDF inventory showed `source_type=pdf | pages=1`
  - HTML detail showed `blocks: 3` with no page field
  - `search "downtown corridor" --source-type html` returned `HTML ingestion smoke test — Transit funding — block 3`

## Checklist

- [x] Tests added first for changed behavior
- [x] Documentation updated
- [x] Discovery and source packets remain out of scope
