### PR TITLE
Extend discovery for source-neutral evidence

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,6 +148,14 @@ The daemon uses filesystem notifications through `watchfiles` and an async worke
 
 `newsrag status` and `newsrag jobs list` should show queue health, failed jobs, and processing state. This matters because OCR and embedding jobs can be slow and failures should not be silent.
 
+## Discovery and enrichment
+
+Discovery evidence uses source-unit start/end IDs as its canonical location for every format. PDF evidence also records derived page IDs and page ranges so existing page-oriented output remains unchanged; HTML evidence records heading/block labels without inventing page values. Optional passage IDs provide narrower quote-validation context. Evidence is persisted only after the cited source-unit range belongs to the document and the quote is found in the canonical source text or cited passage.
+
+Deterministic fact extraction, document briefs, structured enrichment, topics, timelines, and story leads operate over canonical source units. Document profiles store `source_type`, `extent_type`, and `extent_count`; PDF profiles use pages and HTML profiles use blocks. Terminal discovery output formats each typed location as a PDF page citation or HTML heading/block citation.
+
+Schema version 5 replaces the previously unused page-only discovery schema. Upgrading from schema versions 1–4 resets only regenerable document profiles, briefs, discovery items/evidence, and their FTS tables rather than converting old derived records. Sources, artifacts, documents, source units, chunks, passages, embeddings, and search indexes are not reset.
+
 ## Packet generation
 
 `newsrag packet` uses the same retrieval pipeline as search and writes an extractive Markdown source packet. The initial packet template is fixed and research-oriented, with configurable templates left for later.

--- a/newsrag/briefs.py
+++ b/newsrag/briefs.py
@@ -7,12 +7,18 @@ from pathlib import Path
 from typing import Any
 
 from newsrag.discovery import (
+    DiscoveryEvidenceRecord,
     DiscoveryItemRecord,
     DocumentBriefRecord,
     create_document_brief,
     list_discovery_items,
 )
 from newsrag.facts import extract_document_facts
+from newsrag.source_locations import (
+    SourceLocationError,
+    format_evidence_location,
+    load_document_extent,
+)
 
 BRIEF_EXTRACTOR = "deterministic-document-brief"
 BRIEF_PROVIDER = "rules"
@@ -44,7 +50,9 @@ class BriefDocumentContext:
     id: str
     title: str | None
     metadata: dict[str, Any]
-    page_count: int
+    source_type: str
+    extent_type: str
+    extent_count: int
     text_length: int
 
 
@@ -55,8 +63,10 @@ class BriefEvidenceLine:
     item_type: str
     label: str
     summary: str
-    page_start: int
-    page_end: int
+    location_type: str
+    location_label: str
+    page_start: int | None
+    page_end: int | None
     quote: str
 
 
@@ -122,7 +132,8 @@ def format_generated_brief(brief: GeneratedBrief) -> str:
         f"title: {_display_value(document.title)}",
         f"meeting_date: {_display_value(_metadata_string(metadata, 'meeting_date'))}",
         f"body: {_display_value(_metadata_string(metadata, 'body'))}",
-        f"pages: {document.page_count}",
+        f"source_type: {document.source_type}",
+        f"{document.extent_type}: {document.extent_count}",
         "",
         "Summary:",
         brief.record.summary,
@@ -134,10 +145,13 @@ def format_generated_brief(brief: GeneratedBrief) -> str:
     ]
 
     for line in brief.evidence_lines:
-        page_label = f"p. {line.page_start}"
-        if line.page_end != line.page_start:
-            page_label = f"pp. {line.page_start}-{line.page_end}"
-        lines.append(f"- {line.item_type}: {line.label} — {page_label} — {line.quote}")
+        location_label = format_evidence_location(
+            location_type=line.location_type,
+            location_label=line.location_label,
+            page_start=line.page_start,
+            page_end=line.page_end,
+        )
+        lines.append(f"- {line.item_type}: {line.label} — {location_label} — {line.quote}")
 
     lines.extend(["", "Open Questions:"])
     if brief.record.open_questions:
@@ -163,29 +177,27 @@ def _load_document_context(database_path: Path, document_id: str) -> BriefDocume
         connection.row_factory = sqlite3.Row
         row = connection.execute(
             """
-            SELECT
-                documents.id,
-                documents.title,
-                documents.metadata_json,
-                COUNT(pages.id) AS page_count,
-                COALESCE(SUM(LENGTH(pages.text)), 0) AS text_length
+            SELECT id, title, metadata_json
             FROM documents
-            LEFT JOIN pages ON pages.document_id = documents.id
-            WHERE documents.id = ?
-            GROUP BY documents.id
+            WHERE id = ?
             """,
             (document_id,),
         ).fetchone()
-
-    if row is None:
-        raise BriefError(f"Unknown document: {document_id}")
+        if row is None:
+            raise BriefError(f"Unknown document: {document_id}")
+        try:
+            extent = load_document_extent(connection, document_id)
+        except SourceLocationError as exc:
+            raise BriefError(str(exc)) from exc
 
     return BriefDocumentContext(
         id=str(row["id"]),
         title=_optional_string(row["title"]),
         metadata=_load_metadata(row["metadata_json"]),
-        page_count=int(row["page_count"]),
-        text_length=int(row["text_length"]),
+        source_type=extent.source_type,
+        extent_type=extent.extent_type,
+        extent_count=extent.extent_count,
+        text_length=extent.text_length,
     )
 
 
@@ -203,7 +215,7 @@ def _select_notable_items(items: list[DiscoveryItemRecord]) -> tuple[DiscoveryIt
         key=lambda item: (
             _ITEM_PRIORITY.get(item.item_type, 99),
             -(item.confidence or 0.0),
-            item.evidence[0].page_start,
+            _evidence_order(item.evidence[0]),
             item.label.casefold(),
         )
     )
@@ -301,12 +313,23 @@ def _labels_by_type(items: tuple[DiscoveryItemRecord, ...]) -> dict[str, tuple[s
     return {key: tuple(value) for key, value in labels.items()}
 
 
+def _evidence_order(evidence: DiscoveryEvidenceRecord) -> tuple[int, int, str]:
+    if evidence.page_start is not None:
+        return (0, evidence.page_start, evidence.source_unit_start_id)
+    block_suffix = evidence.location_label.rpartition("block ")[2]
+    if block_suffix.isdigit():
+        return (1, int(block_suffix), evidence.source_unit_start_id)
+    return (2, 0, evidence.source_unit_start_id)
+
+
 def _item_to_evidence_line(item: DiscoveryItemRecord) -> BriefEvidenceLine:
     evidence = item.evidence[0]
     return BriefEvidenceLine(
         item_type=item.item_type,
         label=item.label,
         summary=item.summary,
+        location_type=evidence.location_type,
+        location_label=evidence.location_label,
         page_start=evidence.page_start,
         page_end=evidence.page_end,
         quote=evidence.quote,

--- a/newsrag/discovery.py
+++ b/newsrag/discovery.py
@@ -8,6 +8,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from newsrag.source_locations import (
+    ResolvedSourceRange,
+    SourceLocationError,
+    load_document_extent,
+    resolve_source_range,
+    validate_evidence_quote,
+)
+
 
 class DiscoveryError(Exception):
     """Raised when discovery records cannot be persisted or loaded."""
@@ -19,7 +27,9 @@ class DocumentProfileRecord:
 
     id: str
     document_id: str
-    page_count: int
+    source_type: str
+    extent_type: str
+    extent_count: int
     text_length: int
     extraction_quality: dict[str, Any]
     extractor: str
@@ -51,11 +61,10 @@ class DiscoveryEvidenceDraft:
     """Evidence reference to persist for one discovery item."""
 
     document_id: str
-    page_start: int
-    page_end: int
+    source_unit_start_id: str
+    source_unit_end_id: str
     quote: str
     validation_status: str
-    page_id: str | None = None
     passage_id: str | None = None
 
 
@@ -66,10 +75,14 @@ class DiscoveryEvidenceRecord:
     id: str
     item_id: str
     document_id: str
+    source_unit_start_id: str
+    source_unit_end_id: str
+    location_type: str
+    location_label: str
     page_id: str | None
     passage_id: str | None
-    page_start: int
-    page_end: int
+    page_start: int | None
+    page_end: int | None
     quote: str
     validation_status: str
     created_at: str
@@ -97,7 +110,6 @@ def create_document_profile(
     database_path: Path,
     *,
     document_id: str,
-    page_count: int,
     text_length: int,
     extraction_quality: dict[str, Any] | None = None,
     extractor: str,
@@ -109,8 +121,6 @@ def create_document_profile(
 
     _validate_non_empty(document_id, field_name="document_id")
     _validate_non_empty(extractor, field_name="extractor")
-    if page_count < 0:
-        raise DiscoveryError("page_count must be zero or greater")
     if text_length < 0:
         raise DiscoveryError("text_length must be zero or greater")
 
@@ -118,21 +128,29 @@ def create_document_profile(
     quality_json = _dump_json_object(extraction_quality or {}, field_name="extraction_quality")
 
     with sqlite3.connect(database_path) as connection:
+        try:
+            extent = load_document_extent(connection, document_id)
+        except SourceLocationError as exc:
+            raise DiscoveryError(str(exc)) from exc
         connection.execute(
             """
             INSERT INTO document_profiles(
                 id,
                 document_id,
-                page_count,
+                source_type,
+                extent_type,
+                extent_count,
                 text_length,
                 extraction_quality_json,
                 extractor,
                 provider,
                 model
             )
-            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(document_id) DO UPDATE SET
-                page_count = excluded.page_count,
+                source_type = excluded.source_type,
+                extent_type = excluded.extent_type,
+                extent_count = excluded.extent_count,
                 text_length = excluded.text_length,
                 extraction_quality_json = excluded.extraction_quality_json,
                 extractor = excluded.extractor,
@@ -143,7 +161,9 @@ def create_document_profile(
             (
                 resolved_profile_id,
                 document_id,
-                page_count,
+                extent.source_type,
+                extent.extent_type,
+                extent.extent_count,
                 text_length,
                 quality_json,
                 extractor.strip(),
@@ -166,7 +186,9 @@ def get_document_profile(database_path: Path, document_id: str) -> DocumentProfi
             SELECT
                 id,
                 document_id,
-                page_count,
+                source_type,
+                extent_type,
+                extent_count,
                 text_length,
                 extraction_quality_json,
                 extractor,
@@ -344,6 +366,21 @@ def create_discovery_item(
     value_json = _dump_json_object(value or {}, field_name="value")
 
     with sqlite3.connect(database_path) as connection:
+        resolved_evidence: list[ResolvedSourceRange] = []
+        try:
+            for draft in evidence:
+                resolved = resolve_source_range(
+                    connection,
+                    document_id=document_id,
+                    source_unit_start_id=draft.source_unit_start_id,
+                    source_unit_end_id=draft.source_unit_end_id,
+                    passage_id=draft.passage_id,
+                )
+                validate_evidence_quote(resolved, draft.quote)
+                resolved_evidence.append(resolved)
+        except SourceLocationError as exc:
+            raise DiscoveryError(str(exc)) from exc
+
         connection.execute(
             """
             INSERT INTO discovery_items(
@@ -386,6 +423,10 @@ def create_discovery_item(
                 id,
                 item_id,
                 document_id,
+                source_unit_start_id,
+                source_unit_end_id,
+                location_type,
+                location_label,
                 page_id,
                 passage_id,
                 page_start,
@@ -393,21 +434,25 @@ def create_discovery_item(
                 quote,
                 validation_status
             )
-            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
                 (
                     f"evidence-{uuid.uuid4().hex[:8]}",
                     resolved_item_id,
                     draft.document_id,
-                    draft.page_id,
-                    draft.passage_id,
-                    draft.page_start,
-                    draft.page_end,
+                    resolved.source_unit_start_id,
+                    resolved.source_unit_end_id,
+                    resolved.location_type,
+                    resolved.location_label,
+                    resolved.page_id,
+                    resolved.passage_id,
+                    resolved.page_start,
+                    resolved.page_end,
                     draft.quote,
                     draft.validation_status.strip(),
                 )
-                for draft in evidence
+                for draft, resolved in zip(evidence, resolved_evidence, strict=True)
             ],
         )
         connection.commit()
@@ -480,6 +525,10 @@ def list_discovery_items(
                     id,
                     item_id,
                     document_id,
+                    source_unit_start_id,
+                    source_unit_end_id,
+                    location_type,
+                    location_label,
                     page_id,
                     passage_id,
                     page_start,
@@ -529,10 +578,14 @@ def _validate_evidence_draft(
     _validate_non_empty(draft.validation_status, field_name="evidence.validation_status")
     if draft.document_id != item_document_id:
         raise DiscoveryError("evidence.document_id must match discovery item document_id")
-    if draft.page_start < 1:
-        raise DiscoveryError("evidence.page_start must be 1 or greater")
-    if draft.page_end < draft.page_start:
-        raise DiscoveryError("evidence.page_end must be greater than or equal to page_start")
+    _validate_non_empty(
+        draft.source_unit_start_id,
+        field_name="evidence.source_unit_start_id",
+    )
+    _validate_non_empty(
+        draft.source_unit_end_id,
+        field_name="evidence.source_unit_end_id",
+    )
 
 
 def _dump_json_object(value: dict[str, Any], *, field_name: str) -> str:
@@ -572,7 +625,9 @@ def _row_to_document_profile(row: sqlite3.Row) -> DocumentProfileRecord:
     return DocumentProfileRecord(
         id=str(row["id"]),
         document_id=str(row["document_id"]),
-        page_count=int(row["page_count"]),
+        source_type=str(row["source_type"]),
+        extent_type=str(row["extent_type"]),
+        extent_count=int(row["extent_count"]),
         text_length=int(row["text_length"]),
         extraction_quality=_load_json_object(row["extraction_quality_json"]),
         extractor=str(row["extractor"]),
@@ -604,10 +659,14 @@ def _row_to_discovery_evidence(row: sqlite3.Row) -> DiscoveryEvidenceRecord:
         id=str(row["id"]),
         item_id=str(row["item_id"]),
         document_id=str(row["document_id"]),
+        source_unit_start_id=str(row["source_unit_start_id"]),
+        source_unit_end_id=str(row["source_unit_end_id"]),
+        location_type=str(row["location_type"]),
+        location_label=str(row["location_label"]),
         page_id=str(row["page_id"]) if row["page_id"] is not None else None,
         passage_id=str(row["passage_id"]) if row["passage_id"] is not None else None,
-        page_start=int(row["page_start"]),
-        page_end=int(row["page_end"]),
+        page_start=int(row["page_start"]) if row["page_start"] is not None else None,
+        page_end=int(row["page_end"]) if row["page_end"] is not None else None,
         quote=str(row["quote"]),
         validation_status=str(row["validation_status"]),
         created_at=str(row["created_at"]),

--- a/newsrag/discovery_browse.py
+++ b/newsrag/discovery_browse.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from newsrag.discovery import DiscoveryEvidenceRecord, DiscoveryItemRecord
+from newsrag.source_locations import format_evidence_location
 
 DEFAULT_DISCOVERY_LIST_LIMIT = 50
 MAX_DISCOVERY_LIST_LIMIT = 500
@@ -368,6 +369,10 @@ def _load_evidence_for_rows(
             id,
             item_id,
             document_id,
+            source_unit_start_id,
+            source_unit_end_id,
+            location_type,
+            location_label,
             page_id,
             passage_id,
             page_start,
@@ -422,10 +427,14 @@ def _row_to_evidence(row: sqlite3.Row) -> DiscoveryEvidenceRecord:
         id=str(row["id"]),
         item_id=str(row["item_id"]),
         document_id=str(row["document_id"]),
+        source_unit_start_id=str(row["source_unit_start_id"]),
+        source_unit_end_id=str(row["source_unit_end_id"]),
+        location_type=str(row["location_type"]),
+        location_label=str(row["location_label"]),
         page_id=str(row["page_id"]) if row["page_id"] is not None else None,
         passage_id=str(row["passage_id"]) if row["passage_id"] is not None else None,
-        page_start=int(row["page_start"]),
-        page_end=int(row["page_end"]),
+        page_start=int(row["page_start"]) if row["page_start"] is not None else None,
+        page_end=int(row["page_end"]) if row["page_end"] is not None else None,
         quote=str(row["quote"]),
         validation_status=str(row["validation_status"]),
         created_at=str(row["created_at"]),
@@ -489,11 +498,14 @@ def _first_citation(item: DiscoveryItemRecord) -> str | None:
 
 
 def _format_evidence_reference(evidence: DiscoveryEvidenceRecord) -> str:
-    if evidence.page_start == evidence.page_end:
-        page_label = f"p.{evidence.page_start}"
-    else:
-        page_label = f"pp.{evidence.page_start}-{evidence.page_end}"
-    return f"{evidence.document_id} {page_label}"
+    location_label = format_evidence_location(
+        location_type=evidence.location_type,
+        location_label=evidence.location_label,
+        page_start=evidence.page_start,
+        page_end=evidence.page_end,
+        compact_pdf=True,
+    )
+    return f"{evidence.document_id} {location_label}"
 
 
 def _best_source(item: DiscoveryBrowseItem) -> str | None:

--- a/newsrag/enrichment.py
+++ b/newsrag/enrichment.py
@@ -14,6 +14,12 @@ from newsrag.discovery import (
     create_discovery_item,
     create_document_brief,
 )
+from newsrag.source_locations import (
+    ResolvedSourceRange,
+    SourceLocationError,
+    format_evidence_location,
+    resolve_source_range,
+)
 
 ENRICHMENT_EXTRACTOR = "structured-llm-enrichment"
 SUMMARY_ITEM_TYPE = "summary"
@@ -31,9 +37,13 @@ class EvidenceContext:
     """Page or passage text available for quote validation."""
 
     document_id: str
-    page_start: int
-    page_end: int
+    source_unit_start_id: str
+    source_unit_end_id: str
+    location_type: str
+    location_label: str
     text: str
+    page_start: int | None = None
+    page_end: int | None = None
     page_id: str | None = None
     passage_id: str | None = None
 
@@ -178,10 +188,17 @@ def format_enrichment_result(result: EnrichmentResult) -> str:
         "items:",
     ]
     for item in result.items:
-        page_label = ""
+        location = ""
         if item.evidence:
-            page_label = f" p.{item.evidence[0].page_start}"
-        lines.append(f"- {item.item_type}: {item.label}{page_label}")
+            evidence = item.evidence[0]
+            location = " " + format_evidence_location(
+                location_type=evidence.location_type,
+                location_label=evidence.location_label,
+                page_start=evidence.page_start,
+                page_end=evidence.page_end,
+                compact_pdf=True,
+            )
+        lines.append(f"- {item.item_type}: {item.label}{location}")
     return "\n".join(lines)
 
 
@@ -215,47 +232,47 @@ def _build_enrichment_request(database_path: Path, document_id: str) -> Enrichme
         if document_row is None:
             raise EnrichmentError(f"Unknown document: {document_id}")
 
-        page_rows = connection.execute(
+        source_unit_rows = connection.execute(
             """
-            SELECT id, page_number, text
-            FROM pages
+            SELECT id
+            FROM source_units
             WHERE document_id = ?
-            ORDER BY page_number ASC, id ASC
+            ORDER BY ordinal ASC, id ASC
             """,
             (document_id,),
         ).fetchall()
         passage_rows = connection.execute(
             """
-            SELECT id, page_start, page_end, text
+            SELECT id
             FROM passages
-            WHERE document_id = ?
+            WHERE document_id = ? AND source_unit_start_id IS NOT NULL
             ORDER BY page_start ASC, ordinal ASC, id ASC
             """,
             (document_id,),
         ).fetchall()
+        contexts: list[EvidenceContext] = []
+        try:
+            for row in source_unit_rows:
+                source_unit_id = str(row["id"])
+                resolved = resolve_source_range(
+                    connection,
+                    document_id=document_id,
+                    source_unit_start_id=source_unit_id,
+                    source_unit_end_id=source_unit_id,
+                )
+                contexts.append(_resolved_to_evidence_context(resolved))
+            for row in passage_rows:
+                passage_id = str(row["id"])
+                resolved = resolve_source_range(
+                    connection,
+                    document_id=document_id,
+                    source_unit_start_id=None,
+                    passage_id=passage_id,
+                )
+                contexts.append(_resolved_to_evidence_context(resolved))
+        except SourceLocationError as exc:
+            raise EnrichmentError(str(exc)) from exc
 
-    contexts = [
-        EvidenceContext(
-            document_id=document_id,
-            page_id=str(row["id"]),
-            page_start=int(row["page_number"]),
-            page_end=int(row["page_number"]),
-            text=str(row["text"]),
-        )
-        for row in page_rows
-        if str(row["text"]).strip()
-    ]
-    contexts.extend(
-        EvidenceContext(
-            document_id=document_id,
-            passage_id=str(row["id"]),
-            page_start=int(row["page_start"]),
-            page_end=int(row["page_end"]),
-            text=str(row["text"]),
-        )
-        for row in passage_rows
-        if str(row["text"]).strip()
-    )
     if not contexts:
         raise EnrichmentError(f"Document {document_id} has no text available for enrichment")
 
@@ -264,6 +281,21 @@ def _build_enrichment_request(database_path: Path, document_id: str) -> Enrichme
         title=_optional_string(document_row["title"]),
         metadata=_load_metadata(document_row["metadata_json"]),
         evidence_contexts=tuple(contexts),
+    )
+
+
+def _resolved_to_evidence_context(resolved: ResolvedSourceRange) -> EvidenceContext:
+    return EvidenceContext(
+        document_id=resolved.document_id,
+        source_unit_start_id=resolved.source_unit_start_id,
+        source_unit_end_id=resolved.source_unit_end_id,
+        location_type=resolved.location_type,
+        location_label=resolved.location_label,
+        text=resolved.text,
+        page_start=resolved.page_start,
+        page_end=resolved.page_end,
+        page_id=resolved.page_id,
+        passage_id=resolved.passage_id,
     )
 
 
@@ -336,16 +368,16 @@ def _validate_evidence_object(
 ) -> DiscoveryEvidenceDraft:
     if not isinstance(value, dict):
         raise EnrichmentError(f"{field_name} evidence entries must be objects")
-    page_start = _required_int(value, "page_start")
-    page_end = _optional_int(value, "page_end") or page_start
-    if page_start < 1 or page_end < page_start:
-        raise EnrichmentError(f"{field_name} evidence page range is invalid")
+    source_unit_start_id = _optional_string(value.get("source_unit_start_id"))
+    source_unit_end_id = _optional_string(value.get("source_unit_end_id")) or source_unit_start_id
     quote = _required_string(value, "quote")
     passage_id = _optional_string(value.get("passage_id"))
+    if source_unit_start_id is None and passage_id is None:
+        raise EnrichmentError(f"{field_name} evidence requires source_unit_start_id or passage_id")
     context = _find_supporting_context(
         request.evidence_contexts,
-        page_start=page_start,
-        page_end=page_end,
+        source_unit_start_id=source_unit_start_id,
+        source_unit_end_id=source_unit_end_id,
         quote=quote,
         passage_id=passage_id,
     )
@@ -356,10 +388,9 @@ def _validate_evidence_object(
 
     return DiscoveryEvidenceDraft(
         document_id=request.document_id,
-        page_id=context.page_id,
+        source_unit_start_id=context.source_unit_start_id,
+        source_unit_end_id=context.source_unit_end_id,
         passage_id=context.passage_id,
-        page_start=page_start,
-        page_end=page_end,
         quote=quote,
         validation_status=VALIDATION_STATUS_VALIDATED,
     )
@@ -368,8 +399,8 @@ def _validate_evidence_object(
 def _find_supporting_context(
     contexts: Sequence[EvidenceContext],
     *,
-    page_start: int,
-    page_end: int,
+    source_unit_start_id: str | None,
+    source_unit_end_id: str | None,
     quote: str,
     passage_id: str | None,
 ) -> EvidenceContext | None:
@@ -377,7 +408,12 @@ def _find_supporting_context(
     for context in contexts:
         if passage_id is not None and context.passage_id != passage_id:
             continue
-        if context.page_start > page_end or context.page_end < page_start:
+        if (
+            source_unit_start_id is not None
+            and context.source_unit_start_id != source_unit_start_id
+        ):
+            continue
+        if source_unit_end_id is not None and context.source_unit_end_id != source_unit_end_id:
             continue
         if normalized_quote in _normalize_for_match(context.text):
             return context
@@ -408,22 +444,6 @@ def _required_string(payload: Mapping[str, object], key: str) -> str:
     if resolved is None:
         raise EnrichmentError(f"Provider response field '{key}' must be a non-empty string")
     return resolved
-
-
-def _required_int(payload: Mapping[str, object], key: str) -> int:
-    value = payload.get(key)
-    if not isinstance(value, int):
-        raise EnrichmentError(f"Provider response field '{key}' must be an integer")
-    return value
-
-
-def _optional_int(payload: Mapping[str, object], key: str) -> int | None:
-    value = payload.get(key)
-    if value is None:
-        return None
-    if not isinstance(value, int):
-        raise EnrichmentError(f"Provider response field '{key}' must be an integer")
-    return value
 
 
 def _validate_string_list_item(value: object, *, field_name: str) -> str:

--- a/newsrag/facts.py
+++ b/newsrag/facts.py
@@ -14,6 +14,11 @@ from newsrag.discovery import (
     create_discovery_item,
     list_discovery_items,
 )
+from newsrag.source_locations import (
+    SourceLocationError,
+    format_evidence_location,
+    resolve_source_range,
+)
 
 DETERMINISTIC_FACT_EXTRACTOR = "deterministic-civic-facts"
 DETERMINISTIC_FACT_PROVIDER = "rules"
@@ -136,9 +141,8 @@ class FactSource:
 
     document_id: str
     text: str
-    page_start: int
-    page_end: int
-    page_id: str | None = None
+    source_unit_start_id: str
+    source_unit_end_id: str
     passage_id: str | None = None
 
 
@@ -174,7 +178,7 @@ def extract_facts_from_sources(sources: Sequence[FactSource]) -> list[FactDraft]
     """Extract high-confidence civic fact drafts from source text."""
 
     drafts: list[FactDraft] = []
-    seen: set[tuple[str, str, int, str]] = set()
+    seen: set[tuple[str, str, str, str]] = set()
     for source in sources:
         source_text = _normalize_space(source.text)
         if not source_text:
@@ -265,7 +269,13 @@ def format_fact_extraction_result(result: FactExtractionResult) -> str:
         citation = ""
         if item.evidence:
             evidence = item.evidence[0]
-            citation = f" p.{evidence.page_start}"
+            citation = " " + format_evidence_location(
+                location_type=evidence.location_type,
+                location_label=evidence.location_label,
+                page_start=evidence.page_start,
+                page_end=evidence.page_end,
+                compact_pdf=True,
+            )
         lines.append(f"- {item.item_type}: {item.label} confidence={item.confidence:.2f}{citation}")
     return "\n".join(lines)
 
@@ -281,24 +291,35 @@ def _load_document_sources(database_path: Path, document_id: str) -> tuple[FactS
             raise FactExtractionError(f"Unknown document: {document_id}")
         rows = connection.execute(
             """
-            SELECT id, document_id, page_number, text
-            FROM pages
+            SELECT id
+            FROM source_units
             WHERE document_id = ?
-            ORDER BY page_number ASC, id ASC
+            ORDER BY ordinal ASC, id ASC
             """,
             (document_id,),
         ).fetchall()
+        sources: list[FactSource] = []
+        try:
+            for row in rows:
+                source_unit_id = str(row["id"])
+                resolved = resolve_source_range(
+                    connection,
+                    document_id=document_id,
+                    source_unit_start_id=source_unit_id,
+                    source_unit_end_id=source_unit_id,
+                )
+                sources.append(
+                    FactSource(
+                        document_id=document_id,
+                        text=resolved.text,
+                        source_unit_start_id=resolved.source_unit_start_id,
+                        source_unit_end_id=resolved.source_unit_end_id,
+                    )
+                )
+        except SourceLocationError as exc:
+            raise FactExtractionError(str(exc)) from exc
 
-    return tuple(
-        FactSource(
-            document_id=str(row["document_id"]),
-            text=str(row["text"]),
-            page_start=int(row["page_number"]),
-            page_end=int(row["page_number"]),
-            page_id=str(row["id"]),
-        )
-        for row in rows
-    )
+    return tuple(sources)
 
 
 def _extract_regex_facts(source: FactSource) -> Iterable[FactDraft]:
@@ -459,10 +480,9 @@ def _fact_draft(
         confidence=confidence,
         evidence=DiscoveryEvidenceDraft(
             document_id=source.document_id,
-            page_id=source.page_id,
+            source_unit_start_id=source.source_unit_start_id,
+            source_unit_end_id=source.source_unit_end_id,
             passage_id=source.passage_id,
-            page_start=source.page_start,
-            page_end=source.page_end,
             quote=_normalize_space(quote),
             validation_status=VALIDATION_STATUS_VALIDATED,
         ),
@@ -478,7 +498,7 @@ def _iter_sentences(source: FactSource) -> Iterable[str]:
 
 def _append_unique(
     drafts: list[FactDraft],
-    seen: set[tuple[str, str, int, str]],
+    seen: set[tuple[str, str, str, str]],
     draft: FactDraft,
 ) -> None:
     key = _fact_key(draft)
@@ -488,18 +508,18 @@ def _append_unique(
     drafts.append(draft)
 
 
-def _fact_key(draft: FactDraft) -> tuple[str, str, int, str]:
+def _fact_key(draft: FactDraft) -> tuple[str, str, str, str]:
     if draft.item_type in {"entity", "topic"}:
-        return (draft.item_type, draft.label.casefold(), 0, "")
+        return (draft.item_type, draft.label.casefold(), "", "")
     return (
         draft.item_type,
         draft.label.casefold(),
-        draft.evidence.page_start,
+        draft.evidence.source_unit_start_id,
         draft.evidence.quote.casefold(),
     )
 
 
-def _existing_fact_keys(database_path: Path, document_id: str) -> set[tuple[str, str, int, str]]:
+def _existing_fact_keys(database_path: Path, document_id: str) -> set[tuple[str, str, str, str]]:
     existing = list_discovery_items(database_path, document_id=document_id)
     keys = set()
     for item in existing:
@@ -507,13 +527,13 @@ def _existing_fact_keys(database_path: Path, document_id: str) -> set[tuple[str,
             continue
         for evidence in item.evidence:
             if item.item_type in {"entity", "topic"}:
-                keys.add((item.item_type, item.label.casefold(), 0, ""))
+                keys.add((item.item_type, item.label.casefold(), "", ""))
             else:
                 keys.add(
                     (
                         item.item_type,
                         item.label.casefold(),
-                        evidence.page_start,
+                        evidence.source_unit_start_id,
                         evidence.quote.casefold(),
                     )
                 )

--- a/newsrag/source_locations.py
+++ b/newsrag/source_locations.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+
+from newsrag.sources import (
+    HTML_BLOCK_LOCATION_TYPE,
+    PAGE_LOCATION_TYPE,
+    SOURCE_TYPE_HTML,
+    SOURCE_TYPE_PDF,
+    source_type_for_media_type,
+)
+
+
+class SourceLocationError(Exception):
+    """Raised when typed source evidence cannot be resolved or validated."""
+
+
+@dataclass(frozen=True)
+class DocumentExtent:
+    """Source-appropriate extent and text size for one document."""
+
+    source_type: str
+    extent_type: str
+    extent_count: int
+    text_length: int
+
+
+@dataclass(frozen=True)
+class ResolvedSourceRange:
+    """Validated canonical source-unit range for one evidence reference."""
+
+    document_id: str
+    source_unit_start_id: str
+    source_unit_end_id: str
+    location_type: str
+    location_label: str
+    text: str
+    page_id: str | None = None
+    passage_id: str | None = None
+    page_start: int | None = None
+    page_end: int | None = None
+
+
+def load_document_extent(
+    connection: sqlite3.Connection,
+    document_id: str,
+) -> DocumentExtent:
+    """Load a typed document extent from its immutable source units."""
+
+    row = connection.execute(
+        """
+        SELECT source_artifacts.media_type
+        FROM documents
+        JOIN source_artifacts ON source_artifacts.id = documents.artifact_id
+        WHERE documents.id = ?
+        """,
+        (document_id,),
+    ).fetchone()
+    if row is None:
+        raise SourceLocationError(f"Unknown document or published artifact: {document_id}")
+
+    source_type = source_type_for_media_type(str(row[0]))
+    if source_type == SOURCE_TYPE_PDF:
+        location_type = PAGE_LOCATION_TYPE
+        extent_type = "pages"
+    elif source_type == SOURCE_TYPE_HTML:
+        location_type = HTML_BLOCK_LOCATION_TYPE
+        extent_type = "blocks"
+    else:
+        raise SourceLocationError(f"Unsupported source type for document: {document_id}")
+
+    extent_row = connection.execute(
+        """
+        SELECT COUNT(*), COALESCE(SUM(LENGTH(normalized_text)), 0)
+        FROM source_units
+        WHERE document_id = ? AND location_type = ?
+        """,
+        (document_id, location_type),
+    ).fetchone()
+    extent_count = int(extent_row[0]) if extent_row is not None else 0
+    text_length = int(extent_row[1]) if extent_row is not None else 0
+    return DocumentExtent(
+        source_type=source_type,
+        extent_type=extent_type,
+        extent_count=extent_count,
+        text_length=text_length,
+    )
+
+
+def resolve_source_range(
+    connection: sqlite3.Connection,
+    *,
+    document_id: str,
+    source_unit_start_id: str | None,
+    source_unit_end_id: str | None = None,
+    passage_id: str | None = None,
+) -> ResolvedSourceRange:
+    """Resolve and validate a typed source-unit range, optionally through a passage."""
+
+    passage_text: str | None = None
+    resolved_start_id = _optional_string(source_unit_start_id)
+    resolved_end_id = _optional_string(source_unit_end_id)
+    resolved_passage_id = _optional_string(passage_id)
+    if resolved_passage_id is not None:
+        passage_row = connection.execute(
+            """
+            SELECT document_id, source_unit_start_id, source_unit_end_id, text
+            FROM passages
+            WHERE id = ?
+            """,
+            (resolved_passage_id,),
+        ).fetchone()
+        if passage_row is None or str(passage_row[0]) != document_id:
+            raise SourceLocationError("Evidence passage does not belong to the document")
+        passage_start_id = _optional_string(passage_row[1])
+        passage_end_id = _optional_string(passage_row[2]) or passage_start_id
+        if passage_start_id is None or passage_end_id is None:
+            raise SourceLocationError("Evidence passage has no typed source-unit range")
+        if resolved_start_id is not None and resolved_start_id != passage_start_id:
+            raise SourceLocationError("Evidence source-unit range does not match its passage")
+        if resolved_end_id is not None and resolved_end_id != passage_end_id:
+            raise SourceLocationError("Evidence source-unit range does not match its passage")
+        resolved_start_id = passage_start_id
+        resolved_end_id = passage_end_id
+        passage_text = str(passage_row[3])
+
+    if resolved_start_id is None:
+        raise SourceLocationError("Evidence requires a source-unit start ID or typed passage")
+    if resolved_end_id is None:
+        resolved_end_id = resolved_start_id
+
+    unit_rows = connection.execute(
+        """
+        SELECT id, ordinal, location_type, location_json, structure_json
+        FROM source_units
+        WHERE document_id = ? AND id IN (?, ?)
+        """,
+        (document_id, resolved_start_id, resolved_end_id),
+    ).fetchall()
+    units = {str(row[0]): row for row in unit_rows}
+    start_unit = units.get(resolved_start_id)
+    end_unit = units.get(resolved_end_id)
+    if start_unit is None or end_unit is None:
+        raise SourceLocationError("Evidence source units do not belong to the document")
+
+    start_ordinal = int(start_unit[1])
+    end_ordinal = int(end_unit[1])
+    if end_ordinal < start_ordinal:
+        raise SourceLocationError("Evidence source-unit range is reversed")
+    location_type = str(start_unit[2])
+    if str(end_unit[2]) != location_type:
+        raise SourceLocationError("Evidence source-unit range mixes location types")
+
+    range_rows = connection.execute(
+        """
+        SELECT id, location_type, normalized_text
+        FROM source_units
+        WHERE document_id = ? AND ordinal BETWEEN ? AND ?
+        ORDER BY ordinal ASC
+        """,
+        (document_id, start_ordinal, end_ordinal),
+    ).fetchall()
+    if not range_rows or any(str(row[1]) != location_type for row in range_rows):
+        raise SourceLocationError("Evidence source-unit range is incomplete")
+    range_text = "\n".join(str(row[2]) for row in range_rows)
+
+    page_id: str | None = None
+    page_start: int | None = None
+    page_end: int | None = None
+    if location_type == PAGE_LOCATION_TYPE:
+        page_start = _positive_location_number(start_unit[3], "page_number")
+        page_end = _positive_location_number(end_unit[3], "page_number")
+        if page_end < page_start:
+            raise SourceLocationError("Evidence page range is reversed")
+        page_rows = connection.execute(
+            """
+            SELECT pages.id, pages.page_number, pages.source_unit_id
+            FROM pages
+            JOIN source_units ON source_units.id = pages.source_unit_id
+            WHERE pages.document_id = ? AND source_units.ordinal BETWEEN ? AND ?
+            ORDER BY source_units.ordinal ASC
+            """,
+            (document_id, start_ordinal, end_ordinal),
+        ).fetchall()
+        if len(page_rows) != len(range_rows):
+            raise SourceLocationError("PDF source-unit range is missing linked page records")
+        if int(page_rows[0][1]) != page_start or int(page_rows[-1][1]) != page_end:
+            raise SourceLocationError("PDF source-unit locations do not match linked pages")
+        location_label = (
+            f"p. {page_start}" if page_start == page_end else f"pp. {page_start}-{page_end}"
+        )
+        if resolved_start_id == resolved_end_id:
+            page_id = str(page_rows[0][0])
+    elif location_type == HTML_BLOCK_LOCATION_TYPE:
+        block_start = _positive_location_number(start_unit[3], "block_number")
+        block_end = _positive_location_number(end_unit[3], "block_number")
+        if block_end < block_start:
+            raise SourceLocationError("Evidence HTML block range is reversed")
+        structure = _load_json_object(start_unit[4])
+        heading_path = _string_tuple(structure.get("heading_path"))
+        block_label = (
+            f"block {block_start}"
+            if block_start == block_end
+            else f"blocks {block_start}–{block_end}"
+        )
+        location_label = " — ".join((*heading_path, block_label))
+    else:
+        raise SourceLocationError(f"Unsupported evidence location type: {location_type}")
+
+    return ResolvedSourceRange(
+        document_id=document_id,
+        source_unit_start_id=resolved_start_id,
+        source_unit_end_id=resolved_end_id,
+        location_type=location_type,
+        location_label=location_label,
+        text=passage_text or range_text,
+        page_id=page_id,
+        passage_id=resolved_passage_id,
+        page_start=page_start,
+        page_end=page_end,
+    )
+
+
+def validate_evidence_quote(resolved: ResolvedSourceRange, quote: str) -> None:
+    """Require one quote to occur in its cited canonical source or passage text."""
+
+    normalized_quote = _normalize_for_match(quote)
+    if not normalized_quote or normalized_quote not in _normalize_for_match(resolved.text):
+        raise SourceLocationError("Evidence quote was not found in cited source text")
+
+
+def format_evidence_location(
+    *,
+    location_type: str,
+    location_label: str,
+    page_start: int | None,
+    page_end: int | None,
+    compact_pdf: bool = False,
+) -> str:
+    """Format a stored typed evidence location while preserving PDF styles."""
+
+    if location_type != PAGE_LOCATION_TYPE:
+        return location_label
+    if page_start is None or page_end is None:
+        return location_label
+    separator = "" if compact_pdf else " "
+    if page_start == page_end:
+        return f"p.{separator}{page_start}"
+    return f"pp.{separator}{page_start}-{page_end}"
+
+
+def _positive_location_number(raw_json: object, key: str) -> int:
+    value = _load_json_object(raw_json).get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise SourceLocationError(f"Invalid source-unit {key}")
+    return value
+
+
+def _load_json_object(raw_value: object) -> dict[str, object]:
+    try:
+        value = json.loads(str(raw_value))
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(value, dict):
+        return {}
+    return value
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(item.strip() for item in value if isinstance(item, str) and item.strip())
+
+
+def _optional_string(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _normalize_for_match(value: str) -> str:
+    return " ".join(value.casefold().split())

--- a/newsrag/storage.py
+++ b/newsrag/storage.py
@@ -83,7 +83,7 @@ DIRECTORY_NAMES: tuple[tuple[str, str], ...] = (
     ("artifact_staging", "artifacts/staging"),
 )
 DATABASE_FILENAME = "newsrag.sqlite3"
-SCHEMA_VERSION = "4"
+SCHEMA_VERSION = "5"
 REQUIRED_TABLES = {
     "sources",
     "source_artifacts",
@@ -281,7 +281,9 @@ SCHEMA_STATEMENTS = (
     CREATE TABLE IF NOT EXISTS document_profiles (
         id TEXT PRIMARY KEY,
         document_id TEXT NOT NULL UNIQUE,
-        page_count INTEGER NOT NULL,
+        source_type TEXT NOT NULL,
+        extent_type TEXT NOT NULL,
+        extent_count INTEGER NOT NULL,
         text_length INTEGER NOT NULL,
         extraction_quality_json TEXT NOT NULL DEFAULT '{}',
         extractor TEXT NOT NULL,
@@ -343,15 +345,21 @@ SCHEMA_STATEMENTS = (
         id TEXT PRIMARY KEY,
         item_id TEXT NOT NULL,
         document_id TEXT NOT NULL,
+        source_unit_start_id TEXT NOT NULL,
+        source_unit_end_id TEXT NOT NULL,
+        location_type TEXT NOT NULL,
+        location_label TEXT NOT NULL,
         page_id TEXT,
         passage_id TEXT,
-        page_start INTEGER NOT NULL,
-        page_end INTEGER NOT NULL,
+        page_start INTEGER,
+        page_end INTEGER,
         quote TEXT NOT NULL DEFAULT '',
         validation_status TEXT NOT NULL,
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY(item_id) REFERENCES discovery_items(id),
         FOREIGN KEY(document_id) REFERENCES documents(id),
+        FOREIGN KEY(source_unit_start_id) REFERENCES source_units(id),
+        FOREIGN KEY(source_unit_end_id) REFERENCES source_units(id),
         FOREIGN KEY(page_id) REFERENCES pages(id),
         FOREIGN KEY(passage_id) REFERENCES passages(id)
     )
@@ -548,11 +556,11 @@ def _iter_directories(paths: StoragePaths) -> tuple[Path, ...]:
 def _initialize_database(database_path: Path) -> tuple[bool, tuple[str, ...]]:
     with sqlite3.connect(database_path) as connection:
         connection.execute("PRAGMA foreign_keys = ON")
+        previous_schema_version = _read_schema_version(connection)
+        if previous_schema_version in {"1", "2", "3", "4"}:
+            _reset_derived_discovery_schema(connection)
         for statement in SCHEMA_STATEMENTS:
             connection.execute(statement)
-        previous_schema_version = connection.execute(
-            "SELECT value FROM metadata WHERE key = 'schema_version'"
-        ).fetchone()
         _ensure_column(connection, "documents", "source_hash", "TEXT")
         _ensure_column(connection, "documents", "normalized_path", "TEXT")
         _ensure_column(connection, "documents", "metadata_json", "TEXT NOT NULL DEFAULT '{}'")
@@ -648,10 +656,34 @@ def _initialize_database(database_path: Path) -> tuple[bool, tuple[str, ...]]:
         )
         connection.commit()
 
-    migration_required = (
-        previous_schema_version is None or str(previous_schema_version[0]) != SCHEMA_VERSION
-    )
+    migration_required = previous_schema_version != SCHEMA_VERSION
     return migration_required, removed_document_ids
+
+
+def _read_schema_version(connection: sqlite3.Connection) -> str | None:
+    metadata_exists = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'metadata'"
+    ).fetchone()
+    if metadata_exists is None:
+        return None
+    row = connection.execute("SELECT value FROM metadata WHERE key = 'schema_version'").fetchone()
+    if row is None:
+        return None
+    return str(row[0])
+
+
+def _reset_derived_discovery_schema(connection: sqlite3.Connection) -> None:
+    """Reset regenerable discovery records when adopting a new discovery schema."""
+
+    for table_name in (
+        "discovery_evidence",
+        "discovery_items_fts",
+        "discovery_items",
+        "document_briefs_fts",
+        "document_briefs",
+        "document_profiles",
+    ):
+        connection.execute(f"DROP TABLE IF EXISTS {table_name}")
 
 
 def _set_schema_version(database_path: Path) -> None:

--- a/tests/test_briefs.py
+++ b/tests/test_briefs.py
@@ -38,6 +38,22 @@ def test_generate_document_brief_persists_evidence_backed_summary(tmp_path: Path
     assert "Council awarded a $250,000 stormwater contract" in output
 
 
+def test_html_document_brief_uses_block_extent_and_citations(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    database_path = _seed_html_brief_document(data_dir)
+
+    brief = generate_document_brief(database_path, "document-html")
+    output = format_generated_brief(brief)
+
+    assert brief.document.source_type == "html"
+    assert brief.document.extent_type == "blocks"
+    assert brief.document.extent_count == 1
+    assert "source_type: html" in output
+    assert "blocks: 1" in output
+    assert "pages:" not in output
+    assert "Council Update — Stormwater — block 3" in output
+
+
 def test_documents_brief_command_outputs_citations(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
     _seed_brief_document(data_dir)
@@ -72,19 +88,15 @@ def test_documents_brief_command_fails_for_low_text_document(tmp_path: Path) -> 
     data_dir = tmp_path / ".newsrag"
     database_path = initialize_storage(data_dir).database
     with sqlite3.connect(database_path) as connection:
-        connection.execute(
-            """
-            INSERT INTO documents(id, source_path, title, source_hash, normalized_path, metadata_json)
-            VALUES(?, ?, ?, ?, ?, ?)
-            """,
-            ("document-empty", "/tmp/empty.pdf", "Empty", "hash-empty", "/tmp/empty-ocr.pdf", "{}"),
-        )
-        connection.execute(
-            """
-            INSERT INTO pages(id, document_id, page_number, text, extractor)
-            VALUES(?, ?, ?, ?, ?)
-            """,
-            ("page-empty", "document-empty", 1, "short", "pymupdf"),
+        _insert_pdf_source_model(
+            connection,
+            document_id="document-empty",
+            artifact_id="artifact-empty",
+            source_id="source-empty",
+            content_hash="hash-empty",
+            source_path="/tmp/empty.pdf",
+            title="Empty",
+            units=(("unit-empty", 1, "short"),),
         )
         connection.commit()
 
@@ -100,45 +112,146 @@ def test_documents_brief_command_fails_for_low_text_document(tmp_path: Path) -> 
 def _seed_brief_document(data_dir: Path) -> Path:
     database_path = initialize_storage(data_dir).database
     with sqlite3.connect(database_path) as connection:
-        connection.execute(
-            """
-            INSERT INTO documents(id, source_path, source_url, title, source_hash, normalized_path, metadata_json)
-            VALUES(?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                "document-a",
-                "/tmp/council.pdf",
-                "https://example.test/council.pdf",
-                "Council Packet",
-                "hash-a",
-                "/tmp/council-ocr.pdf",
-                '{"body": "City Council", "meeting_date": "2026-05-01"}',
-            ),
-        )
-        connection.executemany(
-            """
-            INSERT INTO pages(id, document_id, page_number, text, extractor)
-            VALUES(?, ?, ?, ?, ?)
-            """,
-            [
+        _insert_pdf_source_model(
+            connection,
+            document_id="document-a",
+            artifact_id="artifact-a",
+            source_id="source-a",
+            content_hash="hash-a",
+            source_path="/tmp/council.pdf",
+            title="Council Packet",
+            units=(
                 (
-                    "page-a-1",
-                    "document-a",
+                    "unit-a-1",
                     1,
-                    (
-                        "Council awarded a $250,000 stormwater contract to ABC Construction. "
-                        "Work must be completed by June 1, 2026."
-                    ),
-                    "pymupdf",
+                    "Council awarded a $250,000 stormwater contract to ABC Construction. Work must be completed by June 1, 2026.",
                 ),
                 (
-                    "page-a-2",
-                    "document-a",
+                    "unit-a-2",
                     2,
                     "Resolution No. 2026-05 schedules a public hearing for July 1, 2026.",
-                    "pymupdf",
                 ),
-            ],
+            ),
+            metadata_json='{"body": "City Council", "meeting_date": "2026-05-01"}',
         )
         connection.commit()
     return database_path
+
+
+def _seed_html_brief_document(data_dir: Path) -> Path:
+    database_path = initialize_storage(data_dir).database
+    text = (
+        "Council approved a $250,000 stormwater contract with ABC Construction. "
+        "Work must be completed by June 1, 2026."
+    )
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+            VALUES('source-html', 'local_path', '/tmp/update.html', '/tmp/update.html')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, byte_size, content_hash, stored_path, acquired_at, state
+            )
+            VALUES(
+                'artifact-html', 'source-html', 'text/html', 10, 'hash-html',
+                '/tmp/update.html', CURRENT_TIMESTAMP, 'published'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO documents(id, source_path, title, source_hash, metadata_json, artifact_id)
+            VALUES(
+                'document-html', '/tmp/update.html', 'Council Update', 'hash-html',
+                '{"body": "City Council"}', 'artifact-html'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_units(
+                id, artifact_id, document_id, ordinal, location_type, location_json,
+                human_label, normalized_text, structure_json, extractor
+            )
+            VALUES(
+                'unit-html-3', 'artifact-html', 'document-html', 3, 'html_block',
+                '{"block_number": 3}', 'block 3', ?,
+                '{"heading_path": ["Council Update", "Stormwater"]}', 'static-html'
+            )
+            """,
+            (text,),
+        )
+        connection.commit()
+    return database_path
+
+
+def _insert_pdf_source_model(
+    connection: sqlite3.Connection,
+    *,
+    document_id: str,
+    artifact_id: str,
+    source_id: str,
+    content_hash: str,
+    source_path: str,
+    title: str,
+    units: tuple[tuple[str, int, str], ...],
+    metadata_json: str = "{}",
+) -> None:
+    connection.execute(
+        """
+        INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+        VALUES(?, 'local_path', ?, ?)
+        """,
+        (source_id, source_path, source_path),
+    )
+    connection.execute(
+        """
+        INSERT INTO source_artifacts(
+            id, source_id, media_type, byte_size, content_hash, stored_path, acquired_at, state
+        )
+        VALUES(?, ?, 'application/pdf', 10, ?, ?, CURRENT_TIMESTAMP, 'published')
+        """,
+        (artifact_id, source_id, content_hash, source_path),
+    )
+    connection.execute(
+        """
+        INSERT INTO documents(id, source_path, title, source_hash, metadata_json, artifact_id)
+        VALUES(?, ?, ?, ?, ?, ?)
+        """,
+        (document_id, source_path, title, content_hash, metadata_json, artifact_id),
+    )
+    connection.executemany(
+        """
+        INSERT INTO source_units(
+            id, artifact_id, document_id, ordinal, location_type, location_json,
+            human_label, normalized_text, structure_json, extractor
+        )
+        VALUES(?, ?, ?, ?, 'page', ?, ?, ?, '{}', 'pymupdf')
+        """,
+        [
+            (
+                unit_id,
+                artifact_id,
+                document_id,
+                page_number,
+                f'{{"page_number": {page_number}}}',
+                f"p. {page_number}",
+                text,
+            )
+            for unit_id, page_number, text in units
+        ],
+    )
+    connection.executemany(
+        """
+        INSERT INTO pages(id, document_id, page_number, source_unit_id, text, extractor)
+        VALUES(?, ?, ?, ?, ?, 'pymupdf')
+        """,
+        [
+            (f"page-{document_id}-{page_number}", document_id, page_number, unit_id, text)
+            for unit_id, page_number, text in units
+        ],
+    )

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -45,7 +45,6 @@ def test_document_profile_can_be_created_and_replaced(tmp_path: Path) -> None:
     first_profile = create_document_profile(
         database_path,
         document_id="document-a",
-        page_count=2,
         text_length=42,
         extraction_quality={"empty_pages": 0},
         extractor="deterministic",
@@ -56,7 +55,6 @@ def test_document_profile_can_be_created_and_replaced(tmp_path: Path) -> None:
     second_profile = create_document_profile(
         database_path,
         document_id="document-a",
-        page_count=3,
         text_length=84,
         extraction_quality={"empty_pages": 1},
         extractor="deterministic",
@@ -68,12 +66,48 @@ def test_document_profile_can_be_created_and_replaced(tmp_path: Path) -> None:
 
     assert first_profile.id == "profile-a"
     assert second_profile.id == "profile-a"
-    assert loaded_profile.page_count == 3
+    assert loaded_profile.source_type == "pdf"
+    assert loaded_profile.extent_type == "pages"
+    assert loaded_profile.extent_count == 2
     assert loaded_profile.text_length == 84
     assert loaded_profile.extraction_quality == {"empty_pages": 1}
     assert loaded_profile.extractor == "deterministic"
     assert loaded_profile.provider == "rules"
     assert loaded_profile.model == "rules-v2"
+
+
+def test_html_profile_and_evidence_use_typed_block_locations(tmp_path: Path) -> None:
+    database_path = _seed_html_discovery_document(tmp_path)
+
+    profile = create_document_profile(
+        database_path,
+        document_id="document-html",
+        text_length=54,
+        extractor="deterministic",
+    )
+    item = create_discovery_item(
+        database_path,
+        document_id="document-html",
+        item_type="topic",
+        label="budget",
+        extractor="deterministic",
+        evidence=(
+            DiscoveryEvidenceDraft(
+                document_id="document-html",
+                source_unit_start_id="unit-html-3",
+                source_unit_end_id="unit-html-3",
+                quote="Council approved the budget amendment.",
+                validation_status="validated",
+            ),
+        ),
+    )
+
+    assert profile.source_type == "html"
+    assert profile.extent_type == "blocks"
+    assert profile.extent_count == 1
+    assert item.evidence[0].location_type == "html_block"
+    assert item.evidence[0].location_label == "Council Update — Budget — block 3"
+    assert item.evidence[0].page_start is None
 
 
 def test_document_brief_persists_provider_identity_and_fts(tmp_path: Path) -> None:
@@ -129,10 +163,9 @@ def test_discovery_item_persists_evidence_references_and_identity(
         evidence=(
             DiscoveryEvidenceDraft(
                 document_id="document-a",
-                page_id="page-a-1",
+                source_unit_start_id="unit-a-1",
+                source_unit_end_id="unit-a-1",
                 passage_id="passage-a-1",
-                page_start=1,
-                page_end=1,
                 quote="Approve a $250,000 stormwater contract.",
                 validation_status="validated",
             ),
@@ -155,6 +188,10 @@ def test_discovery_item_persists_evidence_references_and_identity(
     assert item.model == "rules-v1"
     assert len(item.evidence) == 1
     assert item.evidence[0].document_id == "document-a"
+    assert item.evidence[0].source_unit_start_id == "unit-a-1"
+    assert item.evidence[0].source_unit_end_id == "unit-a-1"
+    assert item.evidence[0].location_type == "page"
+    assert item.evidence[0].location_label == "p. 1"
     assert item.evidence[0].page_id == "page-a-1"
     assert item.evidence[0].passage_id == "passage-a-1"
     assert item.evidence[0].page_start == 1
@@ -171,7 +208,7 @@ def test_discovery_item_persists_evidence_references_and_identity(
     ]
 
 
-def test_discovery_item_validates_confidence_and_evidence_pages(tmp_path: Path) -> None:
+def test_discovery_item_validates_typed_evidence_and_quotes(tmp_path: Path) -> None:
     database_path = _seed_discovery_document(tmp_path)
 
     with pytest.raises(DiscoveryError, match="confidence must be between 0 and 1"):
@@ -184,7 +221,7 @@ def test_discovery_item_validates_confidence_and_evidence_pages(tmp_path: Path) 
             extractor="deterministic",
         )
 
-    with pytest.raises(DiscoveryError, match="evidence.page_end"):
+    with pytest.raises(DiscoveryError, match="source-unit range is reversed"):
         create_discovery_item(
             database_path,
             document_id="document-a",
@@ -194,9 +231,9 @@ def test_discovery_item_validates_confidence_and_evidence_pages(tmp_path: Path) 
             evidence=(
                 DiscoveryEvidenceDraft(
                     document_id="document-a",
-                    page_start=2,
-                    page_end=1,
-                    quote="Stormwater",
+                    source_unit_start_id="unit-a-2",
+                    source_unit_end_id="unit-a-1",
+                    quote="Second page",
                     validation_status="validated",
                 ),
             ),
@@ -212,8 +249,8 @@ def test_discovery_item_validates_confidence_and_evidence_pages(tmp_path: Path) 
             evidence=(
                 DiscoveryEvidenceDraft(
                     document_id="document-other",
-                    page_start=1,
-                    page_end=1,
+                    source_unit_start_id="unit-a-1",
+                    source_unit_end_id="unit-a-1",
                     quote="Stormwater",
                     validation_status="validated",
                 ),
@@ -230,13 +267,78 @@ def test_discovery_item_validates_confidence_and_evidence_pages(tmp_path: Path) 
             evidence=(
                 DiscoveryEvidenceDraft(
                     document_id="document-a",
-                    page_start=1,
-                    page_end=1,
+                    source_unit_start_id="unit-a-1",
+                    source_unit_end_id="unit-a-1",
                     quote="",
                     validation_status="validated",
                 ),
             ),
         )
+
+    with pytest.raises(DiscoveryError, match="quote was not found"):
+        create_discovery_item(
+            database_path,
+            document_id="document-a",
+            item_type="topic",
+            label="Stormwater",
+            extractor="deterministic",
+            evidence=(
+                DiscoveryEvidenceDraft(
+                    document_id="document-a",
+                    source_unit_start_id="unit-a-1",
+                    source_unit_end_id="unit-a-1",
+                    quote="Unsupported quote",
+                    validation_status="validated",
+                ),
+            ),
+        )
+
+
+def _seed_html_discovery_document(tmp_path: Path) -> Path:
+    database_path = initialize_storage(tmp_path / ".newsrag").database
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+            VALUES('source-html', 'local_path', '/tmp/update.html', '/tmp/update.html')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, byte_size, content_hash, stored_path, acquired_at, state
+            )
+            VALUES(
+                'artifact-html', 'source-html', 'text/html', 10, 'hash-html',
+                '/tmp/update.html', CURRENT_TIMESTAMP, 'published'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO documents(id, source_path, title, source_hash, metadata_json, artifact_id)
+            VALUES(
+                'document-html', '/tmp/update.html', 'Council Update', 'hash-html',
+                '{}', 'artifact-html'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_units(
+                id, artifact_id, document_id, ordinal, location_type, location_json,
+                human_label, normalized_text, structure_json, extractor
+            )
+            VALUES(
+                'unit-html-3', 'artifact-html', 'document-html', 3, 'html_block',
+                '{"block_number": 3}', 'block 3',
+                'Council approved the budget amendment.',
+                '{"heading_path": ["Council Update", "Budget"]}', 'static-html'
+            )
+            """
+        )
+        connection.commit()
+    return database_path
 
 
 def _seed_discovery_document(tmp_path: Path) -> Path:
@@ -245,8 +347,28 @@ def _seed_discovery_document(tmp_path: Path) -> Path:
         connection.execute("PRAGMA foreign_keys = ON")
         connection.execute(
             """
-            INSERT INTO documents(id, source_path, source_url, title, source_hash, normalized_path, metadata_json)
-            VALUES(?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+            VALUES('source-a', 'local_path', '/tmp/stormwater.pdf', '/tmp/stormwater.pdf')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, byte_size, content_hash, stored_path, acquired_at, state
+            )
+            VALUES(
+                'artifact-a', 'source-a', 'application/pdf', 10, 'hash-a',
+                '/tmp/stormwater.pdf', CURRENT_TIMESTAMP, 'published'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO documents(
+                id, source_path, source_url, title, source_hash, normalized_path,
+                metadata_json, artifact_id
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "document-a",
@@ -256,38 +378,67 @@ def _seed_discovery_document(tmp_path: Path) -> Path:
                 "hash-a",
                 "/tmp/stormwater-ocr.pdf",
                 '{"body": "Planning Commission", "meeting_date": "2026-05-01"}',
+                "artifact-a",
             ),
+        )
+        connection.executemany(
+            """
+            INSERT INTO source_units(
+                id, artifact_id, document_id, ordinal, location_type, location_json,
+                human_label, normalized_text, structure_json, extractor
+            )
+            VALUES(?, 'artifact-a', 'document-a', ?, 'page', ?, ?, ?, '{}', 'pymupdf')
+            """,
+            [
+                (
+                    "unit-a-1",
+                    1,
+                    '{"page_number": 1}',
+                    "p. 1",
+                    "Approve a $250,000 stormwater contract.",
+                ),
+                ("unit-a-2", 2, '{"page_number": 2}', "p. 2", "Second page text."),
+            ],
         )
         connection.execute(
             """
-            INSERT INTO pages(id, document_id, page_number, text, extractor)
-            VALUES(?, ?, ?, ?, ?)
+            INSERT INTO pages(id, document_id, page_number, source_unit_id, text, extractor)
+            VALUES(?, ?, ?, ?, ?, ?)
             """,
             (
                 "page-a-1",
                 "document-a",
                 1,
+                "unit-a-1",
                 "Approve a $250,000 stormwater contract.",
                 "pymupdf",
             ),
         )
         connection.execute(
             """
-            INSERT INTO chunks(id, document_id, page_start, page_end, text)
-            VALUES(?, ?, ?, ?, ?)
+            INSERT INTO chunks(
+                id, document_id, page_start, page_end, source_unit_start_id,
+                source_unit_end_id, text
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "chunk-a-1",
                 "document-a",
                 1,
                 1,
+                "unit-a-1",
+                "unit-a-1",
                 "Approve a $250,000 stormwater contract.",
             ),
         )
         connection.execute(
             """
-            INSERT INTO passages(id, chunk_id, document_id, page_start, page_end, ordinal, text)
-            VALUES(?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO passages(
+                id, chunk_id, document_id, page_start, page_end, source_unit_start_id,
+                source_unit_end_id, ordinal, text
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "passage-a-1",
@@ -295,6 +446,8 @@ def _seed_discovery_document(tmp_path: Path) -> Path:
                 "document-a",
                 1,
                 1,
+                "unit-a-1",
+                "unit-a-1",
                 1,
                 "Approve a $250,000 stormwater contract.",
             ),

--- a/tests/test_discovery_browse.py
+++ b/tests/test_discovery_browse.py
@@ -145,6 +145,32 @@ def test_leads_list_and_show_include_supporting_evidence(tmp_path: Path) -> None
     assert 'quote: "Council awarded a $250,000 stormwater contract."' in show_result.stdout
 
 
+def test_html_topics_timeline_and_leads_use_heading_block_citations(
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / ".newsrag"
+    _seed_html_discovery_browse_data(data_dir)
+
+    topics_result = runner.invoke(app, ["--data-dir", str(data_dir), "topics", "list"])
+    timeline_result = runner.invoke(app, ["--data-dir", str(data_dir), "timeline"])
+    leads_result = runner.invoke(app, ["--data-dir", str(data_dir), "leads", "list"])
+    show_result = runner.invoke(
+        app,
+        ["--data-dir", str(data_dir), "leads", "show", "lead-html-budget"],
+    )
+
+    citation = "document-html Council Update — Budget — block 3"
+    assert topics_result.exit_code == 0, topics_result.stdout
+    assert timeline_result.exit_code == 0, timeline_result.stdout
+    assert leads_result.exit_code == 0, leads_result.stdout
+    assert show_result.exit_code == 0, show_result.stdout
+    assert f"citation={citation}" in topics_result.stdout
+    assert f"citation={citation}" in timeline_result.stdout
+    assert f"citation={citation}" in leads_result.stdout
+    assert citation in show_result.stdout
+    assert 'quote: "Council approved the $500,000 budget amendment."' in show_result.stdout
+
+
 def test_leads_show_missing_id_fails_clearly(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
     initialize_storage(data_dir)
@@ -160,6 +186,38 @@ def _seed_discovery_browse_data(data_dir: Path) -> Path:
     with sqlite3.connect(database_path) as connection:
         connection.executemany(
             """
+            INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+            VALUES(?, 'local_path', ?, ?)
+            """,
+            [
+                ("source-council", "/tmp/council.pdf", "/tmp/council.pdf"),
+                ("source-planning", "/tmp/planning.pdf", "/tmp/planning.pdf"),
+            ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, byte_size, content_hash, stored_path, acquired_at, state
+            )
+            VALUES(?, ?, 'application/pdf', 10, ?, ?, CURRENT_TIMESTAMP, 'published')
+            """,
+            [
+                (
+                    "artifact-council",
+                    "source-council",
+                    "hash-council",
+                    "/tmp/council.pdf",
+                ),
+                (
+                    "artifact-planning",
+                    "source-planning",
+                    "hash-planning",
+                    "/tmp/planning.pdf",
+                ),
+            ],
+        )
+        connection.executemany(
+            """
             INSERT INTO documents(
                 id,
                 source_path,
@@ -168,9 +226,10 @@ def _seed_discovery_browse_data(data_dir: Path) -> Path:
                 source_hash,
                 normalized_path,
                 metadata_json,
+                artifact_id,
                 created_at
             )
-            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
                 (
@@ -181,6 +240,7 @@ def _seed_discovery_browse_data(data_dir: Path) -> Path:
                     "hash-council",
                     "/tmp/council-ocr.pdf",
                     '{"body": "City Council", "document_type": "agenda_packet", "jurisdiction": "Example City", "meeting_date": "2026-05-12"}',
+                    "artifact-council",
                     "2026-05-12T00:00:00+00:00",
                 ),
                 (
@@ -191,20 +251,51 @@ def _seed_discovery_browse_data(data_dir: Path) -> Path:
                     "hash-planning",
                     "/tmp/planning-ocr.pdf",
                     '{"body": "Planning Board", "document_type": "staff_report", "jurisdiction": "Example City", "meeting_date": "2026-04-10"}',
+                    "artifact-planning",
                     "2026-04-10T00:00:00+00:00",
                 ),
             ],
         )
         connection.executemany(
             """
-            INSERT INTO pages(id, document_id, page_number, text, extractor)
-            VALUES(?, ?, ?, ?, ?)
+            INSERT INTO source_units(
+                id, artifact_id, document_id, ordinal, location_type, location_json,
+                human_label, normalized_text, structure_json, extractor
+            )
+            VALUES(?, ?, ?, ?, 'page', ?, ?, ?, '{}', 'pymupdf')
+            """,
+            [
+                (
+                    "unit-council-2",
+                    "artifact-council",
+                    "document-council",
+                    2,
+                    '{"page_number": 2}',
+                    "p. 2",
+                    "Council awarded a $250,000 stormwater contract. Work must begin by June 1, 2026.",
+                ),
+                (
+                    "unit-planning-1",
+                    "artifact-planning",
+                    "document-planning",
+                    1,
+                    '{"page_number": 1}',
+                    "p. 1",
+                    "Planning Board reviewed the zoning request.",
+                ),
+            ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO pages(id, document_id, page_number, source_unit_id, text, extractor)
+            VALUES(?, ?, ?, ?, ?, ?)
             """,
             [
                 (
                     "page-council-2",
                     "document-council",
                     2,
+                    "unit-council-2",
                     "Council awarded a $250,000 stormwater contract. Work must begin by June 1, 2026.",
                     "pymupdf",
                 ),
@@ -212,6 +303,7 @@ def _seed_discovery_browse_data(data_dir: Path) -> Path:
                     "page-planning-1",
                     "document-planning",
                     1,
+                    "unit-planning-1",
                     "Planning Board reviewed the zoning request.",
                     "pymupdf",
                 ),
@@ -307,6 +399,79 @@ def _seed_discovery_browse_data(data_dir: Path) -> Path:
     return database_path
 
 
+def _seed_html_discovery_browse_data(data_dir: Path) -> Path:
+    database_path = initialize_storage(data_dir).database
+    quote = "Council approved the $500,000 budget amendment."
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+            VALUES('source-html', 'local_path', '/tmp/update.html', '/tmp/update.html')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, byte_size, content_hash, stored_path, acquired_at, state
+            )
+            VALUES(
+                'artifact-html', 'source-html', 'text/html', 10, 'hash-html',
+                '/tmp/update.html', CURRENT_TIMESTAMP, 'published'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO documents(id, source_path, title, source_hash, metadata_json, artifact_id)
+            VALUES(
+                'document-html', '/tmp/update.html', 'Council Update', 'hash-html',
+                '{"body": "City Council"}', 'artifact-html'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_units(
+                id, artifact_id, document_id, ordinal, location_type, location_json,
+                human_label, normalized_text, structure_json, extractor
+            )
+            VALUES(
+                'unit-html-3', 'artifact-html', 'document-html', 3, 'html_block',
+                '{"block_number": 3}', 'block 3', ?,
+                '{"heading_path": ["Council Update", "Budget"]}', 'static-html'
+            )
+            """,
+            (quote,),
+        )
+        connection.commit()
+
+    for item_id, item_type, label in (
+        ("topic-html-budget", "topic", "budget"),
+        ("action-html-approved", "action", "approved"),
+        ("lead-html-budget", "story_lead", "Follow budget amendment"),
+    ):
+        create_discovery_item(
+            database_path,
+            document_id="document-html",
+            item_id=item_id,
+            item_type=item_type,
+            label=label,
+            summary="Evidence from the web update.",
+            confidence=0.8,
+            extractor="test-extractor",
+            evidence=(
+                DiscoveryEvidenceDraft(
+                    document_id="document-html",
+                    source_unit_start_id="unit-html-3",
+                    source_unit_end_id="unit-html-3",
+                    quote=quote,
+                    validation_status="validated",
+                ),
+            ),
+        )
+    return database_path
+
+
 def _create_item(
     database_path: Path,
     *,
@@ -321,6 +486,7 @@ def _create_item(
     quote: str,
     value: dict[str, object] | None = None,
 ) -> None:
+    del page
     create_discovery_item(
         database_path,
         document_id=document_id,
@@ -336,9 +502,8 @@ def _create_item(
         evidence=(
             DiscoveryEvidenceDraft(
                 document_id=document_id,
-                page_id=page_id,
-                page_start=page,
-                page_end=page,
+                source_unit_start_id=page_id.replace("page-", "unit-"),
+                source_unit_end_id=page_id.replace("page-", "unit-"),
                 quote=quote,
                 validation_status="validated",
             ),

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -24,11 +24,12 @@ runner = CliRunner()
 @dataclass(frozen=True)
 class FakeEnrichmentProvider:
     response: str
+    expected_document_id: str = "document-a"
     name: str = "fake-llm"
     model: str = "fake-model"
 
     def enrich(self, request: EnrichmentRequest) -> str:
-        assert request.document_id == "document-a"
+        assert request.document_id == self.expected_document_id
         assert request.evidence_contexts
         return self.response
 
@@ -70,6 +71,33 @@ def test_structured_enrichment_persists_brief_items_and_evidence(tmp_path: Path)
         items_by_type["story_lead"].evidence[0].quote
         == "Council awarded a $250,000 stormwater contract."
     )
+
+
+def test_html_enrichment_creates_story_lead_with_block_evidence(tmp_path: Path) -> None:
+    database_path = _seed_html_enrichment_document(tmp_path / ".newsrag")
+    response = _valid_enrichment_response()
+    summary_evidence = cast(list[dict[str, Any]], response["summary_evidence"])
+    summary_evidence[0]["passage_id"] = "passage-html-3"
+    for collection_name in ("notable_actions", "story_leads"):
+        claims = cast(list[dict[str, Any]], response[collection_name])
+        evidence = cast(dict[str, Any], claims[0]["evidence"])
+        evidence["source_unit_start_id"] = "unit-html-3"
+
+    result = enrich_document(
+        database_path,
+        "document-html",
+        provider=FakeEnrichmentProvider(
+            json.dumps(response),
+            expected_document_id="document-html",
+        ),
+    )
+
+    story_lead = next(item for item in result.items if item.item_type == "story_lead")
+    story_evidence = story_lead.evidence[0]
+    assert story_evidence.location_type == "html_block"
+    assert story_evidence.location_label == "Council Update — Stormwater — block 3"
+    assert story_evidence.page_start is None
+    assert story_evidence.page_id is None
 
 
 def test_structured_enrichment_rejects_malformed_json(tmp_path: Path) -> None:
@@ -142,7 +170,7 @@ def _valid_enrichment_response() -> dict[str, object]:
         "summary": "The packet centers on a stormwater contract award backed by council action.",
         "summary_evidence": [
             {
-                "page_start": 1,
+                "passage_id": "passage-a-1",
                 "quote": "Council awarded a $250,000 stormwater contract.",
             }
         ],
@@ -151,7 +179,7 @@ def _valid_enrichment_response() -> dict[str, object]:
                 "label": "Awarded stormwater contract",
                 "summary": "Council awarded the stormwater contract.",
                 "evidence": {
-                    "page_start": 1,
+                    "source_unit_start_id": "unit-a-1",
                     "quote": "Council awarded a $250,000 stormwater contract.",
                 },
             }
@@ -161,7 +189,7 @@ def _valid_enrichment_response() -> dict[str, object]:
                 "label": "Follow the stormwater contract",
                 "summary": "The contract amount and deadline may merit follow-up reporting.",
                 "evidence": {
-                    "page_start": 1,
+                    "source_unit_start_id": "unit-a-1",
                     "quote": "Council awarded a $250,000 stormwater contract.",
                 },
             }
@@ -175,11 +203,32 @@ def _valid_enrichment_response() -> dict[str, object]:
 
 def _seed_enrichment_document(data_dir: Path) -> Path:
     database_path = initialize_storage(data_dir).database
+    text = "Council awarded a $250,000 stormwater contract. Work must begin by June 1, 2026."
     with sqlite3.connect(database_path) as connection:
         connection.execute(
             """
-            INSERT INTO documents(id, source_path, source_url, title, source_hash, normalized_path, metadata_json)
-            VALUES(?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+            VALUES('source-a', 'local_path', '/tmp/council.pdf', '/tmp/council.pdf')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, byte_size, content_hash, stored_path, acquired_at, state
+            )
+            VALUES(
+                'artifact-a', 'source-a', 'application/pdf', 10, 'hash-a',
+                '/tmp/council.pdf', CURRENT_TIMESTAMP, 'published'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO documents(
+                id, source_path, source_url, title, source_hash, normalized_path,
+                metadata_json, artifact_id
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "document-a",
@@ -189,48 +238,126 @@ def _seed_enrichment_document(data_dir: Path) -> Path:
                 "hash-a",
                 "/tmp/council-ocr.pdf",
                 '{"body": "City Council", "meeting_date": "2026-05-01"}',
+                "artifact-a",
             ),
         )
         connection.execute(
             """
-            INSERT INTO pages(id, document_id, page_number, text, extractor)
-            VALUES(?, ?, ?, ?, ?)
+            INSERT INTO source_units(
+                id, artifact_id, document_id, ordinal, location_type, location_json,
+                human_label, normalized_text, structure_json, extractor
+            )
+            VALUES(
+                'unit-a-1', 'artifact-a', 'document-a', 1, 'page',
+                '{"page_number": 1}', 'p. 1', ?, '{}', 'pymupdf'
+            )
             """,
-            (
-                "page-a-1",
-                "document-a",
-                1,
-                "Council awarded a $250,000 stormwater contract. Work must begin by June 1, 2026.",
-                "pymupdf",
-            ),
+            (text,),
         )
         connection.execute(
             """
-            INSERT INTO chunks(id, document_id, page_start, page_end, text)
-            VALUES(?, ?, ?, ?, ?)
+            INSERT INTO pages(id, document_id, page_number, source_unit_id, text, extractor)
+            VALUES('page-a-1', 'document-a', 1, 'unit-a-1', ?, 'pymupdf')
             """,
-            (
-                "chunk-a-1",
-                "document-a",
-                1,
-                1,
-                "Council awarded a $250,000 stormwater contract.",
-            ),
+            (text,),
         )
         connection.execute(
             """
-            INSERT INTO passages(id, chunk_id, document_id, page_start, page_end, ordinal, text)
-            VALUES(?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO chunks(
+                id, document_id, page_start, page_end, source_unit_start_id,
+                source_unit_end_id, text
+            )
+            VALUES(
+                'chunk-a-1', 'document-a', 1, 1, 'unit-a-1', 'unit-a-1',
+                'Council awarded a $250,000 stormwater contract.'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO passages(
+                id, chunk_id, document_id, page_start, page_end, source_unit_start_id,
+                source_unit_end_id, ordinal, text
+            )
+            VALUES(
+                'passage-a-1', 'chunk-a-1', 'document-a', 1, 1,
+                'unit-a-1', 'unit-a-1', 1,
+                'Council awarded a $250,000 stormwater contract.'
+            )
+            """
+        )
+        connection.commit()
+    return database_path
+
+
+def _seed_html_enrichment_document(data_dir: Path) -> Path:
+    database_path = initialize_storage(data_dir).database
+    text = "Council awarded a $250,000 stormwater contract. Work must begin by June 1, 2026."
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+            VALUES('source-html', 'local_path', '/tmp/update.html', '/tmp/update.html')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, byte_size, content_hash, stored_path, acquired_at, state
+            )
+            VALUES(
+                'artifact-html', 'source-html', 'text/html', 10, 'hash-html',
+                '/tmp/update.html', CURRENT_TIMESTAMP, 'published'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO documents(id, source_path, title, source_hash, metadata_json, artifact_id)
+            VALUES(
+                'document-html', '/tmp/update.html', 'Council Update', 'hash-html',
+                '{"body": "City Council"}', 'artifact-html'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_units(
+                id, artifact_id, document_id, ordinal, location_type, location_json,
+                human_label, normalized_text, structure_json, extractor
+            )
+            VALUES(
+                'unit-html-3', 'artifact-html', 'document-html', 3, 'html_block',
+                '{"block_number": 3}', 'block 3', ?,
+                '{"heading_path": ["Council Update", "Stormwater"]}', 'static-html'
+            )
             """,
-            (
-                "passage-a-1",
-                "chunk-a-1",
-                "document-a",
-                1,
-                1,
-                1,
-                "Council awarded a $250,000 stormwater contract.",
-            ),
+            (text,),
+        )
+        connection.execute(
+            """
+            INSERT INTO chunks(
+                id, document_id, page_start, page_end, source_unit_start_id,
+                source_unit_end_id, text
+            )
+            VALUES(
+                'chunk-html-3', 'document-html', 3, 3, 'unit-html-3', 'unit-html-3', ?
+            )
+            """,
+            (text,),
+        )
+        connection.execute(
+            """
+            INSERT INTO passages(
+                id, chunk_id, document_id, page_start, page_end, source_unit_start_id,
+                source_unit_end_id, ordinal, text
+            )
+            VALUES(
+                'passage-html-3', 'chunk-html-3', 'document-html', 3, 3,
+                'unit-html-3', 'unit-html-3', 1, ?
+            )
+            """,
+            (text,),
         )
         connection.commit()
     return database_path

--- a/tests/test_facts.py
+++ b/tests/test_facts.py
@@ -22,10 +22,9 @@ def test_deterministic_extractors_create_evidence_backed_fact_drafts() -> None:
         [
             FactSource(
                 document_id="document-a",
-                page_id="page-a-1",
-                passage_id="passage-a-1",
-                page_start=4,
-                page_end=4,
+                source_unit_start_id="unit-a-4",
+                source_unit_end_id="unit-a-4",
+                passage_id="passage-a-4",
                 text=(
                     "Council approved a $250,000 stormwater contract with ABC Construction. "
                     "Work must begin by June 1, 2026 and is 95% funded. "
@@ -51,9 +50,9 @@ def test_deterministic_extractors_create_evidence_backed_fact_drafts() -> None:
     assert money.value == {"amount_text": "$250,000"}
     assert money.confidence == 0.95
     assert money.evidence.document_id == "document-a"
-    assert money.evidence.page_id == "page-a-1"
-    assert money.evidence.passage_id == "passage-a-1"
-    assert money.evidence.page_start == 4
+    assert money.evidence.source_unit_start_id == "unit-a-4"
+    assert money.evidence.source_unit_end_id == "unit-a-4"
+    assert money.evidence.passage_id == "passage-a-4"
     assert money.evidence.validation_status == "validated"
     assert "$250,000 stormwater contract" in money.evidence.quote
 
@@ -66,8 +65,8 @@ def test_false_positive_dates_and_entities_are_filtered_or_low_confidence() -> N
         [
             FactSource(
                 document_id="document-a",
-                page_start=1,
-                page_end=1,
+                source_unit_start_id="unit-a-1",
+                source_unit_end_id="unit-a-1",
                 text=(
                     "Page 1 of 2\nCity Manager Report\nInvalid date 2026-99-99. "
                     "Planning Commission reviewed the zoning request."
@@ -110,9 +109,29 @@ def test_extract_document_facts_persists_discovery_items_with_evidence(
     assert money_items[0].provider == "rules"
     assert money_items[0].model == "rules-v1"
     assert money_items[0].confidence == 0.95
+    assert money_items[0].evidence[0].source_unit_start_id == "unit-a-1"
+    assert money_items[0].evidence[0].source_unit_end_id == "unit-a-1"
     assert money_items[0].evidence[0].page_id == "page-a-1"
     assert money_items[0].evidence[0].page_start == 1
     assert "$1.2 million" in money_items[0].evidence[0].quote
+
+
+def test_html_document_facts_use_heading_and_block_evidence(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    database_path = _seed_html_fact_document(data_dir)
+
+    result = extract_document_facts(database_path, "document-html")
+    items = list_discovery_items(database_path, document_id="document-html")
+
+    assert result.total > 0
+    assert {item.item_type for item in items} >= {"action", "money", "topic"}
+    money = next(item for item in items if item.item_type == "money")
+    evidence = money.evidence[0]
+    assert evidence.source_unit_start_id == "unit-html-3"
+    assert evidence.location_type == "html_block"
+    assert evidence.location_label == "Council Update — Parks — block 3"
+    assert evidence.page_id is None
+    assert evidence.page_start is None
 
 
 def test_discover_document_command_outputs_extraction_status(tmp_path: Path) -> None:
@@ -146,11 +165,36 @@ def test_discover_document_command_reports_missing_document(tmp_path: Path) -> N
 
 def _seed_fact_document(data_dir: Path) -> Path:
     database_path = initialize_storage(data_dir).database
+    page_one_text = (
+        "Council awarded a $1.2 million sewer infrastructure contract "
+        "to ABC Construction. Work must be completed by 2026-06-30."
+    )
+    page_two_text = "Ordinance 2026-10 sets a public hearing for July 1, 2026."
     with sqlite3.connect(database_path) as connection:
         connection.execute(
             """
-            INSERT INTO documents(id, source_path, source_url, title, source_hash, normalized_path, metadata_json)
-            VALUES(?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+            VALUES('source-a', 'local_path', '/tmp/council.pdf', '/tmp/council.pdf')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, byte_size, content_hash, stored_path, acquired_at, state
+            )
+            VALUES(
+                'artifact-a', 'source-a', 'application/pdf', 10, 'hash-a',
+                '/tmp/council.pdf', CURRENT_TIMESTAMP, 'published'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO documents(
+                id, source_path, source_url, title, source_hash, normalized_path,
+                metadata_json, artifact_id
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "document-a",
@@ -160,32 +204,79 @@ def _seed_fact_document(data_dir: Path) -> Path:
                 "hash-a",
                 "/tmp/council-ocr.pdf",
                 '{"body": "City Council", "meeting_date": "2026-05-01"}',
+                "artifact-a",
             ),
         )
         connection.executemany(
             """
-            INSERT INTO pages(id, document_id, page_number, text, extractor)
-            VALUES(?, ?, ?, ?, ?)
+            INSERT INTO source_units(
+                id, artifact_id, document_id, ordinal, location_type, location_json,
+                human_label, normalized_text, structure_json, extractor
+            )
+            VALUES(?, 'artifact-a', 'document-a', ?, 'page', ?, ?, ?, '{}', 'pymupdf')
             """,
             [
-                (
-                    "page-a-1",
-                    "document-a",
-                    1,
-                    (
-                        "Council awarded a $1.2 million sewer infrastructure contract "
-                        "to ABC Construction. Work must be completed by 2026-06-30."
-                    ),
-                    "pymupdf",
-                ),
-                (
-                    "page-a-2",
-                    "document-a",
-                    2,
-                    "Ordinance 2026-10 sets a public hearing for July 1, 2026.",
-                    "pymupdf",
-                ),
+                ("unit-a-1", 1, '{"page_number": 1}', "p. 1", page_one_text),
+                ("unit-a-2", 2, '{"page_number": 2}', "p. 2", page_two_text),
             ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO pages(id, document_id, page_number, source_unit_id, text, extractor)
+            VALUES(?, 'document-a', ?, ?, ?, 'pymupdf')
+            """,
+            [
+                ("page-a-1", 1, "unit-a-1", page_one_text),
+                ("page-a-2", 2, "unit-a-2", page_two_text),
+            ],
+        )
+        connection.commit()
+    return database_path
+
+
+def _seed_html_fact_document(data_dir: Path) -> Path:
+    database_path = initialize_storage(data_dir).database
+    text = "Council approved a $2 million parks contract by 2026-07-01."
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+            VALUES('source-html', 'local_path', '/tmp/update.html', '/tmp/update.html')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, byte_size, content_hash, stored_path, acquired_at, state
+            )
+            VALUES(
+                'artifact-html', 'source-html', 'text/html', 10, 'hash-html',
+                '/tmp/update.html', CURRENT_TIMESTAMP, 'published'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO documents(id, source_path, title, source_hash, metadata_json, artifact_id)
+            VALUES(
+                'document-html', '/tmp/update.html', 'Council Update', 'hash-html',
+                '{"body": "City Council"}', 'artifact-html'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_units(
+                id, artifact_id, document_id, ordinal, location_type, location_json,
+                human_label, normalized_text, structure_json, extractor
+            )
+            VALUES(
+                'unit-html-3', 'artifact-html', 'document-html', 3, 'html_block',
+                '{"block_number": 3}', 'block 3', ?,
+                '{"heading_path": ["Council Update", "Parks"]}', 'static-html'
+            )
+            """,
+            (text,),
         )
         connection.commit()
     return database_path

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -50,6 +50,183 @@ def test_initialize_storage_is_idempotent(tmp_path: Path) -> None:
     assert REQUIRED_TABLES == REQUIRED_TABLES.intersection(_existing_tables(second_paths.database))
 
 
+def test_schema_upgrade_resets_only_regenerable_discovery_data(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".newsrag"
+    paths = initialize_storage(data_dir)
+
+    with sqlite3.connect(paths.database) as connection:
+        connection.execute(
+            """
+            INSERT INTO sources(id, kind, submitted_reference, normalized_reference)
+            VALUES('source-1', 'local_path', '/tmp/report.pdf', '/tmp/report.pdf')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, content_hash, stored_path, acquired_at, state
+            )
+            VALUES(
+                'artifact-1', 'source-1', 'application/pdf', 'hash-1',
+                '/tmp/report.pdf', CURRENT_TIMESTAMP, 'published'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO documents(
+                id, source_path, title, source_hash, metadata_json, artifact_id
+            )
+            VALUES(
+                'document-1', '/tmp/report.pdf', 'Report', 'hash-1', '{}', 'artifact-1'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_units(
+                id, artifact_id, document_id, ordinal, location_type, human_label,
+                normalized_text, extractor
+            )
+            VALUES(
+                'unit-1', 'artifact-1', 'document-1', 1, 'page', 'p. 1',
+                'quote', 'pdf-text'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO chunks(
+                id, document_id, page_start, page_end, source_unit_start_id,
+                source_unit_end_id, text
+            )
+            VALUES('chunk-1', 'document-1', 1, 1, 'unit-1', 'unit-1', 'quote')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO passages(
+                id, chunk_id, document_id, page_start, page_end, source_unit_start_id,
+                source_unit_end_id, ordinal, text
+            )
+            VALUES(
+                'passage-1', 'chunk-1', 'document-1', 1, 1,
+                'unit-1', 'unit-1', 1, 'quote'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO embedding_records(
+                id, source_kind, source_key, provider, model, version, dimensions,
+                source_unit_start_id, source_unit_end_id
+            )
+            VALUES(
+                'embedding-1', 'passage', 'passage-1', 'test', 'test', '1', 1,
+                'unit-1', 'unit-1'
+            )
+            """
+        )
+        connection.execute("INSERT INTO chunks_fts(chunk_id, text) VALUES('chunk-1', 'quote')")
+        connection.execute(
+            "INSERT INTO passages_fts(passage_id, text) VALUES('passage-1', 'quote')"
+        )
+        connection.execute(
+            """
+            INSERT INTO document_profiles(
+                id, document_id, source_type, extent_type, extent_count, text_length,
+                extraction_quality_json, extractor
+            )
+            VALUES('profile-1', 'document-1', 'pdf', 'pages', 1, 10, '{}', 'rules')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO document_briefs(id, document_id, summary, extractor)
+            VALUES('brief-1', 'document-1', 'summary', 'rules')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO discovery_items(id, document_id, item_type, label, extractor)
+            VALUES('item-1', 'document-1', 'topic', 'budget', 'rules')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO discovery_evidence(
+                id, item_id, document_id, source_unit_start_id, source_unit_end_id,
+                location_type, location_label, quote, validation_status
+            )
+            VALUES(
+                'evidence-1', 'item-1', 'document-1', 'unit-1', 'unit-1',
+                'page', 'p. 1', 'quote', 'validated'
+            )
+            """
+        )
+        connection.execute(
+            "INSERT INTO document_briefs_fts(brief_id, summary) VALUES('brief-1', 'summary')"
+        )
+        connection.execute(
+            "INSERT INTO discovery_items_fts(item_id, label) VALUES('item-1', 'budget')"
+        )
+        connection.execute("UPDATE metadata SET value = '4' WHERE key = 'schema_version'")
+        connection.commit()
+
+    initialize_storage(data_dir)
+
+    with sqlite3.connect(paths.database) as connection:
+        preserved_counts = {
+            table: connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            for table in (
+                "sources",
+                "source_artifacts",
+                "documents",
+                "source_units",
+                "chunks",
+                "chunks_fts",
+                "passages",
+                "passages_fts",
+                "embedding_records",
+            )
+        }
+        derived_counts = {
+            table: connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            for table in (
+                "document_profiles",
+                "document_briefs",
+                "discovery_items",
+                "discovery_evidence",
+                "document_briefs_fts",
+                "discovery_items_fts",
+            )
+        }
+        schema_version = connection.execute(
+            "SELECT value FROM metadata WHERE key = 'schema_version'"
+        ).fetchone()[0]
+
+    assert preserved_counts == {
+        "sources": 1,
+        "source_artifacts": 1,
+        "documents": 1,
+        "source_units": 1,
+        "chunks": 1,
+        "chunks_fts": 1,
+        "passages": 1,
+        "passages_fts": 1,
+        "embedding_records": 1,
+    }
+    assert derived_counts == {
+        "document_profiles": 0,
+        "document_briefs": 0,
+        "discovery_items": 0,
+        "discovery_evidence": 0,
+        "document_briefs_fts": 0,
+        "discovery_items_fts": 0,
+    }
+    assert schema_version == "5"
+
+
 def test_initialize_storage_backfills_passages_from_existing_chunks(tmp_path: Path) -> None:
     data_dir = tmp_path / ".newsrag"
     paths = initialize_storage(data_dir)


### PR DESCRIPTION
## Summary

Extend discovery and enrichment to use canonical typed source-unit evidence for both PDF and static HTML documents.

## Task

task-c3112638 — Extend discovery for source-neutral evidence

## Changes

- add source-unit range resolution, ownership checks, quote validation, typed extents, and PDF/HTML citation formatting
- run deterministic facts, briefs, structured enrichment, topics, timelines, and story leads over canonical source units
- store PDF page fields only for PDF evidence while using heading/block labels for HTML evidence
- replace the unused page-only discovery schema at schema version 5, resetting only regenerable discovery/profile/brief records and preserving core corpus/search data
- add mixed PDF/HTML discovery, migration, validation, profile, brief, enrichment, browse, and citation coverage
- document the source-neutral discovery model and schema-upgrade policy

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
  - HTML discovery, brief, topics, and timeline through the public CLI with heading/block citations
  - PDF ingestion, discovery, and brief through the public CLI with unchanged page citations

## Checklist

- [x] `./scripts/pre-pr.sh` passes (249 tests)
- [x] Documentation updated
- [x] No unrelated changes included
