### PR TITLE
Extend source packets for mixed sources

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,7 +174,7 @@ Default packet structure:
 ## Source List
 ```
 
-The MVP packet is templated and evidence-based. It should quote or summarize retrieved passages only enough to organize the evidence, and it should preserve citations to document titles, dates, bodies, pages, and source files.
+The MVP packet is templated and evidence-based. It quotes retrieved passages without generating new claims and preserves each search result's typed citation, so one packet can contain PDF page evidence and HTML heading/block evidence without inventing HTML pages. Source-list entries retain the existing descriptive metadata and add authoritative provenance from the published source artifact: source type, submitted URL or path, a differing final URL, remote retrieval time, and exact-byte SHA-256. This ties packet evidence to the immutable ingested artifact.
 
 ## Implementation guidance
 

--- a/newsrag/cli.py
+++ b/newsrag/cli.py
@@ -462,7 +462,12 @@ def packet_command(
 ) -> None:
     """Generate an extractive Markdown source packet from retrieved evidence."""
 
-    from newsrag.packets import PacketError, format_source_packet, write_source_packet
+    from newsrag.packets import (
+        PacketError,
+        format_source_packet,
+        load_packet_source_provenance,
+        write_source_packet,
+    )
     from newsrag.search import SearchError, build_search_engine
     from newsrag.storage import initialize_storage
 
@@ -486,9 +491,15 @@ def packet_command(
             embedding_config=settings.config.embedding,
         )
         results = engine.search(query, filters=filters)
+        source_provenance = load_packet_source_provenance(storage_paths.database, results)
         write_source_packet(
             out,
-            format_source_packet(query=query, results=results, filters=filters),
+            format_source_packet(
+                query=query,
+                results=results,
+                filters=filters,
+                source_provenance=source_provenance,
+            ),
             overwrite=overwrite,
         )
     except (SearchError, PacketError) as exc:

--- a/newsrag/packets.py
+++ b/newsrag/packets.py
@@ -1,13 +1,113 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+import json
+import sqlite3
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 
 from newsrag.search import SearchFilters, SearchResult
+from newsrag.sources import SOURCE_TYPE_HTML, source_type_for_media_type
 
 
 class PacketError(Exception):
     """Raised when a source packet cannot be generated or written."""
+
+
+@dataclass(frozen=True)
+class PacketSourceProvenance:
+    """Durable source and immutable artifact identity for one packet document."""
+
+    document_id: str
+    source_type: str
+    source_kind: str
+    submitted_reference: str
+    resolved_reference: str
+    retrieved_at: str | None
+    artifact_hash: str
+
+
+def load_packet_source_provenance(
+    database_path: Path,
+    results: Sequence[SearchResult],
+) -> dict[str, PacketSourceProvenance]:
+    """Load authoritative source and artifact provenance for packet results."""
+
+    document_ids = sorted({result.document_id for result in results})
+    if not document_ids:
+        return {}
+
+    placeholders = ", ".join("?" for _ in document_ids)
+    with sqlite3.connect(database_path) as connection:
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(
+            f"""
+            SELECT
+                documents.id AS document_id,
+                sources.kind AS source_kind,
+                sources.submitted_reference AS submitted_reference,
+                sources.resolved_reference AS resolved_reference,
+                source_artifacts.media_type AS media_type,
+                source_artifacts.content_hash AS artifact_hash,
+                source_artifacts.acquired_at AS acquired_at,
+                source_artifacts.provenance_json AS provenance_json
+            FROM documents
+            JOIN source_artifacts ON source_artifacts.id = documents.artifact_id
+            JOIN sources ON sources.id = source_artifacts.source_id
+            WHERE documents.id IN ({placeholders})
+                AND source_artifacts.state = 'published'
+            """,
+            tuple(document_ids),
+        ).fetchall()
+
+    provenance: dict[str, PacketSourceProvenance] = {}
+    for row in rows:
+        document_id = str(row["document_id"])
+        source_kind = str(row["source_kind"])
+        source_type = source_type_for_media_type(str(row["media_type"]))
+        if source_type is None or source_kind not in {"local_path", "url"}:
+            raise PacketError(f"Unsupported source provenance for document: {document_id}")
+        artifact_provenance = _load_json_object(row["provenance_json"])
+        submitted_reference = str(row["submitted_reference"])
+        if source_kind == "url":
+            submitted_reference = (
+                _optional_string(artifact_provenance.get("submitted_url")) or submitted_reference
+            )
+            resolved_reference = (
+                _optional_string(artifact_provenance.get("resolved_url"))
+                or _optional_string(row["resolved_reference"])
+                or submitted_reference
+            )
+            retrieved_at = _optional_string(artifact_provenance.get("retrieved_at")) or str(
+                row["acquired_at"]
+            )
+        else:
+            submitted_reference = (
+                _optional_string(artifact_provenance.get("submitted_path")) or submitted_reference
+            )
+            resolved_reference = (
+                _optional_string(artifact_provenance.get("resolved_path"))
+                or _optional_string(row["resolved_reference"])
+                or submitted_reference
+            )
+            retrieved_at = None
+        provenance[document_id] = PacketSourceProvenance(
+            document_id=document_id,
+            source_type=source_type,
+            source_kind=source_kind,
+            submitted_reference=submitted_reference,
+            resolved_reference=resolved_reference,
+            retrieved_at=retrieved_at,
+            artifact_hash=str(row["artifact_hash"]),
+        )
+
+    missing_document_ids = sorted(set(document_ids) - provenance.keys())
+    if missing_document_ids:
+        raise PacketError(
+            "Cannot load immutable source provenance for document(s): "
+            + ", ".join(missing_document_ids)
+        )
+    return provenance
 
 
 def format_source_packet(
@@ -15,6 +115,7 @@ def format_source_packet(
     query: str,
     results: Sequence[SearchResult],
     filters: SearchFilters | None = None,
+    source_provenance: Mapping[str, PacketSourceProvenance] | None = None,
 ) -> str:
     """Format retrieved evidence as a fixed Markdown source packet."""
 
@@ -59,7 +160,14 @@ def format_source_packet(
     lines.extend(["## Source List", ""])
     if results:
         for result in results:
-            lines.append(f"- {format_source_list_entry(result)}")
+            provenance = None
+            if source_provenance is not None:
+                provenance = source_provenance.get(result.document_id)
+                if provenance is None:
+                    raise PacketError(
+                        "Missing source provenance for packet document: " + result.document_id
+                    )
+            lines.append(f"- {format_source_list_entry(result, provenance=provenance)}")
     else:
         lines.append("- No sources found.")
     lines.append("")
@@ -75,10 +183,17 @@ def write_source_packet(path: Path, content: str, *, overwrite: bool = False) ->
     path.write_text(content, encoding="utf-8")
 
 
-def format_source_list_entry(result: SearchResult) -> str:
-    """Format one source-list entry with available metadata."""
+def format_source_list_entry(
+    result: SearchResult,
+    *,
+    provenance: PacketSourceProvenance | None = None,
+) -> str:
+    """Format one source-list entry with available metadata and provenance."""
 
-    details = [f"page {result.page_start}"]
+    source_type = provenance.source_type if provenance is not None else result.source_type
+    details = []
+    if source_type != SOURCE_TYPE_HTML:
+        details.append(f"page {result.page_start}")
     for label, value in (
         ("title", result.title),
         ("body", result.body),
@@ -90,7 +205,38 @@ def format_source_list_entry(result: SearchResult) -> str:
     ):
         if value is not None and value.strip():
             details.append(f"{label}: {value.strip()}")
+
+    if provenance is not None:
+        details.append(f"source type: {provenance.source_type}")
+        if provenance.source_kind == "url":
+            details.append(f"supplied URL: {provenance.submitted_reference}")
+            if provenance.resolved_reference != provenance.submitted_reference:
+                details.append(f"final URL: {provenance.resolved_reference}")
+            if provenance.retrieved_at is not None:
+                details.append(f"retrieved at: {provenance.retrieved_at}")
+        else:
+            details.append(f"supplied path: {provenance.submitted_reference}")
+        details.append(f"artifact SHA-256: {provenance.artifact_hash}")
+
+    if not details:
+        return result.citation
     return f"{result.citation} ({'; '.join(details)})"
+
+
+def _load_json_object(raw_value: object) -> dict[str, object]:
+    try:
+        value = json.loads(str(raw_value))
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(value, dict):
+        return {}
+    return value
+
+
+def _optional_string(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
 
 
 def _normalize_text(value: str) -> str:

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
 
 from newsrag.cli import app
-from newsrag.packets import PacketError, format_source_packet, write_source_packet
+from newsrag.packets import (
+    PacketError,
+    PacketSourceProvenance,
+    format_source_packet,
+    load_packet_source_provenance,
+    write_source_packet,
+)
 from newsrag.search import SearchFilters, SearchResult
+from newsrag.storage import initialize_storage
 
 runner = CliRunner()
 
@@ -32,6 +40,120 @@ def test_source_packet_source_list_includes_available_metadata() -> None:
     assert "meeting date: 2026-05-01" in content
     assert "page 3" in content
     assert "source file: /tmp/stormwater.pdf" in content
+
+
+def test_mixed_source_packet_uses_typed_citations_and_immutable_provenance() -> None:
+    pdf_result = _search_result()
+    html_result = _html_search_result()
+    provenance = {
+        "document-a": PacketSourceProvenance(
+            document_id="document-a",
+            source_type="pdf",
+            source_kind="url",
+            submitted_reference="https://example.test/stormwater.pdf",
+            resolved_reference="https://cdn.example.test/stormwater.pdf",
+            retrieved_at="2026-05-02T10:30:00+00:00",
+            artifact_hash="pdf-sha256",
+        ),
+        "document-html": PacketSourceProvenance(
+            document_id="document-html",
+            source_type="html",
+            source_kind="local_path",
+            submitted_reference="/tmp/budget.html",
+            resolved_reference="/tmp/budget.html",
+            retrieved_at=None,
+            artifact_hash="html-sha256",
+        ),
+    }
+
+    content = format_source_packet(
+        query="budget",
+        results=[pdf_result, html_result],
+        source_provenance=provenance,
+    )
+
+    assert "**Stormwater Report — 2026-05-01 — p. 3**" in content
+    assert "**Council Update — Budget — block 4**" in content
+    source_lines = [line for line in content.splitlines() if line.startswith("- ")]
+    pdf_line = next(line for line in source_lines if "pdf-sha256" in line)
+    html_line = next(line for line in source_lines if "html-sha256" in line)
+    assert "source type: pdf" in pdf_line
+    assert "supplied URL: https://example.test/stormwater.pdf" in pdf_line
+    assert "final URL: https://cdn.example.test/stormwater.pdf" in pdf_line
+    assert "retrieved at: 2026-05-02T10:30:00+00:00" in pdf_line
+    assert "artifact SHA-256: pdf-sha256" in pdf_line
+    assert "page 3" in pdf_line
+    assert "source type: html" in html_line
+    assert "supplied path: /tmp/budget.html" in html_line
+    assert "artifact SHA-256: html-sha256" in html_line
+    assert "page 4" not in html_line
+    assert "retrieved at:" not in html_line
+
+
+def test_source_packet_rejects_incomplete_provenance() -> None:
+    with pytest.raises(PacketError, match="Missing source provenance"):
+        format_source_packet(
+            query="budget",
+            results=[_html_search_result()],
+            source_provenance={},
+        )
+
+
+def test_load_packet_source_provenance_uses_published_artifacts(tmp_path: Path) -> None:
+    database_path = initialize_storage(tmp_path / ".newsrag").database
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO sources(
+                id, kind, submitted_reference, normalized_reference, resolved_reference
+            )
+            VALUES(
+                'source-html', 'url', 'https://example.test/update',
+                'https://example.test/update', 'https://stale.example.test/update.html'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, content_hash, stored_path, acquired_at, state,
+                provenance_json
+            )
+            VALUES(
+                'artifact-html', 'source-html', 'text/html', 'artifact-hash',
+                '/tmp/artifact.html', '2026-05-02T10:00:00+00:00', 'published',
+                '{"submitted_url": "https://example.test/update", "resolved_url": "https://cdn.example.test/update.html", "retrieved_at": "2026-05-02T10:30:00+00:00"}'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO documents(id, title, metadata_json, artifact_id)
+            VALUES('document-html', 'Council Update', '{}', 'artifact-html')
+            """
+        )
+        connection.commit()
+
+    loaded = load_packet_source_provenance(database_path, [_html_search_result()])
+
+    assert loaded == {
+        "document-html": PacketSourceProvenance(
+            document_id="document-html",
+            source_type="html",
+            source_kind="url",
+            submitted_reference="https://example.test/update",
+            resolved_reference="https://cdn.example.test/update.html",
+            retrieved_at="2026-05-02T10:30:00+00:00",
+            artifact_hash="artifact-hash",
+        )
+    }
+
+
+def test_load_packet_source_provenance_rejects_unpublished_results(tmp_path: Path) -> None:
+    database_path = initialize_storage(tmp_path / ".newsrag").database
+
+    with pytest.raises(PacketError, match="immutable source provenance"):
+        load_packet_source_provenance(database_path, [_search_result()])
 
 
 def test_write_source_packet_refuses_existing_output_without_overwrite(tmp_path: Path) -> None:
@@ -72,6 +194,10 @@ def test_packet_command_writes_markdown_from_mocked_retrieval(
             return [_search_result()]
 
     monkeypatch.setattr("newsrag.search.build_search_engine", lambda **_: FakeSearchEngine())
+    monkeypatch.setattr(
+        "newsrag.packets.load_packet_source_provenance",
+        lambda *_: {"document-a": _pdf_source_provenance()},
+    )
 
     result = runner.invoke(
         app,
@@ -96,6 +222,105 @@ def test_packet_command_writes_markdown_from_mocked_retrieval(
     assert captured_filters == [SearchFilters(body="Planning Commission", since="2025-01-01")]
 
 
+def test_packet_command_writes_mixed_source_provenance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data_dir = tmp_path / ".newsrag"
+    output_path = tmp_path / "mixed-packet.md"
+    database_path = initialize_storage(data_dir).database
+    with sqlite3.connect(database_path) as connection:
+        connection.executemany(
+            """
+            INSERT INTO sources(
+                id, kind, submitted_reference, normalized_reference, resolved_reference
+            )
+            VALUES(?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    "source-pdf",
+                    "url",
+                    "https://example.test/stormwater.pdf",
+                    "https://example.test/stormwater.pdf",
+                    "https://cdn.example.test/stormwater.pdf",
+                ),
+                (
+                    "source-html",
+                    "local_path",
+                    "/tmp/budget.html",
+                    "/tmp/budget.html",
+                    "/tmp/budget.html",
+                ),
+            ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO source_artifacts(
+                id, source_id, media_type, content_hash, stored_path, acquired_at, state
+            )
+            VALUES(?, ?, ?, ?, ?, '2026-05-02T10:30:00+00:00', 'published')
+            """,
+            [
+                (
+                    "artifact-pdf",
+                    "source-pdf",
+                    "application/pdf",
+                    "pdf-sha256",
+                    "/tmp/artifact.pdf",
+                ),
+                (
+                    "artifact-html",
+                    "source-html",
+                    "text/html",
+                    "html-sha256",
+                    "/tmp/artifact.html",
+                ),
+            ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO documents(id, title, metadata_json, artifact_id)
+            VALUES(?, ?, '{}', ?)
+            """,
+            [
+                ("document-a", "Stormwater Report", "artifact-pdf"),
+                ("document-html", "Council Update", "artifact-html"),
+            ],
+        )
+        connection.commit()
+
+    class FakeSearchEngine:
+        def search(
+            self,
+            query: str,
+            *,
+            filters: SearchFilters | None = None,
+        ) -> list[SearchResult]:
+            assert query == "budget"
+            return [_search_result(), _html_search_result()]
+
+    monkeypatch.setattr("newsrag.search.build_search_engine", lambda **_: FakeSearchEngine())
+
+    result = runner.invoke(
+        app,
+        [
+            "--data-dir",
+            str(data_dir),
+            "packet",
+            "budget",
+            "--out",
+            str(output_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    content = output_path.read_text(encoding="utf-8")
+    assert "Stormwater Report — 2026-05-01 — p. 3" in content
+    assert "Council Update — Budget — block 4" in content
+    assert "artifact SHA-256: pdf-sha256" in content
+    assert "artifact SHA-256: html-sha256" in content
+
+
 def test_packet_command_requires_overwrite_for_existing_output(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -112,6 +337,10 @@ def test_packet_command_requires_overwrite_for_existing_output(
             return [_search_result()]
 
     monkeypatch.setattr("newsrag.search.build_search_engine", lambda **_: FakeSearchEngine())
+    monkeypatch.setattr(
+        "newsrag.packets.load_packet_source_provenance",
+        lambda *_: {"document-a": _pdf_source_provenance()},
+    )
 
     result = runner.invoke(
         app,
@@ -144,6 +373,38 @@ def test_packet_command_requires_overwrite_for_existing_output(
 
     assert overwrite_result.exit_code == 0
     assert "# Source Packet: stormwater" in output_path.read_text(encoding="utf-8")
+
+
+def _pdf_source_provenance() -> PacketSourceProvenance:
+    return PacketSourceProvenance(
+        document_id="document-a",
+        source_type="pdf",
+        source_kind="local_path",
+        submitted_reference="/tmp/stormwater.pdf",
+        resolved_reference="/tmp/stormwater.pdf",
+        retrieved_at=None,
+        artifact_hash="pdf-sha256",
+    )
+
+
+def _html_search_result() -> SearchResult:
+    return SearchResult(
+        passage_id="passage-html",
+        document_id="document-html",
+        page_start=4,
+        page_end=4,
+        text="Council approved the downtown budget amendment.",
+        citation="Council Update — Budget — block 4",
+        score=0.9,
+        keyword_score=0.2,
+        vector_score=0.1,
+        title="Council Update",
+        body="City Council",
+        source_path="/tmp/budget.html",
+        source_type="html",
+        source_unit_start_id="unit-html-4",
+        source_unit_end_id="unit-html-4",
+    )
 
 
 def _search_result() -> SearchResult:


### PR DESCRIPTION
## Summary

Generate mixed PDF/HTML source packets with format-appropriate citations and durable immutable-artifact provenance.

## Task

task-2c335ff4 — Extend source packets for mixed sources

## Changes

- load authoritative packet provenance from published source, artifact, and document records
- preserve typed search citations for PDF pages and HTML heading/block locations
- add source type, submitted URL/path, differing final URL, remote retrieval time, and exact-byte SHA-256 to source-list entries
- retain existing packet sections, extractive evidence, descriptive metadata, and PDF page details without inventing HTML pages
- fail clearly if a packet result lacks published immutable-artifact provenance
- add mixed-source formatter, provenance loader, and public CLI integration coverage
- document mixed-source packet and provenance behavior

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
  - generated a packet through the public CLI containing HTML block and PDF page citations with artifact hashes and submitted paths
  - generated a public-URL PDF packet with submitted URL, retrieval time, and artifact SHA-256

## Checklist

- [x] `./scripts/pre-pr.sh` passes (254 tests)
- [x] Documentation updated
- [x] No unrelated changes included
